### PR TITLE
fix: write env files in mdp run batch mode

### DIFF
--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/derekgould/multi-dev-proxy/internal/depwait"
 	"github.com/derekgould/multi-dev-proxy/internal/detect"
 	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
+	"github.com/derekgould/multi-dev-proxy/internal/envexport"
 	"github.com/derekgould/multi-dev-proxy/internal/orchestrator"
 	"github.com/derekgould/multi-dev-proxy/internal/ports"
 	"github.com/derekgould/multi-dev-proxy/internal/process"
@@ -165,7 +166,7 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 				svcPorts[k] = v
 			}
 			portMap[name] = svcPorts
-			allocations = append(allocations, batchAlloc{name, svc, svcGroup, 0, portAssignments})
+			allocations = append(allocations, batchAlloc{name: name, svc: svc, svcGroup: svcGroup, portAssignments: portAssignments})
 			continue
 		}
 
@@ -178,7 +179,11 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 			assignedPorts = append(assignedPorts, assignedPort)
 		}
 		portMap[name] = map[string]int{"port": assignedPort, "PORT": assignedPort}
-		allocations = append(allocations, batchAlloc{name, svc, svcGroup, assignedPort, nil})
+		allocations = append(allocations, batchAlloc{name: name, svc: svc, svcGroup: svcGroup, assignedPort: assignedPort})
+	}
+
+	if err := exportBatchEnvFiles(cfg, allocations, portMap); err != nil {
+		return err
 	}
 
 	batchCtx, batchCancel := context.WithCancel(context.Background())
@@ -193,7 +198,7 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 	rt := defaultBatchRuntime()
 	for _, a := range allocations {
 		bt.wg.Add(1)
-		go launchBatchService(batchCtx, bt, client, controlURL, clientID, a, portMap, states, rt)
+		go launchBatchService(batchCtx, bt, client, controlURL, clientID, a, states, rt)
 	}
 
 	slog.Info("batch services started", "group", group)
@@ -241,6 +246,7 @@ type batchAlloc struct {
 	svcGroup        string
 	assignedPort    int            // single-port only
 	portAssignments map[string]int // multi-port only
+	env             []string       // populated by exportBatchEnvFiles before fan-out
 }
 
 // launchBatchService is the per-service batch-mode launcher: it waits for the
@@ -253,7 +259,6 @@ func launchBatchService(
 	client *http.Client,
 	controlURL, clientID string,
 	a batchAlloc,
-	portMap envexpand.PortMap,
 	states map[string]*depwait.State,
 	rt batchRuntime,
 ) {
@@ -367,12 +372,7 @@ func launchBatchService(
 		return
 	}
 
-	env := buildBatchEnv(a, portMap)
-	if env == nil {
-		// env expansion failed inside buildBatchEnv (error already logged).
-		state.Err = fmt.Errorf("env expansion failed for %q", a.name)
-		return
-	}
+	env := a.env
 
 	color := nextColor()
 	pw := newPrefixWriter(a.name, color, os.Stdout)
@@ -472,9 +472,8 @@ func launchBatchService(
 
 const shutdownHookTimeout = 30 * time.Second
 
-// buildBatchEnv builds the environment for a batch-mode service. Returns nil
-// if env expansion fails (the error is logged).
-func buildBatchEnv(a batchAlloc, portMap envexpand.PortMap) []string {
+// buildBatchEnv builds the environment for a batch-mode service.
+func buildBatchEnv(a batchAlloc, portMap envexpand.PortMap) ([]string, error) {
 	env := []string{"MDP=1"}
 	if len(a.svc.Ports) == 0 && a.assignedPort > 0 {
 		env = append(env, fmt.Sprintf("PORT=%d", a.assignedPort))
@@ -488,12 +487,50 @@ func buildBatchEnv(a batchAlloc, portMap envexpand.PortMap) []string {
 		}
 		expanded, err := envexpand.Expand(v, portMap)
 		if err != nil {
-			slog.Error("env expansion failed", "service", a.name, "key", k, "err", err)
-			return nil
+			return nil, fmt.Errorf("env expansion for %s.%s: %w", a.name, k, err)
 		}
 		env = append(env, k+"="+expanded)
 	}
-	return env
+	return env, nil
+}
+
+// exportBatchEnvFiles builds each allocation's env up front and writes the
+// global + per-service env files before any service launches. Env is stored
+// on allocations[i].env for the launch goroutine to consume.
+func exportBatchEnvFiles(cfg *config.Config, allocations []batchAlloc, portMap envexpand.PortMap) error {
+	envMap := envexpand.EnvMap{}
+	for i, a := range allocations {
+		env, err := buildBatchEnv(a, portMap)
+		if err != nil {
+			return err
+		}
+		allocations[i].env = env
+		envMap[a.name] = envSliceToMap(env)
+	}
+	if cfg.Global.EnvFile != "" {
+		if err := envexport.WriteGlobal(cfg.Global.EnvFile, cfg.Global.Env, portMap, envMap); err != nil {
+			return fmt.Errorf("write global env file: %w", err)
+		}
+	}
+	for _, a := range allocations {
+		if a.svc.EnvFile == "" {
+			continue
+		}
+		if err := envexport.WritePerService(a.svc.EnvFile, a.env); err != nil {
+			return fmt.Errorf("write env file for %s: %w", a.name, err)
+		}
+	}
+	return nil
+}
+
+func envSliceToMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			m[kv[:i]] = kv[i+1:]
+		}
+	}
+	return m
 }
 
 // startBatchCommand starts the service process and registers it with bt.

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -230,14 +230,11 @@ func TestLaunchBatchServiceSkipsProxylessPorts(t *testing.T) {
 		},
 		portAssignments: map[string]int{"API_PORT": 40001, "DB_PORT": 54321},
 	}
-	portMap := envexpand.PortMap{
-		"infra": {"API_PORT": 40001, "DB_PORT": 54321},
-	}
 
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"infra"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", a, portMap, states, rt)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", a, states, rt)
 
 	registerMu.Lock()
 	defer registerMu.Unlock()
@@ -309,7 +306,7 @@ func TestLaunchBatchServiceWaitsForDependencies(t *testing.T) {
 
 	for _, a := range allocs {
 		bt.wg.Add(1)
-		go launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", a, envexpand.PortMap{}, states, rt)
+		go launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", a, states, rt)
 	}
 
 	waitFor := func(name string, dur time.Duration) bool {
@@ -379,7 +376,7 @@ func TestLaunchBatchServiceReturnsOnContextCancel(t *testing.T) {
 	bt.wg.Add(1)
 	done := make(chan struct{})
 	go func() {
-		launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", a, envexpand.PortMap{}, states, rt)
+		launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", a, states, rt)
 		close(done)
 	}()
 
@@ -436,7 +433,7 @@ func TestLaunchBatchServiceHookOrdering(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"web"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", a, envexpand.PortMap{}, states, rt)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", a, states, rt)
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -489,7 +486,7 @@ func TestLaunchBatchServiceSetupFailureSkipsRegistration(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"web"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", a, envexpand.PortMap{}, states, rt)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", a, states, rt)
 
 	regMu.Lock()
 	defer regMu.Unlock()
@@ -625,5 +622,141 @@ func TestRunProxiedSetsMDPEnv(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("runProxied should set MDP=1 and PORT: %v", err)
+	}
+}
+
+func TestExportBatchEnvFilesWritesGlobalAndPerService(t *testing.T) {
+	tmp := t.TempDir()
+	globalPath := filepath.Join(tmp, "global.env")
+	apiEnvPath := filepath.Join(tmp, "api.env")
+	webEnvPath := filepath.Join(tmp, "web.env")
+
+	cfg := &config.Config{
+		Global: config.GlobalConfig{
+			EnvFile: globalPath,
+			Env: map[string]config.GlobalEnvValue{
+				"API_PORT": {Ref: "api.env.PORT"},
+				"API_URL":  {Value: "http://localhost:${api.PORT}"},
+				"WEB_MODE": {Ref: "web.env.MODE"},
+			},
+		},
+	}
+
+	allocations := []batchAlloc{
+		{
+			name:         "api",
+			svcGroup:     "test",
+			assignedPort: 40100,
+			svc: config.ServiceConfig{
+				EnvFile: apiEnvPath,
+				Env:     map[string]string{"NAME": "api"},
+			},
+		},
+		{
+			name:         "web",
+			svcGroup:     "test",
+			assignedPort: 40101,
+			svc: config.ServiceConfig{
+				EnvFile: webEnvPath,
+				Env:     map[string]string{"MODE": "dev"},
+			},
+		},
+	}
+	portMap := envexpand.PortMap{
+		"api": {"port": 40100, "PORT": 40100},
+		"web": {"port": 40101, "PORT": 40101},
+	}
+
+	if err := exportBatchEnvFiles(cfg, allocations, portMap); err != nil {
+		t.Fatalf("exportBatchEnvFiles: %v", err)
+	}
+
+	gdata, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("read global: %v", err)
+	}
+	gtext := string(gdata)
+	for _, want := range []string{
+		`API_PORT="40100"`,
+		`API_URL="http://localhost:40100"`,
+		`WEB_MODE="dev"`,
+	} {
+		if !strings.Contains(gtext, want) {
+			t.Errorf("global missing %q in:\n%s", want, gtext)
+		}
+	}
+
+	adata, err := os.ReadFile(apiEnvPath)
+	if err != nil {
+		t.Fatalf("read api: %v", err)
+	}
+	atext := string(adata)
+	for _, want := range []string{`NAME="api"`, `PORT="40100"`} {
+		if !strings.Contains(atext, want) {
+			t.Errorf("api missing %q in:\n%s", want, atext)
+		}
+	}
+
+	wdata, err := os.ReadFile(webEnvPath)
+	if err != nil {
+		t.Fatalf("read web: %v", err)
+	}
+	wtext := string(wdata)
+	for _, want := range []string{`MODE="dev"`, `PORT="40101"`} {
+		if !strings.Contains(wtext, want) {
+			t.Errorf("web missing %q in:\n%s", want, wtext)
+		}
+	}
+
+	if allocations[0].env == nil || allocations[1].env == nil {
+		t.Fatal("expected allocations[i].env to be populated for launch goroutines")
+	}
+}
+
+func TestExportBatchEnvFilesSkipsWhenNoEnvFile(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{}
+	allocations := []batchAlloc{
+		{
+			name:         "api",
+			svcGroup:     "test",
+			assignedPort: 40200,
+			svc:          config.ServiceConfig{Env: map[string]string{"X": "y"}},
+		},
+	}
+	if err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{}); err != nil {
+		t.Fatalf("exportBatchEnvFiles: %v", err)
+	}
+	entries, _ := os.ReadDir(tmp)
+	if len(entries) != 0 {
+		t.Errorf("expected no files written, got: %v", entries)
+	}
+	if allocations[0].env == nil {
+		t.Error("env should be populated even when no env files are configured")
+	}
+}
+
+func TestExportBatchEnvFilesPropagatesExpansionError(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		Global: config.GlobalConfig{
+			EnvFile: filepath.Join(tmp, "global.env"),
+			Env:     map[string]config.GlobalEnvValue{"X": {Ref: "nope.env.MISSING"}},
+		},
+	}
+	allocations := []batchAlloc{
+		{
+			name:         "api",
+			svcGroup:     "test",
+			assignedPort: 40300,
+			svc:          config.ServiceConfig{Env: map[string]string{"A": "b"}},
+		},
+	}
+	err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{"api": {"port": 40300, "PORT": 40300}})
+	if err == nil {
+		t.Fatal("expected error from unresolved ref")
+	}
+	if !strings.Contains(err.Error(), "write global env file") {
+		t.Errorf("expected wrapped global env file error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `global.env_file` and per-service `env_file` are documented as being written before any service starts, but that only happened on the orchestrator path (`StartConfigServices`). `mdp run` batch mode silently did nothing.
- Hoists env-building out of each `launchBatchService` goroutine into a new `exportBatchEnvFiles` helper called from `runBatchMode` before fan-out — mirrors `internal/orchestrator/runner.go:116-128`.
- `buildBatchEnv` now returns `([]string, error)` so expansion failures fail fast instead of being silently logged.

## Test plan
- [x] `go test -race ./...` passes, including three new tests covering global + per-service writes, the no-env-file skip case, and ref-expansion error propagation.
- [x] `go vet ./...` clean.
- [ ] Manual: add `global.env_file` + `env_file:` on a service in `testbed/mdp.yaml`, start an orchestrator, run `mdp run` in another terminal, confirm both files appear with resolved values before services launch.