### PR TITLE
feat: cross-service port refs in mdp.yaml + scheme-isolated routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,31 @@ services:
 
 When you run `mdp run`, mdp assigns free ports, sets them as environment variables, and registers each port mapping with the appropriate proxy.
 
+### Referencing another service's port
+
+Use `${service.port}` inside any `env` value to inject the assigned port of another service. `mdp` resolves these before launching, so every worktree can allocate truly random ports and still wire services together:
+
+```yaml
+services:
+  db:
+    command: docker compose up db --wait
+    # no proxy; internal only
+
+  api:
+    command: ./api
+    proxy: 4000
+    env:
+      DATABASE_URL: "postgres://app:app@localhost:${db.port}/app"
+
+  web:
+    command: npm run dev
+    proxy: 3000
+    env:
+      API_URL: "http://localhost:${api.port}"
+```
+
+For multi-port services, reference the specific env key: `${infra.API_PORT}`.
+
 ## Service groups
 
 Services are automatically grouped by their git branch name (or an explicit `--group` flag). All services sharing the same group name form a switchable group. Switching to a group sets the default upstream on every proxy at once.

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/derekgould/multi-dev-proxy/internal/config"
 	"github.com/derekgould/multi-dev-proxy/internal/detect"
+	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
 	"github.com/derekgould/multi-dev-proxy/internal/orchestrator"
 	"github.com/derekgould/multi-dev-proxy/internal/ports"
 	"github.com/derekgould/multi-dev-proxy/internal/process"
@@ -110,46 +111,87 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 
 	bt := &batchTracker{}
 
+	type alloc struct {
+		name            string
+		svc             config.ServiceConfig
+		svcGroup        string
+		assignedPort    int            // single-port only
+		portAssignments map[string]int // multi-port only
+	}
+	var allocations []alloc
+	portMap := envexpand.PortMap{}
+	var assignedPorts []int
+	for _, svc := range cfg.Services {
+		if svc.Port > 0 {
+			assignedPorts = append(assignedPorts, svc.Port)
+		}
+	}
+
 	for name, svc := range cfg.Services {
 		if svc.Command == "" && svc.Port == 0 {
 			continue
 		}
-
 		svcGroup := svc.Group
 		if svcGroup == "" {
 			svcGroup = group
 		}
 
 		if len(svc.Ports) > 0 {
-			if _, err := registerMultiPortBatch(client, controlURL, name, svc, svcGroup, portRange, bt, clientID); err != nil {
-				return fmt.Errorf("register multi-port service %q: %w", name, err)
+			portAssignments := make(map[string]int)
+			for envName, value := range svc.Env {
+				if value == "auto" {
+					port, err := ports.FindFreePort(portRange, assignedPorts)
+					if err != nil {
+						return fmt.Errorf("find free port for %q.%s: %w", name, envName, err)
+					}
+					portAssignments[envName] = port
+					assignedPorts = append(assignedPorts, port)
+				}
+			}
+			svcPorts := make(map[string]int, len(portAssignments))
+			for k, v := range portAssignments {
+				svcPorts[k] = v
+			}
+			portMap[name] = svcPorts
+			allocations = append(allocations, alloc{name, svc, svcGroup, 0, portAssignments})
+			continue
+		}
+
+		assignedPort := svc.Port
+		if assignedPort == 0 {
+			assignedPort, err = ports.FindFreePort(portRange, assignedPorts)
+			if err != nil {
+				return fmt.Errorf("find free port for %q: %w", name, err)
+			}
+			assignedPorts = append(assignedPorts, assignedPort)
+		}
+		portMap[name] = map[string]int{"port": assignedPort, "PORT": assignedPort}
+		allocations = append(allocations, alloc{name, svc, svcGroup, assignedPort, nil})
+	}
+
+	for _, a := range allocations {
+		if len(a.svc.Ports) > 0 {
+			if err := launchMultiPortBatch(client, controlURL, a.name, a.svc, a.svcGroup, a.portAssignments, portMap, bt, clientID); err != nil {
+				return fmt.Errorf("launch multi-port service %q: %w", a.name, err)
 			}
 			continue
 		}
 
-		serverName := fmt.Sprintf("%s/%s", svcGroup, name)
-		assignedPort := svc.Port
-		if assignedPort == 0 {
-			assignedPort, err = ports.FindFreePort(portRange, nil)
-			if err != nil {
-				return fmt.Errorf("find free port for %q: %w", name, err)
-			}
-		}
-
-		if svc.Proxy > 0 {
+		serverName := fmt.Sprintf("%s/%s", a.svcGroup, a.name)
+		if a.svc.Proxy > 0 {
 			regPayload := map[string]any{
 				"name":      serverName,
-				"port":      assignedPort,
-				"proxyPort": svc.Proxy,
-				"group":     svcGroup,
+				"port":      a.assignedPort,
+				"proxyPort": a.svc.Proxy,
+				"group":     a.svcGroup,
 				"clientID":  clientID,
 			}
-			if svc.Scheme != "" {
-				regPayload["scheme"] = svc.Scheme
+			if a.svc.Scheme != "" {
+				regPayload["scheme"] = a.svc.Scheme
 			}
-			if svc.TLSCert != "" {
-				regPayload["tlsCertPath"] = svc.TLSCert
-				regPayload["tlsKeyPath"] = svc.TLSKey
+			if a.svc.TLSCert != "" {
+				regPayload["tlsCertPath"] = a.svc.TLSCert
+				regPayload["tlsKeyPath"] = a.svc.TLSKey
 			}
 			body, _ := json.Marshal(regPayload)
 			resp, err := client.Post(controlURL+"/__mdp/register", "application/json", bytes.NewReader(body))
@@ -162,15 +204,20 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 			}
 		}
 
-		if svc.Command != "" {
-			env := []string{fmt.Sprintf("PORT=%d", assignedPort), "MDP=1"}
-			for k, v := range svc.Env {
-				if v != "auto" {
-					env = append(env, k+"="+v)
+		if a.svc.Command != "" {
+			env := []string{fmt.Sprintf("PORT=%d", a.assignedPort), "MDP=1"}
+			for k, v := range a.svc.Env {
+				if v == "auto" {
+					continue
 				}
+				expanded, err := envexpand.Expand(v, portMap)
+				if err != nil {
+					return fmt.Errorf("service %q env %q: %w", a.name, k, err)
+				}
+				env = append(env, k+"="+expanded)
 			}
 			bt.wg.Add(1)
-			go runServiceProcess(bt, name, svc.Command, svc.Dir, env, controlURL, serverName)
+			go runServiceProcess(bt, a.name, a.svc.Command, a.svc.Dir, env, controlURL, serverName)
 		}
 	}
 
@@ -208,19 +255,8 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 	return nil
 }
 
-func registerMultiPortBatch(client *http.Client, controlURL, name string, svc config.ServiceConfig, group string, portRange ports.PortRange, bt *batchTracker, clientID string) ([]string, error) {
+func launchMultiPortBatch(client *http.Client, controlURL, name string, svc config.ServiceConfig, group string, portAssignments map[string]int, portMap envexpand.PortMap, bt *batchTracker, clientID string) error {
 	var registered []string
-	portAssignments := make(map[string]int)
-	for envName, value := range svc.Env {
-		if value == "auto" {
-			port, err := ports.FindFreePort(portRange, nil)
-			if err != nil {
-				return nil, err
-			}
-			portAssignments[envName] = port
-		}
-	}
-
 	for _, pm := range svc.Ports {
 		port, ok := portAssignments[pm.Env]
 		if !ok {
@@ -248,11 +284,11 @@ func registerMultiPortBatch(client *http.Client, controlURL, name string, svc co
 		body, _ := json.Marshal(regPayload)
 		resp, err := client.Post(controlURL+"/__mdp/register", "application/json", bytes.NewReader(body))
 		if err != nil {
-			return registered, err
+			return err
 		}
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			return registered, fmt.Errorf("register %q failed (status %d)", serverName, resp.StatusCode)
+			return fmt.Errorf("register %q failed (status %d)", serverName, resp.StatusCode)
 		}
 		registered = append(registered, serverName)
 	}
@@ -264,18 +300,21 @@ func registerMultiPortBatch(client *http.Client, controlURL, name string, svc co
 				if port, ok := portAssignments[k]; ok {
 					env = append(env, fmt.Sprintf("%s=%d", k, port))
 				}
-			} else {
-				env = append(env, k+"="+v)
+				continue
 			}
+			expanded, err := envexpand.Expand(v, portMap)
+			if err != nil {
+				return fmt.Errorf("service %q env %q: %w", name, k, err)
+			}
+			env = append(env, k+"="+expanded)
 		}
-		// All registered names map to this single process
 		namesCopy := make([]string, len(registered))
 		copy(namesCopy, registered)
 		bt.wg.Add(1)
 		go runServiceProcess(bt, name, svc.Command, svc.Dir, env, controlURL, namesCopy...)
 	}
 
-	return registered, nil
+	return nil
 }
 
 var serviceColors = []string{

--- a/internal/envexpand/envexpand.go
+++ b/internal/envexpand/envexpand.go
@@ -1,0 +1,59 @@
+// Package envexpand resolves ${service.port} references in mdp.yaml env values.
+package envexpand
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PortMap holds each service's named port assignments.
+// Outer key is service name (as written in mdp.yaml).
+// Inner key is the port name: "port"/"PORT" for single-port services, or the
+// user-defined env key (from an "auto" entry) for multi-port services.
+type PortMap map[string]map[string]int
+
+var refPattern = regexp.MustCompile(`\$\{([A-Za-z0-9_-]+)\.([A-Za-z0-9_]+)\}`)
+
+// Expand replaces every ${service.key} reference in value using pm.
+// If key is "port" and the service has no entry named "port", "PORT" is tried.
+// Returns an error if any reference cannot be resolved.
+func Expand(value string, pm PortMap) (string, error) {
+	var firstErr error
+	out := refPattern.ReplaceAllStringFunc(value, func(match string) string {
+		m := refPattern.FindStringSubmatch(match)
+		svc, key := m[1], m[2]
+		port, ok := lookup(pm, svc, key)
+		if !ok {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("unresolved reference %s: no such service or port", match)
+			}
+			return match
+		}
+		return strconv.Itoa(port)
+	})
+	if firstErr != nil {
+		return "", firstErr
+	}
+	return out, nil
+}
+
+func lookup(pm PortMap, svc, key string) (int, bool) {
+	ports, ok := pm[svc]
+	if !ok {
+		return 0, false
+	}
+	if port, ok := ports[key]; ok {
+		return port, true
+	}
+	if strings.EqualFold(key, "port") {
+		if port, ok := ports["PORT"]; ok {
+			return port, true
+		}
+		if port, ok := ports["port"]; ok {
+			return port, true
+		}
+	}
+	return 0, false
+}

--- a/internal/envexpand/envexpand_test.go
+++ b/internal/envexpand/envexpand_test.go
@@ -1,0 +1,205 @@
+package envexpand
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	pm := PortMap{
+		"db":  {"port": 5432, "PORT": 5432},
+		"api": {"PORT": 8080, "ADMIN": 8081},
+	}
+
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr string
+	}{
+		{"no refs", "hello", "hello", ""},
+		{"single ref", "${db.port}", "5432", ""},
+		{"embedded in url", "postgres://localhost:${db.port}/app", "postgres://localhost:5432/app", ""},
+		{"multiple refs", "api=${api.PORT} admin=${api.ADMIN}", "api=8080 admin=8081", ""},
+		{"port falls back to PORT", "${api.port}", "8080", ""},
+		{"unknown service", "${nope.port}", "", "unresolved reference ${nope.port}"},
+		{"unknown key", "${api.WHAT}", "", "unresolved reference ${api.WHAT}"},
+		{"hyphenated service name", "${api-main.port}", "", "unresolved reference ${api-main.port}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Expand(tt.in, pm)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandHyphenatedServiceName(t *testing.T) {
+	pm := PortMap{"api-main": {"port": 3001, "PORT": 3001}}
+	got, err := Expand("http://localhost:${api-main.port}", pm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "http://localhost:3001" {
+		t.Errorf("got %q, want http://localhost:3001", got)
+	}
+}
+
+func TestExpandSelfReference(t *testing.T) {
+	pm := PortMap{"web": {"port": 4000, "PORT": 4000}}
+	got, err := Expand("me=${web.port}", pm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "me=4000" {
+		t.Errorf("got %q, want me=4000", got)
+	}
+}
+
+func TestExpandEmptyString(t *testing.T) {
+	got, err := Expand("", PortMap{"db": {"PORT": 5432}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestExpandEmptyPortMap(t *testing.T) {
+	_, err := Expand("${db.port}", PortMap{})
+	if err == nil {
+		t.Fatal("expected error with empty port map, got nil")
+	}
+}
+
+func TestExpandLiteralsPassThrough(t *testing.T) {
+	pm := PortMap{"db": {"PORT": 5432}}
+	cases := []string{
+		"no dollar here",
+		"$PATH is not a ref",
+		"${incomplete",
+		"${no_dot_here}",
+		"$$literal",
+		"${.port}",
+		"${db.}",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			got, err := Expand(in, pm)
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", in, err)
+			}
+			if got != in {
+				t.Errorf("literal %q was modified to %q", in, got)
+			}
+		})
+	}
+}
+
+func TestExpandAdjacentRefs(t *testing.T) {
+	pm := PortMap{
+		"a": {"port": 1000, "PORT": 1000},
+		"b": {"port": 2000, "PORT": 2000},
+	}
+	got, err := Expand("${a.port}${b.port}", pm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "10002000" {
+		t.Errorf("got %q, want 10002000", got)
+	}
+}
+
+func TestExpandExactCaseWinsOverFallback(t *testing.T) {
+	pm := PortMap{"api": {"port": 1234, "PORT": 9999}}
+	got, err := Expand("${api.port}", pm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "1234" {
+		t.Errorf("got %q, want 1234 (exact-case match should win over PORT fallback)", got)
+	}
+}
+
+func TestExpandNoFallbackForNonPortKey(t *testing.T) {
+	pm := PortMap{"api": {"ADMIN": 9000}}
+	_, err := Expand("${api.admin}", pm)
+	if err == nil {
+		t.Fatal("expected error: fallback should only apply to 'port' key, not arbitrary lowercase")
+	}
+}
+
+func TestExpandServiceNameUnderscores(t *testing.T) {
+	pm := PortMap{"my_db_1": {"port": 5432, "PORT": 5432}}
+	got, err := Expand("${my_db_1.port}", pm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "5432" {
+		t.Errorf("got %q, want 5432", got)
+	}
+}
+
+func TestExpandFirstUnresolvedReferenceWins(t *testing.T) {
+	_, err := Expand("${a.port} and ${b.port}", PortMap{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "${a.port}") {
+		t.Errorf("expected error to mention the first unresolved ref ${a.port}, got %v", err)
+	}
+}
+
+func TestExpandRefAtStartMiddleEnd(t *testing.T) {
+	pm := PortMap{"svc": {"port": 7777, "PORT": 7777}}
+	cases := map[string]string{
+		"${svc.port} end":       "7777 end",
+		"start ${svc.port}":     "start 7777",
+		"a ${svc.port} b":       "a 7777 b",
+		"${svc.port}":           "7777",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			got, err := Expand(in, pm)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestExpandMultiPortServiceByEnvKey(t *testing.T) {
+	pm := PortMap{
+		"infra": {"API_PORT": 4001, "AUTH_PORT": 5001},
+	}
+	got, err := Expand("api=${infra.API_PORT} auth=${infra.AUTH_PORT}", pm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "api=4001 auth=5001" {
+		t.Errorf("got %q, want api=4001 auth=5001", got)
+	}
+}
+
+func TestExpandMultiPortNoPortKeyErrors(t *testing.T) {
+	pm := PortMap{"infra": {"API_PORT": 4001}}
+	_, err := Expand("${infra.port}", pm)
+	if err == nil {
+		t.Fatal("expected error: multi-port service with no 'port' or 'PORT' entry should not resolve ${svc.port}")
+	}
+}

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/derekgould/multi-dev-proxy/internal/config"
 	"github.com/derekgould/multi-dev-proxy/internal/detect"
+	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
 	"github.com/derekgould/multi-dev-proxy/internal/ports"
 	"github.com/derekgould/multi-dev-proxy/internal/registry"
 )
@@ -25,42 +26,80 @@ func (o *Orchestrator) StartConfigServices(ctx context.Context, group string) er
 		return fmt.Errorf("invalid port_range: %w", err)
 	}
 
+	type alloc struct {
+		name            string
+		svc             config.ServiceConfig
+		assignedPort    int
+		portAssignments map[string]int // multi-port only
+	}
+	var allocations []alloc
+	portMap := envexpand.PortMap{}
+	var assignedPorts []int
+	for _, svc := range o.cfg.Services {
+		if svc.Port > 0 {
+			assignedPorts = append(assignedPorts, svc.Port)
+		}
+	}
+
 	for name, svc := range o.cfg.Services {
-		if err := o.startConfigService(ctx, name, svc, group, portRange); err != nil {
-			slog.Error("failed to start service", "name", name, "err", err)
+		if svc.Command == "" && svc.Port == 0 {
+			continue
+		}
+		if len(svc.Ports) > 0 {
+			portAssignments := make(map[string]int)
+			for envName, value := range svc.Env {
+				if value == "auto" {
+					port, err := ports.FindFreePort(portRange, assignedPorts)
+					if err != nil {
+						return fmt.Errorf("find free port for %s.%s: %w", name, envName, err)
+					}
+					portAssignments[envName] = port
+					assignedPorts = append(assignedPorts, port)
+				}
+			}
+			svcPorts := make(map[string]int, len(portAssignments))
+			for k, v := range portAssignments {
+				svcPorts[k] = v
+			}
+			portMap[name] = svcPorts
+			allocations = append(allocations, alloc{name, svc, 0, portAssignments})
+			continue
+		}
+		assignedPort := svc.Port
+		if assignedPort == 0 {
+			var err error
+			assignedPort, err = ports.FindFreePort(portRange, assignedPorts)
+			if err != nil {
+				return fmt.Errorf("find free port for %s: %w", name, err)
+			}
+			assignedPorts = append(assignedPorts, assignedPort)
+		}
+		portMap[name] = map[string]int{"port": assignedPort, "PORT": assignedPort}
+		allocations = append(allocations, alloc{name, svc, assignedPort, nil})
+	}
+
+	for _, a := range allocations {
+		if len(a.svc.Ports) > 0 {
+			if err := o.startMultiPortService(ctx, a.name, a.svc, group, a.portAssignments, portMap); err != nil {
+				slog.Error("failed to start service", "name", a.name, "err", err)
+			}
+			continue
+		}
+		if err := o.startSingleService(ctx, a.name, a.svc, group, a.assignedPort, portMap); err != nil {
+			slog.Error("failed to start service", "name", a.name, "err", err)
 		}
 	}
 	return nil
 }
 
-func (o *Orchestrator) startConfigService(ctx context.Context, name string, svc config.ServiceConfig, group string, portRange ports.PortRange) error {
-	if svc.Command == "" && svc.Port == 0 {
-		return nil
-	}
-
-	if len(svc.Ports) > 0 {
-		return o.startMultiPortService(ctx, name, svc, group, portRange)
-	}
-
-	return o.startSingleService(ctx, name, svc, group, portRange)
-}
-
-func (o *Orchestrator) startSingleService(ctx context.Context, name string, svc config.ServiceConfig, group string, portRange ports.PortRange) error {
+func (o *Orchestrator) startSingleService(ctx context.Context, name string, svc config.ServiceConfig, group string, assignedPort int, portMap envexpand.PortMap) error {
 	serverName := fmt.Sprintf("%s/%s", group, name)
 
-	var assignedPort int
-	if svc.Port > 0 {
-		assignedPort = svc.Port
-	} else {
-		var err error
-		assignedPort, err = ports.FindFreePort(portRange, nil)
-		if err != nil {
-			return fmt.Errorf("find free port for %s: %w", name, err)
-		}
-	}
-
 	if svc.Command != "" {
-		env := buildEnv(svc.Env, map[string]int{"PORT": assignedPort})
+		env, err := buildEnv(svc.Env, map[string]int{"PORT": assignedPort}, portMap)
+		if err != nil {
+			return fmt.Errorf("build env for %s: %w", name, err)
+		}
 		if err := o.launchProcess(ctx, name, svc, serverName, group, assignedPort, env); err != nil {
 			return err
 		}
@@ -93,20 +132,12 @@ func (o *Orchestrator) startSingleService(ctx context.Context, name string, svc 
 	return nil
 }
 
-func (o *Orchestrator) startMultiPortService(ctx context.Context, name string, svc config.ServiceConfig, group string, portRange ports.PortRange) error {
-	portAssignments := make(map[string]int)
-	for envName, value := range svc.Env {
-		if value == "auto" {
-			port, err := ports.FindFreePort(portRange, nil)
-			if err != nil {
-				return fmt.Errorf("find free port for %s.%s: %w", name, envName, err)
-			}
-			portAssignments[envName] = port
-		}
-	}
-
+func (o *Orchestrator) startMultiPortService(ctx context.Context, name string, svc config.ServiceConfig, group string, portAssignments map[string]int, portMap envexpand.PortMap) error {
 	if svc.Command != "" {
-		env := buildEnv(svc.Env, portAssignments)
+		env, err := buildEnv(svc.Env, portAssignments, portMap)
+		if err != nil {
+			return fmt.Errorf("build env for %s: %w", name, err)
+		}
 		if err := o.launchProcess(ctx, name, svc, fmt.Sprintf("%s/%s", group, name), group, 0, env); err != nil {
 			return err
 		}
@@ -180,23 +211,27 @@ func (o *Orchestrator) launchProcess(ctx context.Context, name string, svc confi
 	return nil
 }
 
-func buildEnv(configEnv map[string]string, portAssignments map[string]int) []string {
+func buildEnv(configEnv map[string]string, portAssignments map[string]int, portMap envexpand.PortMap) ([]string, error) {
 	var env []string
 	for k, v := range configEnv {
 		if v == "auto" {
 			if port, ok := portAssignments[k]; ok {
 				env = append(env, k+"="+strconv.Itoa(port))
 			}
-		} else {
-			env = append(env, k+"="+v)
+			continue
 		}
+		expanded, err := envexpand.Expand(v, portMap)
+		if err != nil {
+			return nil, fmt.Errorf("env %q: %w", k, err)
+		}
+		env = append(env, k+"="+expanded)
 	}
 	for k, v := range portAssignments {
 		if _, exists := configEnv[k]; !exists {
 			env = append(env, k+"="+strconv.Itoa(v))
 		}
 	}
-	return env
+	return env, nil
 }
 
 // DetectGroup returns the current git branch or fallback "default".

--- a/internal/orchestrator/runner_test.go
+++ b/internal/orchestrator/runner_test.go
@@ -2,48 +2,62 @@ package orchestrator
 
 import (
 	"testing"
+
+	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
 )
 
 func TestBuildEnv(t *testing.T) {
 	tests := []struct {
-		name       string
-		configEnv  map[string]string
-		ports      map[string]int
-		wantLen    int
+		name        string
+		configEnv   map[string]string
+		ports       map[string]int
+		portMap     envexpand.PortMap
+		wantLen     int
 		wantContain string
 	}{
 		{
-			name:       "auto port replaced",
-			configEnv:  map[string]string{"PORT": "auto"},
-			ports:      map[string]int{"PORT": 4001},
-			wantLen:    1,
+			name:        "auto port replaced",
+			configEnv:   map[string]string{"PORT": "auto"},
+			ports:       map[string]int{"PORT": 4001},
+			wantLen:     1,
 			wantContain: "PORT=4001",
 		},
 		{
-			name:       "static value preserved",
-			configEnv:  map[string]string{"NODE_ENV": "production"},
-			ports:      map[string]int{},
-			wantLen:    1,
+			name:        "static value preserved",
+			configEnv:   map[string]string{"NODE_ENV": "production"},
+			ports:       map[string]int{},
+			wantLen:     1,
 			wantContain: "NODE_ENV=production",
 		},
 		{
-			name:       "port assignment added for non-config key",
-			configEnv:  map[string]string{},
-			ports:      map[string]int{"PORT": 3000},
-			wantLen:    1,
+			name:        "port assignment added for non-config key",
+			configEnv:   map[string]string{},
+			ports:       map[string]int{"PORT": 3000},
+			wantLen:     1,
 			wantContain: "PORT=3000",
 		},
 		{
-			name:       "mixed env",
-			configEnv:  map[string]string{"PORT": "auto", "HOST": "0.0.0.0"},
-			ports:      map[string]int{"PORT": 4001},
-			wantLen:    2,
+			name:        "mixed env",
+			configEnv:   map[string]string{"PORT": "auto", "HOST": "0.0.0.0"},
+			ports:       map[string]int{"PORT": 4001},
+			wantLen:     2,
 			wantContain: "PORT=4001",
+		},
+		{
+			name:        "cross-service reference expanded",
+			configEnv:   map[string]string{"DB_URL": "postgres://localhost:${db.port}/app"},
+			ports:       map[string]int{},
+			portMap:     envexpand.PortMap{"db": {"port": 5432, "PORT": 5432}},
+			wantLen:     1,
+			wantContain: "DB_URL=postgres://localhost:5432/app",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env := buildEnv(tt.configEnv, tt.ports)
+			env, err := buildEnv(tt.configEnv, tt.ports, tt.portMap)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if len(env) != tt.wantLen {
 				t.Errorf("expected %d env vars, got %d: %v", tt.wantLen, len(env), env)
 			}
@@ -57,6 +71,55 @@ func TestBuildEnv(t *testing.T) {
 				t.Errorf("expected env to contain %q, got %v", tt.wantContain, env)
 			}
 		})
+	}
+}
+
+func TestBuildEnvUnresolvedReferenceErrors(t *testing.T) {
+	_, err := buildEnv(map[string]string{"X": "${nope.port}"}, nil, envexpand.PortMap{})
+	if err == nil {
+		t.Fatal("expected error for unresolved reference, got nil")
+	}
+}
+
+func TestBuildEnvMultiPortWithCrossServiceRef(t *testing.T) {
+	env, err := buildEnv(
+		map[string]string{
+			"API_PORT":  "auto",
+			"AUTH_PORT": "auto",
+			"DB_URL":    "postgres://localhost:${db.port}/app",
+		},
+		map[string]int{"API_PORT": 4001, "AUTH_PORT": 5001},
+		envexpand.PortMap{"db": {"port": 5432, "PORT": 5432}},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]bool{
+		"API_PORT=4001":                              true,
+		"AUTH_PORT=5001":                             true,
+		"DB_URL=postgres://localhost:5432/app":       true,
+	}
+	for _, e := range env {
+		delete(want, e)
+	}
+	if len(want) > 0 {
+		t.Errorf("missing expected env vars: %v; got full env: %v", want, env)
+	}
+}
+
+func TestBuildEnvAutoWithoutAssignmentIsSkipped(t *testing.T) {
+	env, err := buildEnv(
+		map[string]string{"PORT": "auto"},
+		map[string]int{},
+		envexpand.PortMap{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, e := range env {
+		if e == "PORT=" || len(e) > 4 && e[:5] == "PORT=" {
+			t.Errorf("expected PORT to be skipped when no assignment, got %q in %v", e, env)
+		}
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -140,6 +140,26 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce upstream scheme: if the request's scheme doesn't match the
+	// upstream's declared scheme, redirect to the correct scheme so each
+	// service is only reachable over its own scheme. /__mdp/* paths are
+	// exempt so switching groups still works across scheme changes.
+	if !strings.HasPrefix(r.URL.Path, "/__mdp/") {
+		upstreamScheme := result.Entry.Scheme
+		if upstreamScheme == "" {
+			upstreamScheme = "http"
+		}
+		reqScheme := "http"
+		if r.TLS != nil {
+			reqScheme = "https"
+		}
+		if reqScheme != upstreamScheme {
+			target := upstreamScheme + "://" + r.Host + r.URL.RequestURI()
+			http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+			return
+		}
+	}
+
 	// Track last visited page for this service. Only track browser navigation
 	// requests (Accept: text/html), skip assets, API calls, and /__mdp/ paths.
 	if isNavigationRequest(r) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"crypto/tls"
 	"io"
 	"net"
 	"net/http"
@@ -239,6 +240,129 @@ func TestProxyGetLastPathEmpty(t *testing.T) {
 
 	if got := p.GetLastPath("nonexistent"); got != "" {
 		t.Errorf("last path for unknown service = %q, want empty", got)
+	}
+}
+
+func TestProxyRedirectsHTTPToHTTPSWhenUpstreamIsHTTPS(t *testing.T) {
+	p, reg := newTestProxy(t)
+	if err := reg.Register(&registry.ServerEntry{
+		Name:   "app/main",
+		Repo:   "app",
+		Port:   19998,
+		PID:    1,
+		Scheme: "https",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/some/path?q=1", nil)
+	req.Host = "localhost:3000"
+	req.TLS = nil
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d", rr.Code)
+	}
+	loc := rr.Header().Get("Location")
+	if loc != "https://localhost:3000/some/path?q=1" {
+		t.Errorf("expected redirect to https with path+query, got %q", loc)
+	}
+}
+
+func TestProxySchemeRedirectPreservesPOST(t *testing.T) {
+	p, reg := newTestProxy(t)
+	if err := reg.Register(&registry.ServerEntry{
+		Name:   "app/main",
+		Repo:   "app",
+		Port:   19998,
+		PID:    1,
+		Scheme: "https",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "http://localhost:3000/submit", nil)
+	req.Host = "localhost:3000"
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	// 307 preserves method and body; 302 would let clients downgrade POST to GET.
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307 so POST is preserved, got %d", rr.Code)
+	}
+}
+
+func TestProxyRedirectsHTTPSToHTTPWhenUpstreamIsHTTP(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p, reg := newTestProxy(t)
+	registerUpstream(t, reg, upstream, "app/feature", "app")
+
+	req := httptest.NewRequest("GET", "https://localhost:3000/foo", nil)
+	req.Host = "localhost:3000"
+	req.TLS = &tls.ConnectionState{}
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc != "http://localhost:3000/foo" {
+		t.Errorf("expected redirect to http, got %q", loc)
+	}
+}
+
+func TestProxyDoesNotRedirectMdpPaths(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p, reg := newTestProxy(t)
+	if err := reg.Register(&registry.ServerEntry{
+		Name:   "app/main",
+		Repo:   "app",
+		Port:   serverPort(upstream),
+		PID:    1,
+		Scheme: "https",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plain HTTP request to /__mdp/* with an HTTPS upstream should NOT be
+	// redirected — those paths must stay accessible on both schemes so that
+	// group switching works across scheme changes.
+	req := httptest.NewRequest("GET", "http://localhost:3000/__mdp/health", nil)
+	req.Host = "localhost:3000"
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusTemporaryRedirect {
+		t.Fatalf("/__mdp/* path was unexpectedly redirected (got %d, Location=%q)", rr.Code, rr.Header().Get("Location"))
+	}
+}
+
+func TestProxyNoRedirectWhenSchemeMatches(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p, reg := newTestProxy(t)
+	// http upstream, http request — should not redirect.
+	registerUpstream(t, reg, upstream, "app/main", "app")
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/", nil)
+	req.Host = "localhost:3000"
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusTemporaryRedirect {
+		t.Fatalf("unexpected redirect (Location=%q)", rr.Header().Get("Location"))
 	}
 }
 

--- a/testbed/mdp.yaml
+++ b/testbed/mdp.yaml
@@ -10,7 +10,9 @@ services:
     env:
       NAME: "web / main"
       COLOR: "#0f2027,#203a43,#2c5364"
-      API_URL: "http://localhost:3001"
+      API_URL: "http://localhost:${api-main.PORT}"
+      TLS_CERT: .certs/localhost.pem
+      TLS_KEY: .certs/localhost-key.pem
 
   api-main:
     command: docker compose up --build --wait

--- a/testbed/server/main.go
+++ b/testbed/server/main.go
@@ -40,6 +40,16 @@ func main() {
 	}
 
 	addr := ":" + port
+	tlsCert := os.Getenv("TLS_CERT")
+	tlsKey := os.Getenv("TLS_KEY")
+	if tlsCert != "" && tlsKey != "" {
+		fmt.Printf("%s listening on https://localhost:%s\n", name, port)
+		if err := http.ListenAndServeTLS(addr, tlsCert, tlsKey, mux); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 	fmt.Printf("%s listening on http://localhost:%s\n", name, port)
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)


### PR DESCRIPTION
## Summary
- Adds `${svc.port}` / `${svc.<ENV_NAME>}` interpolation in `mdp.yaml` env values so worktrees with random ports can still wire services together (e.g. `DATABASE_URL: \"postgres://localhost:${db.port}/app\"`). Ports for all services are pre-allocated before any child is launched; exclusion list guards against fixed/auto and auto/auto collisions.
- Proxy now redirects requests to the upstream's declared scheme (307) — a service registered as `scheme: https` is no longer reachable over HTTP, and vice-versa. `/__mdp/*` paths are exempt so group switching works across scheme changes.
- Testbed server supports TLS via `TLS_CERT`/`TLS_KEY` env vars; `web-main` uses it and demonstrates the interpolation feature via `API_URL: \"http://localhost:\${api-main.PORT}\"`.

## Test plan
- [x] `go test -race ./...`
- [ ] Testbed: switch between groups, verify scheme enforcement
- [ ] Testbed: verify `API_URL` env var reaches `web-main` with the correct port