### PR TITLE
fix: auto-shutdown empty proxies to release their port

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -147,8 +147,10 @@ func RegisterHandler(reg *registry.Registry, addCert CertLoader) http.HandlerFun
 	}
 }
 
-// DeregisterHandler handles DELETE /__mdp/register/{name}
-func DeregisterHandler(reg *registry.Registry) http.HandlerFunc {
+// DeregisterHandler handles DELETE /__mdp/register/{name}.
+// onDeregistered, if non-nil, is invoked after a successful deregister so the
+// caller can react (e.g. shut down an empty proxy).
+func DeregisterHandler(reg *registry.Registry, onDeregistered func()) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
 			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
@@ -164,6 +166,9 @@ func DeregisterHandler(reg *registry.Registry) http.HandlerFunc {
 			decodedName = name
 		}
 		deleted := reg.Deregister(decodedName)
+		if deleted && onDeregistered != nil {
+			onDeregistered()
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "deleted": deleted})
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -277,7 +277,7 @@ func TestDeregisterHandler(t *testing.T) {
 			if tt.preRegister {
 				_ = reg.Register(&registry.ServerEntry{Name: "app/main", Repo: "app", Port: 3000, PID: 100})
 			}
-			handler := DeregisterHandler(reg)
+			handler := DeregisterHandler(reg, nil)
 
 			req := httptest.NewRequest(tt.method, tt.path, nil)
 			namePart := strings.TrimPrefix(tt.path, "/__mdp/register/")

--- a/internal/orchestrator/controlapi.go
+++ b/internal/orchestrator/controlapi.go
@@ -194,6 +194,7 @@ func (c *ControlAPI) handleDeregister(w http.ResponseWriter, r *http.Request) {
 	for _, pi := range c.orch.ListProxies() {
 		if pi.Registry.Deregister(name) {
 			deleted = true
+			c.orch.shutdownIfEmpty(pi)
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "deleted": deleted})

--- a/internal/orchestrator/empty_shutdown_test.go
+++ b/internal/orchestrator/empty_shutdown_test.go
@@ -1,0 +1,141 @@
+package orchestrator
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestShutdownProxyIdempotent(t *testing.T) {
+	o, proxyPort := startOrchProxy(t)
+	if o.GetProxy(proxyPort) == nil {
+		t.Fatal("precondition: proxy should exist")
+	}
+
+	o.ShutdownProxy(proxyPort)
+	// Second call must be a no-op (and must not panic).
+	o.ShutdownProxy(proxyPort)
+
+	if pi := o.GetProxy(proxyPort); pi != nil {
+		t.Errorf("proxy still present after shutdown: %+v", pi)
+	}
+	waitPortFree(t, proxyPort, 2*time.Second)
+}
+
+func TestProxyStaysUpWithOtherServers(t *testing.T) {
+	upA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	upB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(upA.Close)
+	t.Cleanup(upB.Close)
+
+	o, proxyPort := startOrchProxy(t)
+	registerViaControlAPI(t, o, map[string]any{
+		"name": "app/a", "port": mustPort(t, upA.URL), "proxyPort": proxyPort,
+	})
+	registerViaControlAPI(t, o, map[string]any{
+		"name": "app/b", "port": mustPort(t, upB.URL), "proxyPort": proxyPort,
+	})
+
+	// Deregister only one — proxy should remain.
+	req := httptest.NewRequest(http.MethodDelete, "/__mdp/register/app/a", nil)
+	rec := httptest.NewRecorder()
+	NewControlAPI(o, nil).Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("deregister: status %d", rec.Code)
+	}
+
+	pi := o.GetProxy(proxyPort)
+	if pi == nil {
+		t.Fatal("proxy shut down despite remaining server")
+	}
+	if got := pi.Registry.Count(); got != 1 {
+		t.Errorf("registry count = %d, want 1", got)
+	}
+}
+
+func TestShutdownProxyOnDisconnect(t *testing.T) {
+	o, proxyPort := startOrchProxy(t)
+	registerViaControlAPI(t, o, map[string]any{
+		"name":      "app/main",
+		"port":      freeTCPPort(t),
+		"proxyPort": proxyPort,
+		"clientID":  "client-1",
+	})
+	if o.GetProxy(proxyPort) == nil {
+		t.Fatal("precondition: proxy should exist")
+	}
+
+	if removed := o.Disconnect("client-1"); removed != 1 {
+		t.Fatalf("Disconnect removed = %d, want 1", removed)
+	}
+
+	if pi := o.GetProxy(proxyPort); pi != nil {
+		t.Errorf("proxy still present after client disconnect: %+v", pi)
+	}
+	waitPortFree(t, proxyPort, 2*time.Second)
+}
+
+// TestShutdownProxyViaPerProxyAPI covers the pathway used by
+// internal/process/manager.go — DELETE to /__mdp/register on the proxy's own
+// port (not the control API).
+func TestShutdownProxyViaPerProxyAPI(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(upstream.Close)
+
+	o, proxyPort := startOrchProxy(t)
+	registerViaControlAPI(t, o, map[string]any{
+		"name":      "app/main",
+		"port":      mustPort(t, upstream.URL),
+		"proxyPort": proxyPort,
+	})
+
+	req, err := http.NewRequest(http.MethodDelete,
+		fmt.Sprintf("http://127.0.0.1:%d/__mdp/register/app/main", proxyPort), nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE via per-proxy API: %v", err)
+	}
+	resp.Body.Close()
+
+	// GetProxy isn't guaranteed to be nil synchronously because the per-proxy
+	// DeregisterHandler callback returns before the map removal completes in
+	// the async shutdown goroutine. Poll briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if o.GetProxy(proxyPort) == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if pi := o.GetProxy(proxyPort); pi != nil {
+		t.Errorf("proxy still present after per-proxy deregister: %+v", pi)
+	}
+	waitPortFree(t, proxyPort, 2*time.Second)
+}
+
+// TestEnsureProxyAfterShutdownReusesPort verifies that EnsureProxy on the
+// same port succeeds immediately after ShutdownProxy returns — without any
+// wait. ShutdownProxy must release the listener synchronously so the port
+// is rebindable before the next net.Listen call.
+func TestEnsureProxyAfterShutdownReusesPort(t *testing.T) {
+	o, proxyPort := startOrchProxy(t)
+	o.ShutdownProxy(proxyPort)
+
+	// Immediately re-bind the same port — no polling, no sleep.
+	pi, err := o.EnsureProxy(proxyPort)
+	if err != nil {
+		t.Fatalf("EnsureProxy on just-shutdown port: %v", err)
+	}
+	t.Cleanup(func() {
+		pi.cancel()
+		_ = pi.Server.Close()
+	})
+	if got := o.GetProxy(proxyPort); got != pi {
+		t.Error("expected fresh proxy registered under same port")
+	}
+}

--- a/internal/orchestrator/integration_test.go
+++ b/internal/orchestrator/integration_test.go
@@ -92,6 +92,23 @@ func freeTCPPort(t *testing.T) int {
 	return port
 }
 
+// waitPortFree polls until a TCP bind to the given port succeeds, or fails
+// the test on timeout. Used to verify an auto-shut-down proxy actually
+// released its listener.
+func waitPortFree(t *testing.T, port int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err == nil {
+			_ = ln.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("port %d not released within %s", port, timeout)
+}
+
 // startOrchProxy spins up an orchestrator listening on a real ephemeral port
 // and returns the orchestrator, proxy port, and a teardown helper that runs
 // on test cleanup.
@@ -204,10 +221,9 @@ func TestPlainHTTPRegisterAndRoute(t *testing.T) {
 	}
 }
 
-// TestDeregisterMidTraffic registers and routes successfully, then deregisters
-// and asserts the next request no longer reaches the upstream — instead it
-// redirects to /__mdp/switch (Count==0 path in routing.ResolveUpstream).
-func TestDeregisterMidTraffic(t *testing.T) {
+// TestDeregisterLastServerShutsDownProxy registers a single server, deregisters
+// it, and asserts the proxy is removed and its port can be rebound.
+func TestDeregisterLastServerShutsDownProxy(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "live")
 	}))
@@ -227,7 +243,7 @@ func TestDeregisterMidTraffic(t *testing.T) {
 		resp.Body.Close()
 	}
 
-	// Deregister via the control API.
+	// Deregister via the control API — proxy should auto-shutdown.
 	delReq := httptest.NewRequest(http.MethodDelete, "/__mdp/register/app/main", nil)
 	delRec := httptest.NewRecorder()
 	NewControlAPI(o, nil).Handler().ServeHTTP(delRec, delReq)
@@ -235,17 +251,12 @@ func TestDeregisterMidTraffic(t *testing.T) {
 		t.Fatalf("deregister: status %d, body %s", delRec.Code, delRec.Body.String())
 	}
 
-	resp, err := noRedirectClient().Get(fmt.Sprintf("http://127.0.0.1:%d/", proxyPort))
-	if err != nil {
-		t.Fatalf("post-deregister GET: %v", err)
+	if pi := o.GetProxy(proxyPort); pi != nil {
+		t.Errorf("proxy still registered after last deregister: %+v", pi)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusFound {
-		t.Errorf("post-deregister status = %d, want 302 (redirect to switch)", resp.StatusCode)
-	}
-	if loc := resp.Header.Get("Location"); loc != "/__mdp/switch" {
-		t.Errorf("Location = %q, want /__mdp/switch", loc)
-	}
+
+	// Wait for the port to be rebindable (Server.Shutdown runs async).
+	waitPortFree(t, proxyPort, 2*time.Second)
 }
 
 // TestCookieRoutingBetweenSiblings registers two upstreams on the same proxy

--- a/internal/orchestrator/integration_test.go
+++ b/internal/orchestrator/integration_test.go
@@ -140,17 +140,6 @@ func registerViaControlAPI(t *testing.T, o *Orchestrator, payload map[string]any
 	}
 }
 
-// noRedirectClient returns an http.Client that surfaces redirects instead of
-// following them, so tests can assert on 302→/__mdp/switch behavior.
-func noRedirectClient() *http.Client {
-	return &http.Client{
-		Timeout: 2 * time.Second,
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-}
-
 func writeSelfSignedCert(t *testing.T) (certPath, keyPath, commonName string) {
 	t.Helper()
 	commonName = "localhost"

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -25,7 +26,7 @@ import (
 
 // Event represents a state change in the orchestrator.
 type Event struct {
-	Type string // "proxy_created", "registered", "deregistered", "default_changed", "group_switched", "service_started", "service_stopped"
+	Type string // "proxy_created", "proxy_destroyed", "registered", "deregistered", "default_changed", "group_switched", "service_started", "service_stopped"
 	Port int
 	Name string
 }
@@ -210,6 +211,16 @@ func (o *Orchestrator) createProxyLocked(port int, label string) (*ProxyInstance
 	inj := inject.New()
 	prx.SetModifyResponse(inj.ModifyResponse)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	pi := &ProxyInstance{
+		Port:       port,
+		Label:      label,
+		Registry:   reg,
+		CookieName: cookieName,
+		Proxy:      prx,
+		cancel:     cancel,
+	}
+
 	configFn := func() api.ConfigResponse {
 		o.mu.RLock()
 		defer o.mu.RUnlock()
@@ -237,7 +248,9 @@ func (o *Orchestrator) createProxyLocked(port int, label string) (*ProxyInstance
 	mux.HandleFunc("GET /__mdp/health", api.HealthHandler(reg))
 	mux.HandleFunc("GET /__mdp/servers", api.ServersHandler(reg))
 	mux.HandleFunc("POST /__mdp/register", api.RegisterHandler(reg, o.AddCert))
-	mux.HandleFunc("DELETE /__mdp/register/{name...}", api.DeregisterHandler(reg))
+	mux.HandleFunc("DELETE /__mdp/register/{name...}", api.DeregisterHandler(reg, func() {
+		o.shutdownIfEmpty(pi)
+	}))
 	mux.HandleFunc("POST /__mdp/switch/{name...}", api.SwitchHandler(reg, cookieName, prx, port))
 	mux.HandleFunc("GET /__mdp/last-path/{name...}", api.LastPathHandler(prx))
 	mux.HandleFunc("GET /__mdp/switch", ui.SwitchPageHandler())
@@ -267,9 +280,6 @@ func (o *Orchestrator) createProxyLocked(port int, label string) (*ProxyInstance
 		ErrorLog: log.New(io.Discard, "", 0),
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	registry.StartPruner(ctx, reg, 10*time.Second, process.IsProcessAlive, registry.TCPCheck)
-
 	ln, listenErr := net.Listen("tcp", addr)
 	if listenErr != nil {
 		cancel()
@@ -284,7 +294,11 @@ func (o *Orchestrator) createProxyLocked(port int, label string) (*ProxyInstance
 	smartLn := proxy.NewSmartListener(ln, tlsCfg)
 
 	go func() {
-		if err := srv.Serve(smartLn); err != nil && err != http.ErrServerClosed {
+		// ShutdownProxy closes the listener synchronously before the async
+		// Server.Shutdown sets the internal shutting-down flag, so Serve can
+		// return net.ErrClosed instead of http.ErrServerClosed. Treat both as
+		// expected shutdown signals.
+		if err := srv.Serve(smartLn); err != nil && err != http.ErrServerClosed && !errors.Is(err, net.ErrClosed) {
 			slog.Error("proxy listener failed", "port", port, "err", err)
 		}
 	}()
@@ -294,17 +308,12 @@ func (o *Orchestrator) createProxyLocked(port int, label string) (*ProxyInstance
 		"cookie", cookieName,
 	)
 
-	pi := &ProxyInstance{
-		Port:       port,
-		Label:      label,
-		Registry:   reg,
-		CookieName: cookieName,
-		Proxy:      prx,
-		Server:     srv,
-		smartLn:    smartLn,
-		cancel:     cancel,
-	}
+	pi.Server = srv
+	pi.smartLn = smartLn
 	o.proxies[port] = pi
+	registry.StartPruner(ctx, reg, 10*time.Second, process.IsProcessAlive, registry.TCPCheck, func() {
+		o.shutdownIfEmpty(pi)
+	})
 	o.emit(Event{Type: "proxy_created", Port: port})
 	return pi, nil
 }
@@ -340,11 +349,52 @@ func (o *Orchestrator) Disconnect(clientID string) int {
 			o.emit(Event{Type: "deregistered", Port: pi.Port, Name: name})
 		}
 		total += len(removed)
+		if len(removed) > 0 {
+			o.shutdownIfEmpty(pi)
+		}
 	}
 	if total > 0 {
 		slog.Info("client disconnected", "clientID", clientID, "removed", total)
 	}
 	return total
+}
+
+// ShutdownProxy tears down the proxy listening on the given port and releases
+// the port. Safe to call for a port that has no proxy (no-op). The listener
+// is closed synchronously so the port is immediately rebindable by a fresh
+// EnsureProxy. In-flight requests drain asynchronously via http.Server.Shutdown
+// so callers don't block.
+func (o *Orchestrator) ShutdownProxy(port int) {
+	o.mu.Lock()
+	pi, ok := o.proxies[port]
+	if !ok {
+		o.mu.Unlock()
+		return
+	}
+	delete(o.proxies, port)
+	pi.cancel()
+	o.mu.Unlock()
+
+	// Close the listener synchronously so the port is released before we
+	// return — a concurrent EnsureProxy on the same port must be able to
+	// net.Listen without racing the goroutine below.
+	if pi.smartLn != nil {
+		_ = pi.smartLn.Close()
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = pi.Server.Shutdown(ctx)
+	}()
+	slog.Info("proxy shut down (empty)", "port", port)
+	o.emit(Event{Type: "proxy_destroyed", Port: port})
+}
+
+// shutdownIfEmpty shuts the proxy down if its registry has no servers.
+func (o *Orchestrator) shutdownIfEmpty(pi *ProxyInstance) {
+	if pi.Registry.Count() == 0 {
+		o.ShutdownProxy(pi.Port)
+	}
 }
 
 // ShutdownCh returns a channel that is closed when the orchestrator shuts down.

--- a/internal/registry/pruner.go
+++ b/internal/registry/pruner.go
@@ -11,7 +11,9 @@ import (
 // StartPruner launches a goroutine that removes dead servers from the registry.
 // isAlive is injected for testability — pass process.IsProcessAlive in production.
 // tcpCheck is used as a fallback for servers with no PID (externally managed).
-func StartPruner(ctx context.Context, reg *Registry, interval time.Duration, isAlive func(pid int) bool, tcpCheck func(port int) bool) {
+// onTick, if non-nil, is invoked after each prune pass (useful for reacting to
+// state changes such as an empty registry).
+func StartPruner(ctx context.Context, reg *Registry, interval time.Duration, isAlive func(pid int) bool, tcpCheck func(port int) bool, onTick func()) {
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -21,6 +23,9 @@ func StartPruner(ctx context.Context, reg *Registry, interval time.Duration, isA
 				return
 			case <-ticker.C:
 				pruneOnce(reg, isAlive, tcpCheck)
+				if onTick != nil {
+					onTick()
+				}
 			}
 		}
 	}()

--- a/internal/registry/pruner_test.go
+++ b/internal/registry/pruner_test.go
@@ -18,7 +18,7 @@ func TestPrunerRemovesDead(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	StartPruner(ctx, reg, 20*time.Millisecond, isAlive, tcpAlive)
+	StartPruner(ctx, reg, 20*time.Millisecond, isAlive, tcpAlive, nil)
 
 	time.Sleep(60 * time.Millisecond)
 
@@ -45,7 +45,7 @@ func TestPrunerStopsOnContextCancel(t *testing.T) {
 	tcpAlive := func(port int) bool { return true }
 
 	ctx, cancel := context.WithCancel(context.Background())
-	StartPruner(ctx, reg, 20*time.Millisecond, isAlive, tcpAlive)
+	StartPruner(ctx, reg, 20*time.Millisecond, isAlive, tcpAlive, nil)
 	time.Sleep(60 * time.Millisecond)
 	cancel()
 	time.Sleep(60 * time.Millisecond)


### PR DESCRIPTION
A proxy's listener now closes as soon as its registry goes empty, releasing the port so another tool (or another `mdp` session) can bind it. The check fires from every deregistration pathway: the control API, the per-proxy API, client disconnect (`mdp run` exit), and the dead-server pruner. `ShutdownProxy` closes the listener synchronously so an immediately-following `EnsureProxy` on the same port succeeds; in-flight requests drain asynchronously via `http.Server.Shutdown`. New tests in `internal/orchestrator/empty_shutdown_test.go` cover idempotency, the non-empty case, disconnect, the per-proxy API path, and immediate port reuse.