### PR TITLE
docs: audit docs and correct stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,13 @@ Require the testbed running in a separate terminal:
 
 ```sh
 cd testbed && ./run.sh   # start proxy + all demo servers
-npm run test:e2e         # run Playwright tests (separate terminal)
+npm run test:e2e         # run Vitest + Puppeteer tests (separate terminal)
 ```
 
 ## Architecture
 
 ```
-cmd/mdp/              CLI entrypoints (root orchestrator, run, register, switch, kill)
+cmd/mdp/              CLI entrypoints (root orchestrator, run, register, deregister, switch, status, logs)
 internal/
   api/                HTTP handlers for /__mdp/* per-proxy endpoints + CORS + config
   certs/              TLS cert generation helpers (unused — proxy inherits certs from services)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ mdp run -P 3000 -- npm run dev
 # Terminal 3 — run your backend
 mdp run -P 4000 -- go run ./cmd/server
 
-# Open https://localhost:3000 — use the widget to switch branches
+# Open http://localhost:3000 — use the widget to switch branches
 ```
 
 ## Install

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,22 +2,26 @@
 
 ## Per-proxy endpoints
 
-Each proxy instance serves these endpoints:
+Each proxy instance serves these endpoints on its listen port (e.g. `:3000`, `:4000`):
 
 
-| Method   | Path                     | Description                                                        |
-| -------- | ------------------------ | ------------------------------------------------------------------ |
-| `GET`    | `/__mdp/health`          | Health check. Returns `{"ok":true,"servers":N}`                    |
-| `GET`    | `/__mdp/servers`         | List all servers grouped by repo                                   |
-| `POST`   | `/__mdp/register`        | Register a server. Body: `{"name":"repo/branch","port":N,"pid":N}` |
-| `DELETE` | `/__mdp/register/{name}` | Deregister a server by name                                        |
-| `POST`   | `/__mdp/switch/{name}`   | Switch active server. Sets cookie + default, redirects             |
-| `GET`    | `/__mdp/switch`          | Server switcher UI page                                            |
-| `GET`    | `/__mdp/widget.js`       | Floating switcher widget script                                    |
-| `GET`    | `/__mdp/config`          | Proxy config (cookie name, siblings, groups)                       |
-| `GET`    | `/__mdp/default`         | Get current default upstream                                       |
-| `DELETE` | `/__mdp/default`         | Clear default upstream                                             |
-| `POST`   | `/__mdp/default/{name}`  | Set default upstream                                               |
+| Method   | Path                          | Description                                                        |
+| -------- | ----------------------------- | ------------------------------------------------------------------ |
+| `GET`    | `/__mdp/health`               | Health check. Returns `{"ok":true,"servers":N}`                    |
+| `GET`    | `/__mdp/servers`              | List all servers grouped by repo                                   |
+| `POST`   | `/__mdp/register`             | Register a server. Body: `{"name":"repo/branch","port":N,"pid":N}` |
+| `DELETE` | `/__mdp/register/{name}`      | Deregister a server by name                                        |
+| `POST`   | `/__mdp/switch/{name}`        | Switch active server. Sets cookie + default, redirects             |
+| `GET`    | `/__mdp/switch`               | Server switcher UI page                                            |
+| `GET`    | `/__mdp/widget.js`            | Floating switcher widget script                                    |
+| `GET`    | `/__mdp/sw.js`                | Service worker that powers per-tab routing via `__mdp_upstream`    |
+| `GET`    | `/__mdp/events`               | Server-sent events stream of registry changes (used by the widget) |
+| `GET`    | `/__mdp/config`               | Proxy config (cookie name, siblings, groups)                       |
+| `GET`    | `/__mdp/default`              | Get current default upstream                                       |
+| `DELETE` | `/__mdp/default`              | Clear default upstream                                             |
+| `POST`   | `/__mdp/default/{name}`       | Set default upstream                                               |
+| `POST`   | `/__mdp/groups/{name}/switch` | Switch every proxy's default to the named group                    |
+| `GET`    | `/__mdp/last-path/{name}`     | Last path observed for a server (used by the widget to restore position) |
 
 
 ## Orchestrator control API (port 13100)
@@ -37,7 +41,27 @@ Each proxy instance serves these endpoints:
 | `POST`   | `/__mdp/shutdown`                      | Graceful shutdown                 |
 
 
-**Dead server pruning:** Each proxy checks registered servers every 10 seconds. Any server whose PID is no longer alive is removed automatically.
+### Internal client protocol
+
+These endpoints are used by `mdp run` to talk to the orchestrator and by the built-in UIs. They are not considered a stable public API and may change without notice.
+
+
+| Method   | Path                      | Description                                                    |
+| -------- | ------------------------- | -------------------------------------------------------------- |
+| `PATCH`  | `/__mdp/register/{name}`  | Update PID for a registered service (after async start)        |
+| `POST`   | `/__mdp/heartbeat`        | Keep-alive from `mdp run` clients                              |
+| `POST`   | `/__mdp/disconnect`       | Client disconnect — deregisters all of the client's servers    |
+| `GET`    | `/__mdp/shutdown/watch`   | Long-poll; returns when the orchestrator shuts down            |
+| `GET`    | `/__mdp/events`           | Server-sent events stream used by the dashboard and widget     |
+
+
+## Dead server pruning
+
+Each proxy sweeps its registry every 10 seconds:
+
+- Servers with a PID are dropped as soon as the process is no longer alive.
+- Servers registered without a PID but with a client ID (e.g. `mdp run` wraps) are cleaned up when their client disconnects or stops heartbeating.
+- Servers registered without a PID or client ID (e.g. `mdp register` for externally managed processes) are dropped after they fail a TCP health check 3 times in a row, following a 30-second grace period after registration.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,13 @@ mdp run                        # uses current git branch as group
 mdp run --group feature-auth   # override group name
 ```
 
-If no orchestrator is running, `mdp run` falls back to solo mode and just runs the command directly.
+When a command is given, `mdp run` picks its mode in this order:
+
+1. **Orchestrator mode** — if an orchestrator is running on `--control-port`, register with it.
+2. **Standalone proxy mode** — otherwise, probe `--proxy-port` for a bare `mdp` proxy (no orchestrator) and register with it if found.
+3. **Solo mode** — otherwise, run the command directly with no proxy.
+
+Batch mode (`mdp run` with no command) requires an orchestrator — it errors out if one isn't running.
 
 ## `mdp register`
 
@@ -51,6 +57,14 @@ mdp register myapp/main --port 4000 --pid 12345
 mdp register --list
 ```
 
+## `mdp deregister`
+
+Remove a server from all proxies. Useful when an externally managed service (e.g. Docker) stops without notifying the orchestrator.
+
+```sh
+mdp deregister myapp/main
+```
+
 ## `mdp switch`
 
 Switch active upstream service or group from the command line. See [how switching works](./concepts.md#how-switching-works) for the resolution order.
@@ -59,6 +73,25 @@ Switch active upstream service or group from the command line. See [how switchin
 mdp switch app/main -P 3000          # switch individual server
 mdp switch --group main              # switch all services in a group
 mdp switch --clear -P 3000           # clear default
+```
+
+## `mdp status`
+
+Print daemon status, proxies, registered servers, and groups. Add `--json` for machine-readable output.
+
+```sh
+mdp status
+mdp status --json
+```
+
+## `mdp logs`
+
+Show the daemon's log output. Defaults to the last 50 lines; use `-f` to follow.
+
+```sh
+mdp logs
+mdp logs -n 200
+mdp logs -f
 ```
 
 ## `mdp --stop`
@@ -103,6 +136,9 @@ mdp --stop
 | `--group`          |               | Group name override (default: git branch)        |
 | `--env`            | `PORT`        | Env var name for the assigned port               |
 | `--port-range`     | `10000-60000` | Port range for spawned services                  |
+| `--tls-cert`       |               | TLS certificate file (serves this service over HTTPS; see [recipes](./recipes.md)) |
+| `--tls-key`        |               | TLS key file (paired with `--tls-cert`)          |
+| `--auto-tls`       | `false`       | Auto-detect TLS certs from mkcert                |
 | `--control-port`   | `13100`       | Orchestrator control port                        |
 
 
@@ -116,7 +152,20 @@ mdp --stop
 | `-P, --proxy-port` | `3000`  | Proxy port to connect to                  |
 | `--group`          |         | Group name override                       |
 | `-l, --list`       |         | List registered services                  |
+| `--tls-cert`       |         | TLS certificate file (registers as HTTPS) |
+| `--tls-key`        |         | TLS key file (paired with `--tls-cert`)   |
 | `--control-port`   | `13100` | Orchestrator control port                 |
+
+
+`**mdp switch` flags:**
+
+
+| Flag               | Default | Description                                    |
+| ------------------ | ------- | ---------------------------------------------- |
+| `-P, --proxy-port` |         | Proxy port (required for individual switches)  |
+| `--group`          |         | Switch all services in a group                 |
+| `--clear`          |         | Clear the default upstream (needs `-P`)        |
+| `--control-port`   | `13100` | Orchestrator control port                      |
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -20,6 +20,15 @@ browser → :3000 (frontend proxy) → :42301 (main branch)
                                   → :20235 (api/feature-auth)
 ```
 
+## The switcher widget
+
+The floating widget mentioned above is auto-injected into every HTML response routed through a proxy. A few things worth knowing:
+
+- It runs inside a **Shadow DOM**, so your page's CSS can't style it and its styles can't leak into your page.
+- Selection is persisted per proxy port via the `__mdp_upstream_<port>` cookie — each proxy gets its own cookie to avoid collisions.
+- It subscribes to a server-sent events stream so the list of available servers updates live as services come and go.
+- There's currently no flag to disable injection; if you don't want it, route traffic to the upstream port directly instead of through the proxy.
+
 ## Service groups
 
 Services are automatically grouped by their git branch name (or an explicit `--group` flag). All services sharing the same group name form a switchable group. Switching to a group sets the default upstream on every proxy at once.
@@ -38,10 +47,11 @@ See [`mdp switch`](./cli.md#mdp-switch) for CLI details.
 
 Each proxy has its own cookie (e.g., `__mdp_upstream_3000`) to avoid collisions when multiple proxies run on localhost. The resolution order for each request is:
 
-1. **Cookie** — if a valid cookie is present, route to that server
-2. **Default upstream** — a server-side default set via `mdp switch` or the TUI
-3. **Auto-route** — if only one server is registered, route to it automatically
-4. **Redirect** — redirect to the switch page at `/__mdp/switch`
+1. **Auto-route** — if only one server is registered, route to it (skips every other step)
+2. **Query parameter** — `?__mdp_upstream=<name>` wins over cookie. Useful for per-iframe or per-tab routing where a shared cookie would collide
+3. **Cookie** — if a valid cookie is present, route to that server
+4. **Default upstream** — a server-side default set via `mdp switch` or the TUI
+5. **Redirect** — redirect to the switch page at `/__mdp/switch`
 
 The default upstream is especially useful for backend proxies where cookies aren't available (dev-server proxies, curl, API clients).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ E2E tests require the testbed running in a separate terminal. See [Testbed](./te
 
 ```sh
 cd testbed && ./run.sh   # terminal 1: start proxy + demo servers
-npm run test:e2e         # terminal 2: run Playwright tests
+npm run test:e2e         # terminal 2: run Vitest + Puppeteer tests
 ```
 
 ## Conventional commits

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ mdp run -P 3000 -- npm run dev
 # Terminal 3 — run your backend
 mdp run -P 4000 -- go run ./cmd/server
 
-# Open https://localhost:3000 — use the widget to switch branches
+# Open http://localhost:3000 — use the widget to switch branches
 ```
 
 ## Documentation

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,7 +10,8 @@ mdp run -P 3000 -- npm run dev
 # Terminal 3 — run your backend
 mdp run -P 4000 -- go run ./cmd/server
 
-# Open https://localhost:3000 — use the widget to switch branches
+# Open http://localhost:3000 — use the widget to switch branches
+# (switch to https once you've set up TLS certs — see the recipes page)
 ```
 
 Next steps:

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -1,26 +1,38 @@
 # Testbed
 
-The `testbed/` directory contains demo servers across different frameworks to verify the proxy works end-to-end:
+The `testbed/` directory is a full end-to-end playground for `mdp` — it exercises group switching, TLS, Docker-managed services, and non-HTTP ports in one setup.
 
+`testbed/run.sh` builds `mdp`, generates a self-signed cert, starts the orchestrator as a daemon, and batch-starts every service declared in `testbed/mdp.yaml`.
 
-| Server       | Framework                 | Features                                     |
-| ------------ | ------------------------- | -------------------------------------------- |
-| go-websocket | Go                        | WebSocket echo, counter                      |
-| vite-ts      | Vite + TypeScript         | Todo list, HMR                               |
-| nextjs       | Next.js                   | SSR, API routes                              |
-| vue          | Vue 3 + TypeScript        | Reactivity, color picker                     |
-| svelte       | SvelteKit + TypeScript    | Reactivity, live filter                      |
-| docker       | nginx + Go API + Postgres | GraphQL API, reverse proxy (requires Docker) |
+## Services
 
+Three groups (`main`, `feature-a`, `feature-b`), each with a `web` + `api` pair, plus a non-HTTP `db-main` service to exercise port-only declarations:
 
-Run them all behind the proxy:
+| Service         | Group     | Proxy | Notes                                                  |
+| --------------- | --------- | ----- | ------------------------------------------------------ |
+| `web-main`      | main      | 3000  | Go demo server with TLS (self-signed cert)             |
+| `api-main`      | main      | 3001  | `docker compose up` — Go API built from `testbed/docker` |
+| `db-main`       | main      | —     | Fake DB; demonstrates an allocated port with no proxy  |
+| `web-feature-a` | feature-a | 3000  | Go demo server (plain HTTP)                            |
+| `api-feature-a` | feature-a | 3001  | Go demo server with `setup` + `shutdown` hooks         |
+| `web-feature-b` | feature-b | 3000  | Go demo server                                         |
+| `api-feature-b` | feature-b | 3001  | Go demo server                                         |
+
+## Run it
 
 ```sh
 cd testbed
 ./run.sh
 ```
 
-Open `https://localhost:3000` and use the widget to switch between them.
+Then:
+
+- Open `http://localhost:3000` (frontend proxy — `https://` also works after TLS kicks in for `main`).
+- Open `http://localhost:3001` (API proxy).
+- Use the widget or `mdp switch --group feature-a` to flip both proxies at once.
+- Open `http://localhost:6370` for the dashboard.
+
+The legacy framework folders (`go-websocket/`, `vite-ts/`, `nextjs/`, `vue/`, `svelte/`, `echo-api/`) are still in the tree but are not wired into `run.sh` — leave them alone unless you're repurposing them.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ ARCH=$(uname -m)
 
 case "$OS" in
   linux|darwin) ;;
-  *) die "Unsupported OS: $OS. Use 'npm install -g mdp' on Windows." ;;
+  *) die "Unsupported OS: $OS. Use Scoop on Windows (see docs/installation.md)." ;;
 esac
 
 case "$ARCH" in


### PR DESCRIPTION
Audit of `docs/`, `README.md`, and `CLAUDE.md` for correctness and completeness. Fixes quick-start URLs (the default proxy is HTTP, not HTTPS), updates E2E test tooling references from Playwright to Vitest + Puppeteer, rewrites `docs/testbed.md` to match the current `testbed/mdp.yaml`, and corrects the routing resolution order in `docs/concepts.md` (adds query-param override and single-server auto-route). Adds the `deregister` / `status` / `logs` subcommands and `--tls-cert` / `--tls-key` / `--auto-tls` flags to the CLI reference, and expands `docs/api.md` with per-proxy endpoints (`sw.js`, `events`, `groups/.../switch`, `last-path`), the internal client protocol (heartbeat, disconnect, etc.), and the full pruner logic. Also fixes one install-script bug: `install.sh` now points Windows users to Scoop instead of the stale `npm install -g mdp` hint.