### PR TITLE
fix: make proxy optional on multi-port service ports

### DIFF
--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -262,6 +262,10 @@ func launchMultiPortBatch(client *http.Client, controlURL, name string, svc conf
 		if !ok {
 			continue
 		}
+		if pm.Proxy <= 0 {
+			// Non-HTTP port: allocated for env interpolation only.
+			continue
+		}
 		serviceName := pm.Name
 		if serviceName == "" {
 			serviceName = pm.Env

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +12,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/derekgould/multi-dev-proxy/internal/config"
+	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
 )
 
 func TestPrefixWriter(t *testing.T) {
@@ -177,6 +182,63 @@ func TestWatchHealthStaysOpenWhenHealthy(t *testing.T) {
 	case <-gone:
 		t.Fatal("watchHealth should not close while healthy")
 	case <-time.After(5 * time.Second):
+	}
+}
+
+func TestLaunchMultiPortBatchSkipsProxylessPorts(t *testing.T) {
+	var registerMu sync.Mutex
+	var registerBodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/__mdp/register" {
+			b, _ := io.ReadAll(r.Body)
+			var body map[string]any
+			json.Unmarshal(b, &body)
+			registerMu.Lock()
+			registerBodies = append(registerBodies, body)
+			registerMu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	svc := config.ServiceConfig{
+		// Command empty → no process launched by the test.
+		Env: map[string]string{
+			"API_PORT": "auto",
+			"DB_PORT":  "auto",
+		},
+		Ports: []config.PortMapping{
+			{Env: "API_PORT", Proxy: 4000, Name: "api"},
+			{Env: "DB_PORT"}, // no proxy — should be skipped
+		},
+	}
+	portAssignments := map[string]int{"API_PORT": 40001, "DB_PORT": 54321}
+	portMap := envexpand.PortMap{
+		"infra": {"API_PORT": 40001, "DB_PORT": 54321},
+	}
+
+	bt := &batchTracker{}
+	err := launchMultiPortBatch(http.DefaultClient, srv.URL, "infra", svc, "main", portAssignments, portMap, bt, "client-1")
+	if err != nil {
+		t.Fatalf("launchMultiPortBatch: %v", err)
+	}
+
+	registerMu.Lock()
+	defer registerMu.Unlock()
+	if len(registerBodies) != 1 {
+		t.Fatalf("expected 1 register call, got %d", len(registerBodies))
+	}
+	body := registerBodies[0]
+	if got, _ := body["proxyPort"].(float64); int(got) != 4000 {
+		t.Errorf("proxyPort = %v, want 4000", body["proxyPort"])
+	}
+	if got, _ := body["port"].(float64); int(got) != 40001 {
+		t.Errorf("port = %v, want 40001", body["port"])
+	}
+	if got, _ := body["name"].(string); got != "main/api" {
+		t.Errorf("name = %v, want main/api", body["name"])
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,9 @@ type ServiceConfig struct {
 }
 
 // PortMapping maps an auto-assigned port env var to a proxy and service name.
+// Proxy is optional: omit it for non-HTTP ports (databases, caches, etc.) that
+// need a free port allocated for ${svc.env} interpolation but should not be
+// registered with an HTTP reverse-proxy listener.
 type PortMapping struct {
 	Env   string `yaml:"env"`
 	Proxy int    `yaml:"proxy"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,39 @@ services:
 	}
 }
 
+func TestLoadMultiPortWithoutProxy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  postgres:
+    command: ./run-pg.sh
+    env:
+      DB_PORT: auto
+      REPL_PORT: auto
+    ports:
+      - env: DB_PORT
+      - env: REPL_PORT
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	pg := cfg.Services["postgres"]
+	if len(pg.Ports) != 2 {
+		t.Fatalf("expected 2 port mappings, got %d", len(pg.Ports))
+	}
+	for i, pm := range pg.Ports {
+		if pm.Proxy != 0 {
+			t.Errorf("ports[%d].Proxy = %d, want 0", i, pm.Proxy)
+		}
+	}
+	if pg.Ports[0].Env != "DB_PORT" || pg.Ports[1].Env != "REPL_PORT" {
+		t.Errorf("ports envs = %q, %q", pg.Ports[0].Env, pg.Ports[1].Env)
+	}
+}
+
 func TestLoadDefaultPortRange(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mdp.yaml")

--- a/testbed/mdp.yaml
+++ b/testbed/mdp.yaml
@@ -1,5 +1,5 @@
 services:
-  # === main branch (TLS frontend + Docker API) ===
+  # === main branch (TLS frontend + Docker API + proxy-less fake DB) ===
   web-main:
     command: ./server/server
     proxy: 3000
@@ -11,8 +11,20 @@ services:
       NAME: "web / main"
       COLOR: "#0f2027,#203a43,#2c5364"
       API_URL: "http://localhost:${api-main.PORT}"
+      DB_URL: "postgres://localhost:${db-main.DB_PORT}/app"
       TLS_CERT: .certs/localhost.pem
       TLS_KEY: .certs/localhost-key.pem
+
+  # Fake DB: demonstrates a non-HTTP port declared without a proxy.
+  # DB_PORT gets an allocated free port for ${db-main.DB_PORT} interpolation
+  # (see web-main's DB_URL), but no proxy listener is registered.
+  db-main:
+    command: sh -c 'echo "fake-db listening on $DB_PORT"; exec tail -f /dev/null'
+    group: main
+    env:
+      DB_PORT: auto
+    ports:
+      - env: DB_PORT
 
   api-main:
     command: docker compose up --build --wait


### PR DESCRIPTION
Allow `PortMapping` entries in `mdp.yaml` to omit `proxy:` for non-HTTP ports (databases, caches, queues) that need a free port allocated for `${svc.env}` interpolation but should not be registered with an HTTP reverse-proxy listener.

Previously, multi-port services were forced to invent dummy proxy ports that cluttered `mdp status` and never received real traffic. A `ports:` entry without `proxy:` now skips registration while still allocating a port and exposing it to the process via the declared env var.

Adds a demo to `testbed/mdp.yaml` with a proxy-less `db-main` service referenced by `web-main`'s `DB_URL`, plus unit tests covering config parsing and the registration-skipping behavior.