### PR TITLE
fix: resolve relative TLS paths against caller cwd

### DIFF
--- a/cmd/mdp/register.go
+++ b/cmd/mdp/register.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -46,6 +47,23 @@ func runRegister(cmd *cobra.Command, args []string) error {
 
 	if (tlsCert != "") != (tlsKey != "") {
 		return fmt.Errorf("both --tls-cert and --tls-key are required")
+	}
+
+	// Resolve TLS paths against the caller's cwd — the daemon, which actually
+	// loads the cert, may be running from a different directory.
+	if tlsCert != "" {
+		abs, err := filepath.Abs(tlsCert)
+		if err != nil {
+			return fmt.Errorf("resolve --tls-cert: %w", err)
+		}
+		tlsCert = abs
+	}
+	if tlsKey != "" {
+		abs, err := filepath.Abs(tlsKey)
+		if err != nil {
+			return fmt.Errorf("resolve --tls-key: %w", err)
+		}
+		tlsKey = abs
 	}
 
 	if isOrchestratorRunning(controlPort) {

--- a/cmd/mdp/register_test.go
+++ b/cmd/mdp/register_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -93,6 +95,44 @@ func TestRegisterViaOrchestratorForwardsTLS(t *testing.T) {
 	}
 	if gotBody["scheme"] != "https" {
 		t.Errorf("scheme = %v, want https", gotBody["scheme"])
+	}
+}
+
+func TestRegisterViaOrchestratorResolvesRelativeTLSPaths(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/__mdp/health" {
+			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+			return
+		}
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}))
+	defer srv.Close()
+
+	t.Chdir(t.TempDir())
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	port := testPort(t, srv.URL)
+	cmd := newRegisterCmd(port, map[string]string{
+		"port":       "4001",
+		"proxy-port": "3000",
+		"tls-cert":   "cert.pem",
+		"tls-key":    "key.pem",
+	}, []string{"app/main"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	wantCert := filepath.Join(cwd, "cert.pem")
+	wantKey := filepath.Join(cwd, "key.pem")
+	if gotBody["tlsCertPath"] != wantCert {
+		t.Errorf("tlsCertPath = %v, want %s", gotBody["tlsCertPath"], wantCert)
+	}
+	if gotBody["tlsKeyPath"] != wantKey {
+		t.Errorf("tlsKeyPath = %v, want %s", gotBody["tlsKeyPath"], wantKey)
 	}
 }
 

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -646,6 +646,22 @@ func runSingleMode(cmd *cobra.Command, args []string, controlPort int, groupFlag
 	if err != nil {
 		return fmt.Errorf("cannot determine working directory: %w", err)
 	}
+	// Resolve TLS paths against the caller's cwd — the daemon, which actually
+	// loads the cert, may be running from a different directory.
+	if tlsCert != "" {
+		abs, err := filepath.Abs(tlsCert)
+		if err != nil {
+			return fmt.Errorf("resolve --tls-cert: %w", err)
+		}
+		tlsCert = abs
+	}
+	if tlsKey != "" {
+		abs, err := filepath.Abs(tlsKey)
+		if err != nil {
+			return fmt.Errorf("resolve --tls-key: %w", err)
+		}
+		tlsKey = abs
+	}
 	serverName := nameOverride
 	if serverName == "" {
 		repo := repoOverride


### PR DESCRIPTION
Resolve `--tls-cert` and `--tls-key` to absolute paths in `mdp run` and `mdp register` before sending them to the daemon, so relative paths work regardless of where the daemon was started.

Regression introduced in 1.5.1: commit cf0c8d0 tightened orchestrator cert-load errors from a silent `slog.Warn` to HTTP 400, which surfaced the fact that paths were being resolved against the daemon's cwd. Env files are unaffected — batch-mode env file paths are already absolutised in `config.Load`, and neither `mdp run` nor `mdp register` have env-file flags. Adds a unit test that chdirs into a temp dir and asserts the registration payload carries the absolute path.