### PR TITLE
docs: split README into docs/ tree

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,44 @@
+# API reference
+
+## Per-proxy endpoints
+
+Each proxy instance serves these endpoints:
+
+
+| Method   | Path                     | Description                                                        |
+| -------- | ------------------------ | ------------------------------------------------------------------ |
+| `GET`    | `/__mdp/health`          | Health check. Returns `{"ok":true,"servers":N}`                    |
+| `GET`    | `/__mdp/servers`         | List all servers grouped by repo                                   |
+| `POST`   | `/__mdp/register`        | Register a server. Body: `{"name":"repo/branch","port":N,"pid":N}` |
+| `DELETE` | `/__mdp/register/{name}` | Deregister a server by name                                        |
+| `POST`   | `/__mdp/switch/{name}`   | Switch active server. Sets cookie + default, redirects             |
+| `GET`    | `/__mdp/switch`          | Server switcher UI page                                            |
+| `GET`    | `/__mdp/widget.js`       | Floating switcher widget script                                    |
+| `GET`    | `/__mdp/config`          | Proxy config (cookie name, siblings, groups)                       |
+| `GET`    | `/__mdp/default`         | Get current default upstream                                       |
+| `DELETE` | `/__mdp/default`         | Clear default upstream                                             |
+| `POST`   | `/__mdp/default/{name}`  | Set default upstream                                               |
+
+
+## Orchestrator control API (port 13100)
+
+
+| Method   | Path                                   | Description                       |
+| -------- | -------------------------------------- | --------------------------------- |
+| `GET`    | `/__mdp/health`                        | Orchestrator health check         |
+| `GET`    | `/__mdp/proxies`                       | List all proxy instances          |
+| `POST`   | `/__mdp/register`                      | Register (with `proxyPort` field) |
+| `DELETE` | `/__mdp/register/{name}`               | Deregister from all proxies       |
+| `POST`   | `/__mdp/proxies/{port}/default/{name}` | Set default on a specific proxy   |
+| `DELETE` | `/__mdp/proxies/{port}/default`        | Clear default on a specific proxy |
+| `GET`    | `/__mdp/groups`                        | List all groups                   |
+| `POST`   | `/__mdp/groups/{name}/switch`          | Switch group (set defaults)       |
+| `GET`    | `/__mdp/services`                      | List managed services             |
+| `POST`   | `/__mdp/shutdown`                      | Graceful shutdown                 |
+
+
+**Dead server pruning:** Each proxy checks registered servers every 10 seconds. Any server whose PID is no longer alive is removed automatically.
+
+---
+
+[← Back to docs index](./index.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,123 @@
+# CLI reference
+
+## `mdp`
+
+Starts the orchestrator with an interactive TUI. Manages all proxy instances and shows their registered services.
+
+Keys: `↑`/`↓` (or `j`/`k`) navigate, `Enter` switch active server, `Tab` / `h` / `l` switch tabs, `d` detach (leave daemon running), `q` quit (stop daemon). Mouse clicks are supported.
+
+```sh
+mdp
+mdp --control-port 13100
+```
+
+A web dashboard is also served on `--dashboard-port` (default `6370`) — open `http://localhost:6370` if you prefer a browser UI to the TUI.
+
+## `mdp --daemon` / `mdp -d`
+
+Starts the orchestrator as a background daemon (no TUI). Useful for CI or when you don't need the interactive interface.
+
+```sh
+mdp -d
+# prints: mdp orchestrator started (PID 12345, ctrl :13100)
+```
+
+## `mdp run`
+
+Wraps a dev command. Picks a free port, sets it as an environment variable in the child process, and registers with the orchestrator. When the process exits, it deregisters automatically.
+
+```sh
+mdp run -- npm run dev
+mdp run -P 4000 -- go run ./cmd/server
+mdp run --env API_PORT -- docker compose up
+```
+
+Without a command, reads `mdp.yaml` and batch-starts all configured services:
+
+```sh
+mdp run                        # uses current git branch as group
+mdp run --group feature-auth   # override group name
+```
+
+If no orchestrator is running, `mdp run` falls back to solo mode and just runs the command directly.
+
+## `mdp register`
+
+Manually registers an already-running service.
+
+```sh
+mdp register myapp/main --port 4000 -P 3000
+mdp register myapp/main --port 4000 --pid 12345
+mdp register --list
+```
+
+## `mdp switch`
+
+Switch active upstream service or group from the command line. See [how switching works](./concepts.md#how-switching-works) for the resolution order.
+
+```sh
+mdp switch app/main -P 3000          # switch individual server
+mdp switch --group main              # switch all services in a group
+mdp switch --clear -P 3000           # clear default
+```
+
+## `mdp --stop`
+
+Stop the background orchestrator.
+
+```sh
+mdp --stop
+```
+
+## Configuration
+
+**Environment variables:**
+
+
+| Variable         | Description                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------- |
+| `MDP_PROXY_PORT` | Default proxy port for `mdp run` and `mdp register` (overrides the default of 3000) |
+
+
+`**mdp` flags:**
+
+
+| Flag               | Default   | Description                                 |
+| ------------------ | --------- | ------------------------------------------- |
+| `--control-port`   | `13100`   | Control API port                            |
+| `--dashboard-port` | `6370`    | Dashboard web UI port                       |
+| `-d, --daemon`     |           | Run as background daemon (no TUI)           |
+| `--stop`           |           | Stop the background daemon                  |
+| `--config`         |           | Path to mdp.yaml (auto-detected if not set) |
+| `--host`           | `0.0.0.0` | Host for proxy listeners                    |
+
+
+`**mdp run` flags:**
+
+
+| Flag               | Default       | Description                                      |
+| ------------------ | ------------- | ------------------------------------------------ |
+| `-P, --proxy-port` | `3000`        | Proxy port to connect to                         |
+| `--repo`           |               | Repository name override                         |
+| `--name`           |               | Full server name override (skips auto-detection) |
+| `--group`          |               | Group name override (default: git branch)        |
+| `--env`            | `PORT`        | Env var name for the assigned port               |
+| `--port-range`     | `10000-60000` | Port range for spawned services                  |
+| `--control-port`   | `13100`       | Orchestrator control port                        |
+
+
+`**mdp register` flags:**
+
+
+| Flag               | Default | Description                               |
+| ------------------ | ------- | ----------------------------------------- |
+| `-p, --port`       |         | Port the service is running on (required) |
+| `--pid`            | `0`     | Process ID for liveness tracking          |
+| `-P, --proxy-port` | `3000`  | Proxy port to connect to                  |
+| `--group`          |         | Group name override                       |
+| `-l, --list`       |         | List registered services                  |
+| `--control-port`   | `13100` | Orchestrator control port                 |
+
+---
+
+[← Back to docs index](./index.md)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,4 @@
-# Multi-dev Proxy (AKA mdp)
-
-Run multiple dev servers from different branches and even repos behind a single port.
+# Concepts
 
 ## The problem
 
@@ -22,43 +20,52 @@ browser → :3000 (frontend proxy) → :42301 (main branch)
                                   → :20235 (api/feature-auth)
 ```
 
-See [docs/concepts.md](docs/concepts.md) for service groups, switching resolution order, and multi-repo naming.
+## Service groups
 
-## Quick start
+Services are automatically grouped by their git branch name (or an explicit `--group` flag). All services sharing the same group name form a switchable group. Switching to a group sets the default upstream on every proxy at once.
 
 ```sh
-# Terminal 1 — start the orchestrator (opens TUI)
-mdp
+# Start services under the "main" group
+mdp run --group main
 
-# Terminal 2 — run your frontend dev server
+# Switch all proxies to the "feature-auth" group
+mdp switch --group feature-auth
+```
+
+See [`mdp switch`](./cli.md#mdp-switch) for CLI details.
+
+## How switching works
+
+Each proxy has its own cookie (e.g., `__mdp_upstream_3000`) to avoid collisions when multiple proxies run on localhost. The resolution order for each request is:
+
+1. **Cookie** — if a valid cookie is present, route to that server
+2. **Default upstream** — a server-side default set via `mdp switch` or the TUI
+3. **Auto-route** — if only one server is registered, route to it automatically
+4. **Redirect** — redirect to the switch page at `/__mdp/switch`
+
+The default upstream is especially useful for backend proxies where cookies aren't available (dev-server proxies, curl, API clients).
+
+## Multi-repo support
+
+Server names use the format `repo/branch`. The repo name is auto-detected from `git remote get-url origin`, falling back to the directory name.
+
+```sh
+# In ~/code/frontend on branch feature/nav
 mdp run -P 3000 -- npm run dev
+# Registers as: frontend/feature/nav
 
-# Terminal 3 — run your backend
+# In ~/code/api on branch main
 mdp run -P 4000 -- go run ./cmd/server
-
-# Open https://localhost:3000 — use the widget to switch branches
+# Registers as: api/main
 ```
 
-## Install
+Override the name with `--name` or just the repo with `--repo`:
 
 ```sh
-brew install drgould/mdp/mdp
+mdp run --name myapp/staging -- npm run dev
+mdp run --repo frontend -- npm run dev
 ```
 
-Other methods (curl, Scoop): see [docs/installation.md](docs/installation.md).
+---
 
-## Documentation
-
-- [Concepts](docs/concepts.md) — the problem, how it works, groups, switching, multi-repo
-- [Installation](docs/installation.md) — Homebrew, curl, Scoop
-- [Quick start](docs/quick-start.md) — tutorial flow
-- [CLI reference](docs/cli.md) — every command and flag
-- [Config (`mdp.yaml`)](docs/config.md) — services, hooks, `depends_on`, `env_file`, ports, TLS
-- [Recipes](docs/recipes.md) — Docker Compose, HTTPS / mkcert
-- [API reference](docs/api.md) — per-proxy and orchestrator endpoints
-- [Testbed](docs/testbed.md) — demo servers
-- [Contributing](docs/contributing.md) — build, test, release
-
-## License
-
-GPL-3.0. See [LICENSE](LICENSE).
+[← Back to docs index](./index.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,135 @@
+# Config file (`mdp.yaml`)
+
+Place an `mdp.yaml` in your project root to declaratively define services. When present, `mdp run` (without a command) starts all configured services.
+
+```yaml
+services:
+  frontend:
+    setup:
+      - bun install
+    command: bun dev
+    shutdown:
+      - rm -rf .cache/dev
+    dir: ./frontend
+    proxy: 3000
+    env:
+      NEXT_PUBLIC_API_URL: https://localhost:4000
+
+  api:
+    command: go run ./cmd/server
+    dir: ./backend
+    proxy: 4000
+    env:
+      DATABASE_URL: postgres://localhost:5432/dev
+
+  auth:
+    port: 8080          # fixed port, externally managed
+    proxy: 5000
+
+port_range: "10000-60000"  # optional
+```
+
+**Hooks:** `setup` commands run sequentially before `command` — if any exits non-zero the service is marked failed and `command` is not started. `shutdown` commands run sequentially after `command` exits (for any reason), best-effort with a 30s per-step timeout. Both share the same `dir` and `env` as `command`.
+
+**Other service fields:**
+
+- `scheme:` — `http` (default) or `https`. Auto-inferred as `https` when `tls_cert` is set.
+- `tls_cert:` / `tls_key:` — Paths to a TLS cert and key. The proxy serves HTTPS on this port using them. See [HTTPS](./recipes.md#https).
+- `env_file:` — Optional path for writing the service's resolved env vars as a `.env` file. See [Exporting env vars](#exporting-env-vars-to-env-files) below.
+- `depends_on:` — See [Startup dependencies](#startup-dependencies) below.
+- `ports:` — See [Docker Compose](./recipes.md#docker-compose).
+
+## Exporting env vars to `.env` files
+
+`mdp` generates free ports and resolves `${svc.port}` refs at startup, so the final env vars aren't known until the orchestrator is up. To make those values visible to tools that run outside of `mdp` (your editor's run config, `psql`, `curl`, a standalone shell), export them to `.env` files.
+
+**Per-service** — `env_file:` writes exactly what that service's process sees:
+
+```yaml
+services:
+  api:
+    command: ./api
+    proxy: 4000
+    env_file: ./.mdp.api.env   # relative to the service's dir
+    env:
+      DATABASE_URL: "postgres://localhost:${db.port}/app"
+```
+
+**Project-wide** — a top-level `global:` block writes an aggregate file with any keys you pick:
+
+```yaml
+global:
+  env_file: ./.mdp.env          # relative to the mdp.yaml dir
+  env:
+    # Scalar form — any string, with ${svc.key} / ${svc.env.VAR} interpolation.
+    API_URL: "http://localhost:${api.port}"
+    DB_URL:  "postgres://localhost:${db.env.DB_PORT}/app"
+    # Mapping form — pass through another service's port or env var as-is.
+    API_PORT:
+      ref: api.env.PORT
+    DB_PORT:
+      ref: db.env.DB_PORT
+
+services:
+  # ...
+```
+
+Files are written after port resolution, before any service `command` runs. Per-service paths resolve against the service's `dir`; `global.env_file` resolves against the `mdp.yaml` directory.
+
+## Referencing another service's port
+
+Use `${service.port}` inside any `env` value to inject the assigned port of another service. `mdp` resolves these before launching, so every worktree can allocate truly random ports and still wire services together:
+
+```yaml
+services:
+  db:
+    command: docker compose up db --wait
+    # no proxy; internal only
+
+  api:
+    command: ./api
+    proxy: 4000
+    env:
+      DATABASE_URL: "postgres://app:app@localhost:${db.port}/app"
+
+  web:
+    command: npm run dev
+    proxy: 3000
+    env:
+      API_URL: "http://localhost:${api.port}"
+```
+
+For multi-port services, reference the specific env key: `${infra.API_PORT}`.
+
+## Startup dependencies
+
+Use `depends_on` to declare that a service needs other services to be up first. `mdp` waits for each dependency to be TCP-reachable on its assigned port(s) before launching dependents:
+
+```yaml
+services:
+  db:
+    command: docker compose up db --wait
+    env:
+      DB_PORT: auto
+    ports:
+      - env: DB_PORT
+
+  api:
+    command: ./api
+    proxy: 4000
+    depends_on:
+      - db
+
+  web:
+    command: npm run dev
+    proxy: 3000
+    depends_on:
+      - api
+      - db
+```
+
+Services without `depends_on` start in parallel. Independent branches of the dependency graph run in parallel too — only direct dependents wait. Each dependency has a 60s readiness timeout; if a dependency fails to become ready, its dependents are marked `failed` and skipped. Cycles and references to undefined services are rejected at config-load time.
+
+---
+
+[← Back to docs index](./index.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Getting set up
+
+```sh
+git clone https://github.com/drgould/multi-dev-proxy
+cd multi-dev-proxy
+go build ./...
+go test ./...
+```
+
+## Build and test
+
+```sh
+go build ./...             # build all packages
+go build -o mdp ./cmd/mdp  # build the CLI binary
+go test ./...              # run all tests
+go test -race ./...        # run with the race detector
+go vet ./...               # static analysis
+```
+
+### End-to-end tests
+
+E2E tests require the testbed running in a separate terminal. See [Testbed](./testbed.md) for what's in there.
+
+```sh
+cd testbed && ./run.sh   # terminal 1: start proxy + demo servers
+npm run test:e2e         # terminal 2: run Playwright tests
+```
+
+## Conventional commits
+
+Commits to `main` must use [conventional commit](https://www.conventionalcommits.org) prefixes — they drive the next version bump. PR titles must carry the same prefix (release-please reads them when squash-merging).
+
+| Prefix | Effect |
+| --- | --- |
+| `feat:` | minor bump |
+| `fix:` | patch bump |
+| `feat!:` / `fix!:` | major bump |
+| `perf:` | no release, shown in changelog |
+| `docs:` / `test:` / `chore:` / `ci:` / `refactor:` | no release, hidden from changelog |
+
+## Releases
+
+Releases are managed by [release-please](https://github.com/googleapis/release-please) — **do not tag manually**. The flow is:
+
+1. Land conventional commits on `main`.
+2. release-please opens (or updates) a "Release PR" that bumps the version and rewrites `CHANGELOG.md`.
+3. Merge the Release PR. That creates a GitHub Release and pushes the `v*` tag.
+4. The tag triggers [GoReleaser](https://goreleaser.com), which builds and publishes the binaries.
+
+---
+
+[← Back to docs index](./index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+# mdp docs
+
+Run multiple dev servers from different branches and even repos behind a single port.
+
+```sh
+# Terminal 1 — start the orchestrator (opens TUI)
+mdp
+
+# Terminal 2 — run your frontend dev server
+mdp run -P 3000 -- npm run dev
+
+# Terminal 3 — run your backend
+mdp run -P 4000 -- go run ./cmd/server
+
+# Open https://localhost:3000 — use the widget to switch branches
+```
+
+## Documentation
+
+- [Concepts](./concepts.md) — the problem, how it works, groups, switching, multi-repo
+- [Installation](./installation.md) — Homebrew, curl, Scoop
+- [Quick start](./quick-start.md) — tutorial flow
+- [CLI reference](./cli.md) — every command and flag
+- [Config (`mdp.yaml`)](./config.md) — services, hooks, `depends_on`, `env_file`, ports, TLS
+- [Recipes](./recipes.md) — Docker Compose, HTTPS / mkcert
+- [API reference](./api.md) — per-proxy and orchestrator endpoints
+- [Testbed](./testbed.md) — demo servers
+- [Contributing](./contributing.md) — build, test, release

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,24 @@
+# Installation
+
+**Homebrew (macOS/Linux):**
+
+```sh
+brew install drgould/mdp/mdp
+```
+
+**curl (macOS/Linux):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/drgould/multi-dev-proxy/main/install.sh | sh
+```
+
+**Scoop (Windows):**
+
+```powershell
+scoop bucket add mdp https://github.com/drgould/scoop-mdp
+scoop install mdp
+```
+
+---
+
+[← Back to docs index](./index.md)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,25 @@
+# Quick start
+
+```sh
+# Terminal 1 — start the orchestrator (opens TUI)
+mdp
+
+# Terminal 2 — run your frontend dev server
+mdp run -P 3000 -- npm run dev
+
+# Terminal 3 — run your backend
+mdp run -P 4000 -- go run ./cmd/server
+
+# Open https://localhost:3000 — use the widget to switch branches
+```
+
+Next steps:
+
+- Declare services in an [`mdp.yaml`](./config.md) so `mdp run` starts them all at once.
+- Learn how [switching](./concepts.md#how-switching-works) resolves which upstream a request goes to.
+- Put services with their own proxy ports behind a [Docker Compose](./recipes.md#docker-compose) stack.
+- Set up [HTTPS with mkcert](./recipes.md#https) so OAuth flows Just Work.
+
+---
+
+[← Back to docs index](./index.md)

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,77 @@
+# Recipes
+
+## Docker Compose
+
+For projects using Docker Compose where multiple services need their own proxy ports, use the `ports` mapping with `auto` port assignment:
+
+```yaml
+# mdp.yaml
+services:
+  frontend:
+    command: npm run dev
+    proxy: 3000
+
+  infra:
+    command: docker compose up
+    env:
+      API_PORT: auto       # mdp assigns a free port
+      AUTH_PORT: auto
+    ports:
+      - env: API_PORT
+        proxy: 4000
+        name: api          # registered as "<branch>/api"
+      - env: AUTH_PORT
+        proxy: 5000
+        name: auth
+```
+
+In your `docker-compose.yml`, reference the environment variables:
+
+```yaml
+# docker-compose.yml
+services:
+  api:
+    build: ./api
+    ports:
+      - "${API_PORT:-8080}:8080"
+  auth:
+    build: ./auth
+    ports:
+      - "${AUTH_PORT:-8081}:8080"
+```
+
+When you run `mdp run`, mdp assigns free ports, sets them as environment variables, and registers each port mapping with the appropriate proxy.
+
+**Non-HTTP ports (no proxy):** omit `proxy:` (and optionally `name:`) on a `ports:` entry to allocate a free port for `${svc.env.VAR}` interpolation without starting a reverse-proxy listener for it. Useful for databases, caches, and other non-HTTP services other services just need to connect to directly.
+
+```yaml
+db:
+  command: docker compose up db --wait
+  env:
+    DB_PORT: auto
+  ports:
+    - env: DB_PORT    # allocated & interpolatable, no proxy
+```
+
+## HTTPS
+
+mdp inherits TLS certificates from the services it proxies. When a service registers with `--tls-cert` and `--tls-key`, the proxy automatically starts accepting HTTPS connections using that certificate. Each proxy port serves both HTTP and HTTPS on the same port.
+
+```sh
+# Service provides its own cert — proxy inherits it
+mdp run --tls-cert ./certs/localhost.pem --tls-key ./certs/localhost-key.pem -- npm run dev
+
+# Auto-detect mkcert certs
+mdp run --auto-tls -- npm run dev
+```
+
+Generate a local cert with [mkcert](https://github.com/FiloSottile/mkcert):
+
+```sh
+mkcert localhost
+mdp run --tls-cert localhost.pem --tls-key localhost-key.pem -- npm run dev
+```
+
+---
+
+[← Back to docs index](./index.md)

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -1,0 +1,27 @@
+# Testbed
+
+The `testbed/` directory contains demo servers across different frameworks to verify the proxy works end-to-end:
+
+
+| Server       | Framework                 | Features                                     |
+| ------------ | ------------------------- | -------------------------------------------- |
+| go-websocket | Go                        | WebSocket echo, counter                      |
+| vite-ts      | Vite + TypeScript         | Todo list, HMR                               |
+| nextjs       | Next.js                   | SSR, API routes                              |
+| vue          | Vue 3 + TypeScript        | Reactivity, color picker                     |
+| svelte       | SvelteKit + TypeScript    | Reactivity, live filter                      |
+| docker       | nginx + Go API + Postgres | GraphQL API, reverse proxy (requires Docker) |
+
+
+Run them all behind the proxy:
+
+```sh
+cd testbed
+./run.sh
+```
+
+Open `https://localhost:3000` and use the widget to switch between them.
+
+---
+
+[← Back to docs index](./index.md)


### PR DESCRIPTION
Splits the 518-line README.md into a `docs/` tree (`concepts`, `installation`, `quick-start`, `cli`, `config`, `recipes`, `api`, `testbed`, `contributing`, plus an `index`). README is now a 64-line landing page that keeps the problem/how-it-works pitch and quick start inline, with Homebrew as the primary install method. `docs/contributing.md` is fleshed out with build/test commands, a conventional-commit prefix table, and the release-please flow (no more manual `git tag` instructions).

Resolves #18