### PR TITLE
docs: add mkdocs-shadcn site with GitHub Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs-shadcn
+      - run: mkdocs build --strict
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,8 @@ playwright-report/
 # GoReleaser dist
 dist/
 
+# MkDocs build output
+/site/
+
 # Coding Agents
 .sisyphus/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,32 @@
+site_name: mdp
+site_url: https://drgould.github.io/multi-dev-proxy/
+repo_url: https://github.com/drgould/multi-dev-proxy
+repo_name: drgould/multi-dev-proxy
+edit_uri: edit/main/docs/
+
+theme:
+  name: shadcn
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Quick start: quick-start.md
+  - Installation: installation.md
+  - Concepts: concepts.md
+  - CLI reference: cli.md
+  - Config: config.md
+  - Recipes: recipes.md
+  - API reference: api.md
+  - Testbed: testbed.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - admonition
+  - codehilite
+  - fenced_code
+  - footnotes
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.blocks.details


### PR DESCRIPTION
Adds a MkDocs Material-style docs site using the `mkdocs-shadcn` theme, sourced from the existing `docs/` tree. A new `.github/workflows/docs.yml` builds with `mkdocs build --strict` and deploys via `actions/deploy-pages@v4` on pushes to `main` that touch `docs/` or `mkdocs.yml`. `/site/` is gitignored.

One-time manual step required: **Settings → Pages → Source = "GitHub Actions"**.

Resolves #19