### PR TITLE
fix: exclude component name from release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Release-please was tagging releases as `mdp-v1.x.x` due to the `component: mdp` config, but the goreleaser workflow triggers on `v*` tags only. This adds `include-component-in-tag: false` so future releases use plain `v1.x.x` tags and goreleaser actually runs.