### PR TITLE
fix: load TLS certs across all register paths

### DIFF
--- a/cmd/mdp/register.go
+++ b/cmd/mdp/register.go
@@ -28,6 +28,8 @@ func init() {
 	registerCmd.Flags().BoolP("list", "l", false, "List registered services")
 	registerCmd.Flags().String("group", "", "Group name override (default: git branch)")
 	registerCmd.Flags().Int("control-port", 13100, "Orchestrator control port")
+	registerCmd.Flags().String("tls-cert", "", "TLS certificate file (forwarded to proxy for HTTPS)")
+	registerCmd.Flags().String("tls-key", "", "TLS key file (forwarded to proxy for HTTPS)")
 }
 
 func runRegister(cmd *cobra.Command, args []string) error {
@@ -35,13 +37,19 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	listFlag, _ := cmd.Flags().GetBool("list")
 	controlPort, _ := cmd.Flags().GetInt("control-port")
 	groupFlag, _ := cmd.Flags().GetString("group")
+	tlsCert, _ := cmd.Flags().GetString("tls-cert")
+	tlsKey, _ := cmd.Flags().GetString("tls-key")
 
 	if envPort := os.Getenv("MDP_PROXY_PORT"); envPort != "" && !cmd.Flags().Changed("proxy-port") {
 		fmt.Sscanf(envPort, "%d", &proxyPort)
 	}
 
+	if (tlsCert != "") != (tlsKey != "") {
+		return fmt.Errorf("both --tls-cert and --tls-key are required")
+	}
+
 	if isOrchestratorRunning(controlPort) {
-		return runRegisterViaOrchestrator(cmd, args, controlPort, proxyPort, groupFlag, listFlag)
+		return runRegisterViaOrchestrator(cmd, args, controlPort, proxyPort, groupFlag, listFlag, tlsCert, tlsKey)
 	}
 
 	proxyURL := discoverProxyURL(proxyPort)
@@ -61,7 +69,13 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	}
 	pid, _ := cmd.Flags().GetInt("pid")
 
-	body, _ := json.Marshal(map[string]any{"name": name, "port": port, "pid": pid, "group": groupFlag})
+	payload := map[string]any{"name": name, "port": port, "pid": pid, "group": groupFlag}
+	if tlsCert != "" {
+		payload["scheme"] = "https"
+		payload["tlsCertPath"] = tlsCert
+		payload["tlsKeyPath"] = tlsKey
+	}
+	body, _ := json.Marshal(payload)
 	req, _ := http.NewRequest(http.MethodPost, proxyURL+"/__mdp/register", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := tlsSkipClient().Do(req)
@@ -77,7 +91,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runRegisterViaOrchestrator(cmd *cobra.Command, args []string, controlPort, proxyPort int, groupFlag string, listFlag bool) error {
+func runRegisterViaOrchestrator(cmd *cobra.Command, args []string, controlPort, proxyPort int, groupFlag string, listFlag bool, tlsCert, tlsKey string) error {
 	controlURL := fmt.Sprintf("http://127.0.0.1:%d", controlPort)
 	client := &http.Client{Timeout: 5 * time.Second}
 
@@ -113,13 +127,19 @@ func runRegisterViaOrchestrator(cmd *cobra.Command, args []string, controlPort, 
 	}
 	pid, _ := cmd.Flags().GetInt("pid")
 
-	body, _ := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"name":      name,
 		"port":      port,
 		"pid":       pid,
 		"proxyPort": proxyPort,
 		"group":     groupFlag,
-	})
+	}
+	if tlsCert != "" {
+		payload["scheme"] = "https"
+		payload["tlsCertPath"] = tlsCert
+		payload["tlsKeyPath"] = tlsKey
+	}
+	body, _ := json.Marshal(payload)
 	resp, err := client.Post(controlURL+"/__mdp/register", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("orchestrator not reachable: %w", err)

--- a/cmd/mdp/register_test.go
+++ b/cmd/mdp/register_test.go
@@ -18,6 +18,8 @@ func newRegisterCmd(controlPort int, flags map[string]string, args []string) *co
 	cmd.Flags().BoolP("list", "l", false, "")
 	cmd.Flags().String("group", "", "")
 	cmd.Flags().Int("control-port", controlPort, "")
+	cmd.Flags().String("tls-cert", "", "")
+	cmd.Flags().String("tls-key", "", "")
 	for k, v := range flags {
 		cmd.Flags().Set(k, v)
 	}
@@ -58,6 +60,51 @@ func TestRegisterViaOrchestratorSuccess(t *testing.T) {
 	}
 	if gotBody["name"] != "app/main" {
 		t.Errorf("expected name app/main, got %v", gotBody["name"])
+	}
+}
+
+func TestRegisterViaOrchestratorForwardsTLS(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/__mdp/health" {
+			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+			return
+		}
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}))
+	defer srv.Close()
+
+	port := testPort(t, srv.URL)
+	cmd := newRegisterCmd(port, map[string]string{
+		"port":       "4001",
+		"proxy-port": "3000",
+		"tls-cert":   "/tmp/c.pem",
+		"tls-key":    "/tmp/k.pem",
+	}, []string{"app/main"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if gotBody["tlsCertPath"] != "/tmp/c.pem" {
+		t.Errorf("tlsCertPath = %v, want /tmp/c.pem", gotBody["tlsCertPath"])
+	}
+	if gotBody["tlsKeyPath"] != "/tmp/k.pem" {
+		t.Errorf("tlsKeyPath = %v, want /tmp/k.pem", gotBody["tlsKeyPath"])
+	}
+	if gotBody["scheme"] != "https" {
+		t.Errorf("scheme = %v, want https", gotBody["scheme"])
+	}
+}
+
+func TestRegisterTLSFlagsRequiredTogether(t *testing.T) {
+	port := 1
+	cmd := newRegisterCmd(port, map[string]string{
+		"port":     "4001",
+		"tls-cert": "/tmp/c.pem",
+	}, []string{"app/main"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "both --tls-cert and --tls-key") {
+		t.Fatalf("expected paired-flag error, got: %v", err)
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -86,8 +86,15 @@ func ServersHandler(reg *registry.Registry) http.HandlerFunc {
 	}
 }
 
-// RegisterHandler handles POST /__mdp/register
-func RegisterHandler(reg *registry.Registry) http.HandlerFunc {
+// CertLoader loads a TLS keypair into the proxy's cert store. Optional
+// dependency for RegisterHandler — when nil, cert paths in the request are
+// stored on the registry entry but not loaded.
+type CertLoader func(certPath, keyPath string) error
+
+// RegisterHandler handles POST /__mdp/register. If addCert is non-nil and the
+// request includes both tlsCertPath and tlsKeyPath, the cert is loaded into
+// the proxy's TLS store so the listener can serve HTTPS for the new service.
+func RegisterHandler(reg *registry.Registry, addCert CertLoader) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
@@ -113,6 +120,14 @@ func RegisterHandler(reg *registry.Registry) http.HandlerFunc {
 		scheme := body.Scheme
 		if scheme == "" {
 			scheme = "http"
+		}
+		// Load TLS cert before registering so a bad cert doesn't leave the
+		// service half-registered with scheme=https but no listener cert.
+		if addCert != nil && body.TLSCertPath != "" && body.TLSKeyPath != "" {
+			if err := addCert(body.TLSCertPath, body.TLSKeyPath); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "load TLS cert: " + err.Error()})
+				return
+			}
 		}
 		entry := &registry.ServerEntry{
 			Name:        body.Name,

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +12,8 @@ import (
 	"github.com/derekgould/multi-dev-proxy/internal/registry"
 	"github.com/derekgould/multi-dev-proxy/internal/routing"
 )
+
+var errAddCert = errors.New("bad cert")
 
 func newTestRegistry(entries ...*registry.ServerEntry) *registry.Registry {
 	reg := registry.New()
@@ -203,7 +206,7 @@ func TestRegisterHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := registry.New()
-			handler := RegisterHandler(reg)
+			handler := RegisterHandler(reg, nil)
 
 			req := httptest.NewRequest(tt.method, "/__mdp/register", strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", "application/json")
@@ -572,7 +575,7 @@ func TestCORSMiddleware(t *testing.T) {
 
 func TestRegisterHandlerInfersRepo(t *testing.T) {
 	reg := registry.New()
-	handler := RegisterHandler(reg)
+	handler := RegisterHandler(reg, nil)
 
 	body := `{"name":"myrepo/feature","port":3000,"pid":100}`
 	req := httptest.NewRequest(http.MethodPost, "/__mdp/register", strings.NewReader(body))
@@ -594,7 +597,7 @@ func TestRegisterHandlerInfersRepo(t *testing.T) {
 
 func TestRegisterHandlerDefaultScheme(t *testing.T) {
 	reg := registry.New()
-	handler := RegisterHandler(reg)
+	handler := RegisterHandler(reg, nil)
 
 	body := `{"name":"app/main","port":3000,"pid":100}`
 	req := httptest.NewRequest(http.MethodPost, "/__mdp/register", strings.NewReader(body))
@@ -605,6 +608,70 @@ func TestRegisterHandlerDefaultScheme(t *testing.T) {
 	entry := reg.Get("app/main")
 	if entry.Scheme != "http" {
 		t.Errorf("scheme = %q, want http (default)", entry.Scheme)
+	}
+}
+
+func TestRegisterHandlerLoadsTLSCert(t *testing.T) {
+	reg := registry.New()
+	var gotCert, gotKey string
+	addCert := func(certPath, keyPath string) error {
+		gotCert, gotKey = certPath, keyPath
+		return nil
+	}
+	handler := RegisterHandler(reg, addCert)
+
+	body := `{"name":"app/main","port":3000,"scheme":"https","tlsCertPath":"/tmp/c.pem","tlsKeyPath":"/tmp/k.pem"}`
+	req := httptest.NewRequest(http.MethodPost, "/__mdp/register", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if gotCert != "/tmp/c.pem" || gotKey != "/tmp/k.pem" {
+		t.Errorf("addCert called with (%q,%q), want (/tmp/c.pem,/tmp/k.pem)", gotCert, gotKey)
+	}
+}
+
+func TestRegisterHandlerAtomicOnTLSFailure(t *testing.T) {
+	reg := registry.New()
+	addCert := func(certPath, keyPath string) error {
+		return errAddCert
+	}
+	handler := RegisterHandler(reg, addCert)
+
+	body := `{"name":"app/main","port":3000,"scheme":"https","tlsCertPath":"/tmp/c.pem","tlsKeyPath":"/tmp/k.pem"}`
+	req := httptest.NewRequest(http.MethodPost, "/__mdp/register", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if reg.Get("app/main") != nil {
+		t.Error("service should not be registered when cert load fails")
+	}
+}
+
+func TestRegisterHandlerSkipsTLSWhenPathsMissing(t *testing.T) {
+	reg := registry.New()
+	called := false
+	addCert := func(certPath, keyPath string) error {
+		called = true
+		return nil
+	}
+	handler := RegisterHandler(reg, addCert)
+
+	body := `{"name":"app/main","port":3000}`
+	req := httptest.NewRequest(http.MethodPost, "/__mdp/register", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if called {
+		t.Error("addCert should not be called when cert paths are absent")
 	}
 }
 

--- a/internal/orchestrator/controlapi.go
+++ b/internal/orchestrator/controlapi.go
@@ -149,6 +149,20 @@ func (c *ControlAPI) handleRegister(w http.ResponseWriter, r *http.Request) {
 	if scheme == "" {
 		scheme = "http"
 	}
+	// Bind the proxy port up front so a port-bind failure doesn't leave the
+	// cert store mutated by a subsequent AddCert call.
+	if _, err := c.orch.EnsureProxy(body.ProxyPort); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	// Load TLS cert before registering so a bad cert doesn't leave the
+	// service half-registered with scheme=https but no listener cert.
+	if body.TLSCertPath != "" && body.TLSKeyPath != "" {
+		if err := c.orch.AddCert(body.TLSCertPath, body.TLSKeyPath); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "load TLS cert: " + err.Error()})
+			return
+		}
+	}
 	entry := &registry.ServerEntry{
 		Name:        body.Name,
 		Repo:        repo,
@@ -166,12 +180,6 @@ func (c *ControlAPI) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.ClientID != "" {
 		c.orch.Heartbeat(body.ClientID)
-	}
-	// Dynamically load the service's TLS cert into the proxy cert store.
-	if body.TLSCertPath != "" && body.TLSKeyPath != "" {
-		if err := c.orch.AddCert(body.TLSCertPath, body.TLSKeyPath); err != nil {
-			slog.Warn("failed to load service TLS cert", "name", body.Name, "err", err)
-		}
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }

--- a/internal/orchestrator/controlapi_test.go
+++ b/internal/orchestrator/controlapi_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bytes"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -82,6 +83,72 @@ func TestControlAPIRegister(t *testing.T) {
 	pi := o.GetProxy(3000)
 	if pi.Registry.Get("api/main") == nil {
 		t.Error("expected api/main to be registered")
+	}
+}
+
+// TestControlAPIRegisterDoesNotLoadCertWhenProxyBindFails verifies that a
+// failure to bind the proxy port aborts the request before AddCert mutates
+// the orchestrator-wide cert store. Otherwise a busy port could leak certs.
+func TestControlAPIRegisterDoesNotLoadCertWhenProxyBindFails(t *testing.T) {
+	// Hold a port so EnsureProxy(busyPort) fails on bind.
+	busyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer busyLn.Close()
+	busyPort := busyLn.Addr().(*net.TCPAddr).Port
+
+	o := New(&config.Config{}, "127.0.0.1")
+	capi := NewControlAPI(o, nil)
+
+	// Use real cert paths so AddCert *would* succeed if it were called.
+	certPath, keyPath, _ := writeSelfSignedCert(t)
+
+	payload := map[string]any{
+		"name":        "app/main",
+		"port":        9999,
+		"proxyPort":   busyPort,
+		"scheme":      "https",
+		"tlsCertPath": certPath,
+		"tlsKeyPath":  keyPath,
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/__mdp/register", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	capi.Handler().ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("expected non-200 when port bind fails, got 200")
+	}
+	if o.HasCerts() {
+		t.Error("cert store should be empty when proxy bind fails")
+	}
+}
+
+func TestControlAPIRegisterAtomicOnTLSFailure(t *testing.T) {
+	o, handler := setupControlAPI(t)
+
+	payload := map[string]any{
+		"name":         "api/main",
+		"port":         5001,
+		"pid":          300,
+		"proxyPort":    3000,
+		"group":        "dev",
+		"scheme":       "https",
+		"tlsCertPath":  "/nonexistent/cert.pem",
+		"tlsKeyPath":   "/nonexistent/key.pem",
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/__mdp/register", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	pi := o.GetProxy(3000)
+	if pi.Registry.Get("api/main") != nil {
+		t.Error("service should not be registered when cert load fails")
 	}
 }
 

--- a/internal/orchestrator/integration_test.go
+++ b/internal/orchestrator/integration_test.go
@@ -1,0 +1,420 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/derekgould/multi-dev-proxy/internal/config"
+	"github.com/derekgould/multi-dev-proxy/internal/routing"
+)
+
+// TestRegisterTLSEndToEnd exercises the full path that was broken before:
+// register a service via the control API with cert paths → orchestrator loads
+// the keypair → SmartListener serves real TLS → tls.Dial completes the
+// handshake and receives the same cert.
+func TestRegisterTLSEndToEnd(t *testing.T) {
+	certPath, keyPath, wantCN := writeSelfSignedCert(t)
+
+	proxyPort := freeTCPPort(t)
+	o := New(&config.Config{}, "127.0.0.1")
+	pi, err := o.EnsureProxy(proxyPort)
+	if err != nil {
+		t.Fatalf("EnsureProxy: %v", err)
+	}
+	t.Cleanup(func() {
+		pi.cancel()
+		_ = pi.Server.Close()
+	})
+
+	capi := NewControlAPI(o, nil)
+	body, _ := json.Marshal(map[string]any{
+		"name":        "app/main",
+		"port":        freeTCPPort(t),
+		"proxyPort":   proxyPort,
+		"scheme":      "https",
+		"tlsCertPath": certPath,
+		"tlsKeyPath":  keyPath,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/__mdp/register", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	capi.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("register: status %d, body %s", rec.Code, rec.Body.String())
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
+	dialer := &net.Dialer{Timeout: 2 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "localhost",
+	})
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	defer conn.Close()
+
+	state := conn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		t.Fatal("server presented no certificate")
+	}
+	if got := state.PeerCertificates[0].Subject.CommonName; got != wantCN {
+		t.Errorf("served cert CN = %q, want %q", got, wantCN)
+	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// startOrchProxy spins up an orchestrator listening on a real ephemeral port
+// and returns the orchestrator, proxy port, and a teardown helper that runs
+// on test cleanup.
+func startOrchProxy(t *testing.T) (*Orchestrator, int) {
+	t.Helper()
+	port := freeTCPPort(t)
+	o := New(&config.Config{}, "127.0.0.1")
+	pi, err := o.EnsureProxy(port)
+	if err != nil {
+		t.Fatalf("EnsureProxy: %v", err)
+	}
+	t.Cleanup(func() {
+		pi.cancel()
+		_ = pi.Server.Close()
+	})
+	return o, port
+}
+
+// registerViaControlAPI POSTs a register payload and fails the test if the
+// orchestrator rejects it.
+func registerViaControlAPI(t *testing.T, o *Orchestrator, payload map[string]any) {
+	t.Helper()
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/__mdp/register", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	NewControlAPI(o, nil).Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("register: status %d, body %s", rec.Code, rec.Body.String())
+	}
+}
+
+// noRedirectClient returns an http.Client that surfaces redirects instead of
+// following them, so tests can assert on 302→/__mdp/switch behavior.
+func noRedirectClient() *http.Client {
+	return &http.Client{
+		Timeout: 2 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func writeSelfSignedCert(t *testing.T) (certPath, keyPath, commonName string) {
+	t.Helper()
+	commonName = "localhost"
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{commonName},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+// TestPlainHTTPRegisterAndRoute spins up a real upstream, registers it via
+// the control API, then issues a real HTTP request to the proxy port and
+// asserts the upstream's body comes back. This is the bare-bones happy-path
+// integration that previously had no Go-level coverage.
+func TestPlainHTTPRegisterAndRoute(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "hello from upstream")
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamPort := mustPort(t, upstream.URL)
+	o, proxyPort := startOrchProxy(t)
+	registerViaControlAPI(t, o, map[string]any{
+		"name":      "app/main",
+		"port":      upstreamPort,
+		"proxyPort": proxyPort,
+	})
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/", proxyPort))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if got, want := string(body), "hello from upstream\n"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+// TestDeregisterMidTraffic registers and routes successfully, then deregisters
+// and asserts the next request no longer reaches the upstream — instead it
+// redirects to /__mdp/switch (Count==0 path in routing.ResolveUpstream).
+func TestDeregisterMidTraffic(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "live")
+	}))
+	t.Cleanup(upstream.Close)
+
+	o, proxyPort := startOrchProxy(t)
+	registerViaControlAPI(t, o, map[string]any{
+		"name":      "app/main",
+		"port":      mustPort(t, upstream.URL),
+		"proxyPort": proxyPort,
+	})
+
+	// Sanity: routing works.
+	if resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/", proxyPort)); err != nil {
+		t.Fatalf("pre-deregister GET: %v", err)
+	} else {
+		resp.Body.Close()
+	}
+
+	// Deregister via the control API.
+	delReq := httptest.NewRequest(http.MethodDelete, "/__mdp/register/app/main", nil)
+	delRec := httptest.NewRecorder()
+	NewControlAPI(o, nil).Handler().ServeHTTP(delRec, delReq)
+	if delRec.Code != http.StatusOK {
+		t.Fatalf("deregister: status %d, body %s", delRec.Code, delRec.Body.String())
+	}
+
+	resp, err := noRedirectClient().Get(fmt.Sprintf("http://127.0.0.1:%d/", proxyPort))
+	if err != nil {
+		t.Fatalf("post-deregister GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("post-deregister status = %d, want 302 (redirect to switch)", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/__mdp/switch" {
+		t.Errorf("Location = %q, want /__mdp/switch", loc)
+	}
+}
+
+// TestCookieRoutingBetweenSiblings registers two upstreams on the same proxy
+// and asserts that the routing cookie picks the correct one for each request.
+func TestCookieRoutingBetweenSiblings(t *testing.T) {
+	upA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "A")
+	}))
+	upB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "B")
+	}))
+	t.Cleanup(upA.Close)
+	t.Cleanup(upB.Close)
+
+	o, proxyPort := startOrchProxy(t)
+	registerViaControlAPI(t, o, map[string]any{
+		"name": "app/a", "port": mustPort(t, upA.URL), "proxyPort": proxyPort,
+	})
+	registerViaControlAPI(t, o, map[string]any{
+		"name": "app/b", "port": mustPort(t, upB.URL), "proxyPort": proxyPort,
+	})
+
+	cookieName := routing.CookieNameForPort(proxyPort)
+	for _, tc := range []struct {
+		name, body string
+	}{
+		{"app/a", "A"},
+		{"app/b", "B"},
+	} {
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/", proxyPort), nil)
+		req.AddCookie(&http.Cookie{Name: cookieName, Value: url.QueryEscape(tc.name)})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", tc.name, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if string(body) != tc.body {
+			t.Errorf("cookie=%s → body %q, want %q", tc.name, body, tc.body)
+		}
+	}
+}
+
+// TestGroupSwitchUpdatesDefaults registers two services in different groups
+// on a single proxy, then issues a group switch and verifies a cookieless
+// request now routes to the switched group's service.
+func TestGroupSwitchUpdatesDefaults(t *testing.T) {
+	upDev := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "dev")
+	}))
+	upStg := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "stg")
+	}))
+	t.Cleanup(upDev.Close)
+	t.Cleanup(upStg.Close)
+
+	o, proxyPort := startOrchProxy(t)
+	registerViaControlAPI(t, o, map[string]any{
+		"name": "app/dev", "port": mustPort(t, upDev.URL), "proxyPort": proxyPort, "group": "dev",
+	})
+	registerViaControlAPI(t, o, map[string]any{
+		"name": "app/stg", "port": mustPort(t, upStg.URL), "proxyPort": proxyPort, "group": "stg",
+	})
+
+	// Switch the default to the stg group.
+	switchReq := httptest.NewRequest(http.MethodPost, "/__mdp/groups/stg/switch", nil)
+	switchRec := httptest.NewRecorder()
+	NewControlAPI(o, nil).Handler().ServeHTTP(switchRec, switchReq)
+	if switchRec.Code != http.StatusOK {
+		t.Fatalf("group switch: status %d, body %s", switchRec.Code, switchRec.Body.String())
+	}
+
+	// Cookieless request should now hit the stg upstream via the registry default.
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/", proxyPort))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "stg" {
+		t.Errorf("default after switch = %q, want %q", body, "stg")
+	}
+}
+
+// TestHeartbeatPrunesStaleSession registers a service tied to a clientID and
+// verifies the session pruner deregisters it once heartbeats stop arriving.
+func TestHeartbeatPrunesStaleSession(t *testing.T) {
+	o, proxyPort := startOrchProxy(t)
+	registerViaControlAPI(t, o, map[string]any{
+		"name":      "app/main",
+		"port":      freeTCPPort(t),
+		"proxyPort": proxyPort,
+		"clientID":  "client-1",
+	})
+	pi := o.GetProxy(proxyPort)
+	if pi.Registry.Get("app/main") == nil {
+		t.Fatal("precondition: service should be registered")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	o.StartSessionPruner(ctx, 5*time.Millisecond, 1*time.Millisecond)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if pi.Registry.Get("app/main") == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Error("expected pruner to deregister stale-session service within 1s")
+}
+
+// TestMultiPortServiceRegistersAll exercises startMultiPortService end-to-end:
+// a single mdp.yaml service declares two `ports:` entries, each pointing to a
+// different proxy. After StartConfigServices, both registrations should appear
+// on their respective proxy registries.
+func TestMultiPortServiceRegistersAll(t *testing.T) {
+	swapTimeouts(t, 100*time.Millisecond, 5*time.Millisecond)
+	swapTCPCheck(t, func(int) bool { return true })
+
+	proxyA := freeTCPPort(t)
+	proxyB := freeTCPPort(t)
+
+	cfg := &config.Config{
+		PortRange: "30000-31000",
+		Services: map[string]config.ServiceConfig{
+			"myapp": {
+				Command: "true", // exits immediately; registration happens after cmd.Start
+				Env:     map[string]string{"API_PORT": "auto", "WS_PORT": "auto"},
+				Ports: []config.PortMapping{
+					{Env: "API_PORT", Proxy: proxyA, Name: "api"},
+					{Env: "WS_PORT", Proxy: proxyB, Name: "ws"},
+				},
+			},
+		},
+	}
+	o := New(cfg, "127.0.0.1")
+	t.Cleanup(func() { o.Shutdown(context.Background()) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := o.StartConfigServices(ctx, "test"); err != nil {
+		t.Fatalf("StartConfigServices: %v", err)
+	}
+
+	piA := o.GetProxy(proxyA)
+	if piA == nil || piA.Registry.Get("test/api") == nil {
+		t.Errorf("expected test/api registered on proxy %d", proxyA)
+	}
+	piB := o.GetProxy(proxyB)
+	if piB == nil || piB.Registry.Get("test/ws") == nil {
+		t.Errorf("expected test/ws registered on proxy %d", proxyB)
+	}
+}
+
+func mustPort(t *testing.T, rawURL string) int {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawURL, err)
+	}
+	_, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split host %q: %v", u.Host, err)
+	}
+	var port int
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
+		t.Fatalf("parse port %q: %v", portStr, err)
+	}
+	return port
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -236,7 +236,7 @@ func (o *Orchestrator) createProxyLocked(port int, label string) (*ProxyInstance
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /__mdp/health", api.HealthHandler(reg))
 	mux.HandleFunc("GET /__mdp/servers", api.ServersHandler(reg))
-	mux.HandleFunc("POST /__mdp/register", api.RegisterHandler(reg))
+	mux.HandleFunc("POST /__mdp/register", api.RegisterHandler(reg, o.AddCert))
 	mux.HandleFunc("DELETE /__mdp/register/{name...}", api.DeregisterHandler(reg))
 	mux.HandleFunc("POST /__mdp/switch/{name...}", api.SwitchHandler(reg, cookieName, prx, port))
 	mux.HandleFunc("GET /__mdp/last-path/{name...}", api.LastPathHandler(prx))


### PR DESCRIPTION
The per-proxy `/__mdp/register` handler accepted `tlsCertPath`/`tlsKeyPath` but never loaded the cert into the proxy's TLS store, and the `mdp register` CLI had no `--tls-cert`/`--tls-key` flags at all. Both paths now forward and load the cert atomically — `EnsureProxy` first (so a port-bind failure aborts before mutating cert state), then `AddCert`, then registry update — so a failure in any step leaves no half-mutated state.

Adds integration tests in `internal/orchestrator/integration_test.go` covering register-with-cert → real `tls.Dial` handshake, plus plain HTTP routing, deregister mid-traffic, cookie sibling routing, group switching, heartbeat pruning, and multi-port services from `mdp.yaml`.