### PR TITLE
feat: health check fallback for detached services

### DIFF
--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -910,16 +910,78 @@ func runProxied(args []string, envVar string, port int, controlURL string, serve
 			<-done
 		}
 	case err := <-done:
-		hbCancel()
-		disconnectFromOrchestrator(controlURL, clientID)
 		if err != nil {
+			hbCancel()
+			disconnectFromOrchestrator(controlURL, clientID)
 			if ee, ok := err.(*exec.ExitError); ok {
 				os.Exit(ee.ExitCode())
 			}
 			return err
 		}
+		// Clean exit. The command may have detached (e.g. `docker compose
+		// up -d`) — keep the registration alive while the port still
+		// answers, and only disconnect once it stops or the user
+		// interrupts.
+		if err := holdDetached(sigCh, gone, controlURL, clientID, port); err != nil {
+			return err
+		}
+		hbCancel()
 	}
 	return nil
+}
+
+// holdDetached keeps the client session alive after a clean command exit
+// as long as the service port keeps responding. Returns when a signal
+// arrives, the orchestrator goes away, or the port stops answering.
+func holdDetached(sigCh <-chan os.Signal, gone <-chan struct{}, controlURL, clientID string, port int) error {
+	// A detached command (e.g. `docker compose up -d`) may exit before the
+	// backgrounded process has finished binding its port, so give the port
+	// a short grace window to come up before concluding the command just
+	// crashed.
+	const bindGrace = 5 * time.Second
+	deadline := time.Now().Add(bindGrace)
+	for !registry.TCPCheck(port) {
+		if time.Now().After(deadline) {
+			disconnectFromOrchestrator(controlURL, clientID)
+			return nil
+		}
+		select {
+		case <-sigCh:
+			disconnectFromOrchestrator(controlURL, clientID)
+			return nil
+		case <-gone:
+			disconnectFromOrchestrator(controlURL, clientID)
+			return nil
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	slog.Info("command exited cleanly; port still reachable — keeping session alive", "port", port)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	failures := 0
+	const threshold = 3
+	for {
+		select {
+		case <-sigCh:
+			disconnectFromOrchestrator(controlURL, clientID)
+			return nil
+		case <-gone:
+			slog.Warn("orchestrator is shutting down")
+			disconnectFromOrchestrator(controlURL, clientID)
+			return nil
+		case <-ticker.C:
+			if registry.TCPCheck(port) {
+				failures = 0
+				continue
+			}
+			failures++
+			if failures >= threshold {
+				slog.Info("service port no longer reachable; disconnecting", "port", port, "failures", failures)
+				disconnectFromOrchestrator(controlURL, clientID)
+				return nil
+			}
+		}
+	}
 }
 
 func updatePIDWithOrchestrator(controlURL, serverName string, pid int) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -132,6 +132,29 @@ services:
 
 Services without `depends_on` start in parallel. Independent branches of the dependency graph run in parallel too — only direct dependents wait. Each dependency has a 60s readiness timeout; if a dependency fails to become ready, its dependents are marked `failed` and skipped. Cycles and references to undefined services are rejected at config-load time.
 
+## Detached commands and health checks
+
+By default, `mdp` keeps a service's proxy registration alive as long as either its process is running or its port is still answering a TCP probe. That makes detached commands like `docker compose up -d` work out of the box — the foreground process exits, but the probe keeps the entry alive while the containers keep listening.
+
+Override the probe with `health_check`:
+
+```yaml
+services:
+  db:
+    command: docker compose up -d
+    dir: ./db
+    port: 5432
+    health_check: docker               # shorthand for `docker compose ps -q`
+
+  api:
+    command: bun run dev
+    proxy: 4000
+    health_check:
+      http: http://localhost:4000/health
+```
+
+Supported variants: `tcp: <port>`, `http: <url>`, `command: <shell tokens>`, and the `docker` shorthand. See the [`mdp.yaml` reference](./mdp-yaml-reference.md#detached-services-and-health-checks) for details.
+
 ---
 
 [← Back to docs index](./index.md)

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -111,6 +111,7 @@ Keys under `services.<name>`.
 | `env` | map of name → string | `{}` | Env vars for `command`, `setup`, and `shutdown`. Values support: literal strings, `auto` (allocates a port in the corresponding `ports[]` entry), `${svc.port}` (another service's primary port), and `${svc.NAMED_PORT}` (a named port from another service's `ports[]`). `${svc.env.VAR}` is **not** supported here — it only works in `global.env`. |
 | `ports` | list of [port mapping](#port-mapping) | `[]` | Multi-port mode. When present, `port` is ignored and ports are allocated per entry. |
 | `depends_on` | list of service names | `[]` | Wait for each dependency to be TCP-reachable on its assigned port(s) before starting. 60s per-dependency timeout. Unknown names and cycles are rejected at config load. |
+| `health_check` | [health check](#health_check) \| `"docker"` | nil (TCP on `port`) | Liveness probe used by the registry pruner. When unset, the default is a TCP dial of the service's registered port. See [Detached services and health checks](#detached-services-and-health-checks). |
 
 ### `command` — the basic case
 
@@ -313,6 +314,55 @@ services:
 ```
 
 Services without `depends_on` start in parallel. Independent branches of the dependency graph also run in parallel — only direct dependents wait. Each dependency has a 60s TCP-readiness timeout. Failed deps cause dependents to be marked `failed` and skipped. Cycles and references to undefined services are rejected at config load.
+
+### Detached services and health checks
+
+By default, `mdp` prunes a service from its proxy when the command process exits. That's wrong for detached commands like `docker compose up -d`: the foreground process exits quickly, but the real service is still listening on its port.
+
+Instead, once the process exits `mdp` falls back to a liveness probe and keeps the entry around until the probe fails for ~30 seconds. The default probe is a TCP dial of the service's port. Override it with `health_check`:
+
+```yaml
+services:
+  # Default — TCP probe on svc.port.
+  web:
+    command: npm run dev
+    proxy: 3000
+
+  # Custom HTTP probe.
+  api:
+    command: bun run dev
+    proxy: 4000
+    health_check:
+      http: http://localhost:4000/health
+
+  # Shorthand for docker compose: runs `docker compose ps -q` in `dir`,
+  # healthy as long as at least one container in the project is running.
+  db:
+    command: docker compose up -d
+    dir: ./db
+    port: 5432
+    health_check: docker
+
+  # For compose projects whose services are all short-lived, probe the
+  # network directly instead.
+  workers:
+    command: docker compose up -d
+    dir: ./workers
+    port: 6000
+    health_check:
+      command: "docker network inspect workers_default"
+```
+
+Variants (mutually exclusive):
+
+| Field | Healthy when |
+|---|---|
+| `tcp: <port>` | a TCP connection to `localhost:<port>` succeeds |
+| `http: <url>` | an HTTP GET returns a 2xx or 3xx status |
+| `command: <shell tokens>` | the command exits 0 (run in the service's `dir`) |
+| shorthand `docker` | `docker compose ps -q` in the service's `dir` exits 0 with non-empty output |
+
+Command parsing honors single/double quotes but does not invoke a shell, so write `sh -c "..."` explicitly if you need shell features. Timeouts: TCP 2s, HTTP 3s, command/docker 5s.
 
 ## Port mapping
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,62 @@ type ServiceConfig struct {
 	// DependsOn names other services that must be ready before this service
 	// starts. Names must match keys in the top-level services map.
 	DependsOn []string `yaml:"depends_on"`
+
+	// HealthCheck customizes the liveness probe used to decide whether the
+	// service is still up after its command has exited. Nil falls back to
+	// a TCP probe on the service's registered port.
+	HealthCheck *HealthCheck `yaml:"health_check"`
+}
+
+// HealthCheck customizes the liveness probe used to decide whether a service
+// is still up. Exactly one of TCP, HTTP, Command, or Docker must be set.
+type HealthCheck struct {
+	TCP     int    `yaml:"tcp"`     // TCP-dial localhost on this port
+	HTTP    string `yaml:"http"`    // HTTP GET on this absolute URL; 2xx/3xx = healthy
+	Command string `yaml:"command"` // shell tokens (same rules as service.command); exit 0 = healthy
+	Docker  bool   `yaml:"-"`       // set via the scalar shorthand `health_check: docker`
+}
+
+// UnmarshalYAML accepts either a scalar shorthand (currently only "docker") or
+// a mapping with tcp/http/command fields.
+func (h *HealthCheck) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Value != "docker" {
+			return fmt.Errorf("line %d: unknown health_check shorthand %q (only \"docker\" is supported)", node.Line, node.Value)
+		}
+		h.Docker = true
+		return nil
+	case yaml.MappingNode:
+		type raw HealthCheck
+		return node.Decode((*raw)(h))
+	default:
+		return fmt.Errorf("line %d: health_check must be a string or mapping", node.Line)
+	}
+}
+
+// Validate checks that exactly one variant is set.
+func (h *HealthCheck) Validate() error {
+	set := 0
+	if h.TCP > 0 {
+		set++
+	}
+	if h.HTTP != "" {
+		set++
+	}
+	if h.Command != "" {
+		set++
+	}
+	if h.Docker {
+		set++
+	}
+	if set == 0 {
+		return fmt.Errorf("health_check: must set one of tcp, http, command, or the \"docker\" shorthand")
+	}
+	if set > 1 {
+		return fmt.Errorf("health_check: only one of tcp, http, command, or docker may be set")
+	}
+	return nil
 }
 
 // PortMapping maps an auto-assigned port env var to a proxy and service name.
@@ -125,6 +181,11 @@ func Load(path string) (*Config, error) {
 		// Infer scheme from cert presence.
 		if svc.Scheme == "" && svc.TLSCert != "" {
 			svc.Scheme = "https"
+		}
+		if svc.HealthCheck != nil {
+			if err := svc.HealthCheck.Validate(); err != nil {
+				return nil, fmt.Errorf("service %q: %w", name, err)
+			}
 		}
 		cfg.Services[name] = svc
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -417,3 +417,118 @@ services:
 		t.Errorf("api.EnvFile = %q, want %q", api.EnvFile, wantAPI)
 	}
 }
+
+func TestLoadHealthCheckMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  tcp_svc:
+    command: run tcp
+    port: 3000
+    health_check:
+      tcp: 3100
+  http_svc:
+    command: run http
+    port: 4000
+    health_check:
+      http: http://localhost:4000/health
+  cmd_svc:
+    command: run cmd
+    port: 5000
+    health_check:
+      command: "echo ok"
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if hc := cfg.Services["tcp_svc"].HealthCheck; hc == nil || hc.TCP != 3100 {
+		t.Errorf("tcp_svc health_check = %+v", hc)
+	}
+	if hc := cfg.Services["http_svc"].HealthCheck; hc == nil || hc.HTTP != "http://localhost:4000/health" {
+		t.Errorf("http_svc health_check = %+v", hc)
+	}
+	if hc := cfg.Services["cmd_svc"].HealthCheck; hc == nil || hc.Command != "echo ok" {
+		t.Errorf("cmd_svc health_check = %+v", hc)
+	}
+}
+
+func TestLoadHealthCheckDockerShorthand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  db:
+    command: docker compose up -d
+    dir: ./db
+    port: 5432
+    health_check: docker
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	hc := cfg.Services["db"].HealthCheck
+	if hc == nil || !hc.Docker {
+		t.Errorf("expected Docker=true, got %+v", hc)
+	}
+}
+
+func TestLoadHealthCheckUnknownShorthand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  svc:
+    command: run
+    port: 3000
+    health_check: bogus
+`), 0644)
+
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for unknown shorthand")
+	} else if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("expected error to mention 'bogus', got: %v", err)
+	}
+}
+
+func TestLoadHealthCheckMultipleVariants(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  svc:
+    command: run
+    port: 3000
+    health_check:
+      tcp: 3000
+      http: http://localhost:3000/health
+`), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error when multiple variants are set")
+	}
+	if !strings.Contains(err.Error(), "only one") {
+		t.Errorf("expected 'only one' error, got: %v", err)
+	}
+}
+
+func TestLoadHealthCheckEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  svc:
+    command: run
+    port: 3000
+    health_check: {}
+`), 0644)
+
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for empty health_check mapping")
+	}
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,137 @@
+// Package health builds liveness probe closures for service entries.
+package health
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/derekgould/multi-dev-proxy/internal/config"
+)
+
+const (
+	tcpTimeout     = 2 * time.Second
+	httpTimeout    = 3 * time.Second
+	commandTimeout = 5 * time.Second
+)
+
+// Build returns a liveness probe for the given health-check config. When hc is
+// nil, the probe defaults to a TCP dial of defaultPort on localhost. workDir
+// is used as the working directory for command- and docker-style probes, so
+// users can rely on the service's configured dir (e.g. to place a docker
+// compose command in the right project).
+func Build(hc *config.HealthCheck, defaultPort int, workDir string) func() bool {
+	if hc == nil {
+		return func() bool { return tcpProbe(defaultPort) }
+	}
+	switch {
+	case hc.TCP > 0:
+		port := hc.TCP
+		return func() bool { return tcpProbe(port) }
+	case hc.HTTP != "":
+		url := hc.HTTP
+		return func() bool { return httpProbe(url) }
+	case hc.Command != "":
+		cmd := hc.Command
+		return func() bool { return commandProbe(cmd, workDir) }
+	case hc.Docker:
+		return func() bool { return dockerProbe(workDir) }
+	}
+	// Validated away at load time; fall back to the default TCP probe.
+	return func() bool { return tcpProbe(defaultPort) }
+}
+
+func tcpProbe(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), tcpTimeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+func httpProbe(url string) bool {
+	client := &http.Client{Timeout: httpTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 400
+}
+
+func commandProbe(cmdLine, workDir string) bool {
+	parts, err := splitArgs(cmdLine)
+	if err != nil || len(parts) == 0 {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+	c := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	c.Dir = workDir
+	return c.Run() == nil
+}
+
+func dockerProbe(workDir string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+	c := exec.CommandContext(ctx, "docker", "compose", "ps", "-q")
+	c.Dir = workDir
+	out, err := c.Output()
+	if err != nil {
+		return false
+	}
+	return len(strings.TrimSpace(string(out))) > 0
+}
+
+// splitArgs tokenizes a command line honoring single and double quotes. Kept
+// local to avoid an import cycle with internal/orchestrator, where the same
+// logic lives as SplitHookArgs.
+func splitArgs(s string) ([]string, error) {
+	var args []string
+	var cur strings.Builder
+	var inSingle, inDouble, hasTok bool
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			} else {
+				cur.WriteByte(c)
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			} else {
+				cur.WriteByte(c)
+			}
+		case c == '\'':
+			inSingle = true
+			hasTok = true
+		case c == '"':
+			inDouble = true
+			hasTok = true
+		case c == ' ' || c == '\t':
+			if hasTok {
+				args = append(args, cur.String())
+				cur.Reset()
+				hasTok = false
+			}
+		default:
+			cur.WriteByte(c)
+			hasTok = true
+		}
+	}
+	if inSingle || inDouble {
+		return nil, fmt.Errorf("unterminated quote in %q", s)
+	}
+	if hasTok {
+		args = append(args, cur.String())
+	}
+	return args, nil
+}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,169 @@
+package health
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/derekgould/multi-dev-proxy/internal/config"
+)
+
+func TestBuildNilDefaultsToTCPPort(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	probe := Build(nil, port, "")
+	if !probe() {
+		t.Error("expected probe to succeed on open port")
+	}
+
+	ln.Close()
+	if probe() {
+		t.Error("expected probe to fail on closed port")
+	}
+}
+
+func TestBuildTCP(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	probe := Build(&config.HealthCheck{TCP: port}, 1, "")
+	if !probe() {
+		t.Error("expected TCP probe to hit configured port, not defaultPort")
+	}
+}
+
+func TestBuildHTTP(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		healthy bool
+	}{
+		{"200", http.StatusOK, true},
+		{"301", http.StatusMovedPermanently, true},
+		{"399", 399, true},
+		{"400", http.StatusBadRequest, false},
+		{"500", http.StatusInternalServerError, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+			probe := Build(&config.HealthCheck{HTTP: srv.URL}, 0, "")
+			got := probe()
+			if got != tc.healthy {
+				t.Errorf("status %d: got healthy=%v, want %v", tc.status, got, tc.healthy)
+			}
+		})
+	}
+}
+
+func TestBuildHTTPUnreachable(t *testing.T) {
+	ln, _ := net.Listen("tcp", "localhost:0")
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	probe := Build(&config.HealthCheck{HTTP: "http://localhost:" + strconv.Itoa(port)}, 0, "")
+	if probe() {
+		t.Error("expected probe to fail when server is down")
+	}
+}
+
+func TestBuildCommand(t *testing.T) {
+	if _, err := exec.LookPath("true"); err != nil {
+		t.Skip("'true' not available")
+	}
+	probe := Build(&config.HealthCheck{Command: "true"}, 0, "")
+	if !probe() {
+		t.Error("expected 'true' to be healthy")
+	}
+
+	probe = Build(&config.HealthCheck{Command: "false"}, 0, "")
+	if probe() {
+		t.Error("expected 'false' to be unhealthy")
+	}
+
+	probe = Build(&config.HealthCheck{Command: "does-not-exist-xyzzy"}, 0, "")
+	if probe() {
+		t.Error("expected missing binary to be unhealthy")
+	}
+}
+
+func TestBuildCommandQuoted(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("'sh' not available")
+	}
+	probe := Build(&config.HealthCheck{Command: `sh -c "exit 0"`}, 0, "")
+	if !probe() {
+		t.Error("expected quoted command to parse and succeed")
+	}
+}
+
+func TestBuildDockerSkipsWhenDockerMissing(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		// Without docker installed we can still assert the probe doesn't
+		// panic and simply reports unhealthy.
+		probe := Build(&config.HealthCheck{Docker: true}, 0, t.TempDir())
+		if probe() {
+			t.Error("expected docker probe to fail when docker is not installed")
+		}
+		return
+	}
+	// With docker installed, an empty temp dir has no compose project, so the
+	// probe should report unhealthy (exit nonzero or empty output).
+	probe := Build(&config.HealthCheck{Docker: true}, 0, t.TempDir())
+	if probe() {
+		t.Error("expected docker probe to fail in dir with no compose project")
+	}
+}
+
+func TestTCPProbeClosedPort(t *testing.T) {
+	// Grab a port, release it, probe should fail.
+	ln, _ := net.Listen("tcp", "localhost:0")
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	if tcpProbe(port) {
+		t.Errorf("expected probe on closed port %d to fail", port)
+	}
+}
+
+func TestSplitArgsBasic(t *testing.T) {
+	got, err := splitArgs(`docker compose ps -q`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"docker", "compose", "ps", "-q"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitArgsQuoted(t *testing.T) {
+	got, err := splitArgs(`sh -c "echo hello world"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"sh", "-c", "echo hello world"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitArgsUnterminated(t *testing.T) {
+	if _, err := splitArgs(`foo "bar`); err == nil {
+		t.Error("expected error for unterminated quote")
+	}
+}

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/derekgould/multi-dev-proxy/internal/detect"
 	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
 	"github.com/derekgould/multi-dev-proxy/internal/envexport"
+	"github.com/derekgould/multi-dev-proxy/internal/health"
 	"github.com/derekgould/multi-dev-proxy/internal/ports"
 	"github.com/derekgould/multi-dev-proxy/internal/registry"
 )
@@ -234,7 +235,10 @@ func (o *Orchestrator) waitForReady(ctx context.Context, serverName string, prob
 	ticker := time.NewTicker(readyPoll)
 	defer ticker.Stop()
 	for {
-		if status, ok := o.ServiceStatus(serverName); ok && (status == "stopped" || status == "failed") {
+		// Only treat "failed" as a terminal signal. A clean exit ("stopped")
+		// can be a detached service (e.g. `docker compose up -d`) whose port
+		// is about to come up — keep polling until it does or we time out.
+		if status, ok := o.ServiceStatus(serverName); ok && status == "failed" {
 			return fmt.Errorf("service exited before becoming ready (status=%s)", status)
 		}
 		allReady := true
@@ -280,6 +284,7 @@ func (o *Orchestrator) startSingleService(ctx context.Context, name string, svc 
 			Scheme:      scheme,
 			TLSCertPath: svc.TLSCert,
 			TLSKeyPath:  svc.TLSKey,
+			HealthCheck: health.Build(svc.HealthCheck, assignedPort, svc.Dir),
 		}
 		if err := o.Register(svc.Proxy, entry); err != nil {
 			return fmt.Errorf("register %s: %w", serverName, err)
@@ -312,10 +317,11 @@ func (o *Orchestrator) startMultiPortService(ctx context.Context, name string, s
 		}
 		serverName := fmt.Sprintf("%s/%s", group, serviceName)
 		entry := &registry.ServerEntry{
-			Name:  serverName,
-			Repo:  name,
-			Group: group,
-			Port:  port,
+			Name:        serverName,
+			Repo:        name,
+			Group:       group,
+			Port:        port,
+			HealthCheck: health.Build(svc.HealthCheck, port, svc.Dir),
 		}
 		if err := o.Register(pm.Proxy, entry); err != nil {
 			slog.Error("register multi-port service", "name", serverName, "err", err)

--- a/internal/registry/pruner.go
+++ b/internal/registry/pruner.go
@@ -38,34 +38,49 @@ const (
 
 func pruneOnce(reg *Registry, isAlive func(int) bool, tcpCheck func(int) bool) {
 	for _, e := range reg.List() {
-		if e.PID > 0 {
-			if !isAlive(e.PID) {
-				reg.Deregister(e.Name)
-				slog.Info("pruned dead server", "name", e.Name, "pid", e.PID)
-			}
+		// Pure session-owned entries (no PID to track) are the session
+		// pruner's responsibility.
+		if e.PID == 0 && e.ClientID != "" {
 			continue
 		}
 
-		// PID=0 with clientID: handled by session pruner, skip here
-		if e.ClientID != "" {
+		// If the process is still running, the entry is live regardless of
+		// whether the port is responsive yet (the service may still be
+		// starting). Reset failures so a later check starts clean.
+		if e.PID > 0 && isAlive(e.PID) {
+			reg.ResetFailures(e.Name)
 			continue
 		}
 
-		// PID=0, no clientID: use TCP liveness check with grace period
+		// Process is gone (or was never tracked). Fall back to the liveness
+		// probe. Grace period prevents flapping on just-registered entries
+		// and gives detached processes time to hand off to their child
+		// (e.g. `docker compose up -d` exiting while containers come up).
 		if time.Since(e.RegisteredAt) < tcpGracePeriod {
 			continue
 		}
 
-		if tcpCheck(e.Port) {
+		if probe(e, tcpCheck) {
+			// Port/health check passes — keep the entry. For detached
+			// services this is what keeps the proxy alive after the
+			// foreground process has exited.
 			reg.ResetFailures(e.Name)
-		} else {
-			failures := reg.IncrementFailures(e.Name)
-			if failures >= tcpFailThreshold {
-				reg.Deregister(e.Name)
-				slog.Info("pruned unreachable server", "name", e.Name, "port", e.Port, "failures", failures)
-			}
+			continue
+		}
+
+		failures := reg.IncrementFailures(e.Name)
+		if failures >= tcpFailThreshold {
+			reg.Deregister(e.Name)
+			slog.Info("pruned unreachable server", "name", e.Name, "pid", e.PID, "port", e.Port, "failures", failures)
 		}
 	}
+}
+
+func probe(e ServerEntry, tcpCheck func(int) bool) bool {
+	if e.HealthCheck != nil {
+		return e.HealthCheck()
+	}
+	return tcpCheck(e.Port)
 }
 
 // TCPCheck attempts a TCP connection to localhost on the given port.

--- a/internal/registry/pruner_test.go
+++ b/internal/registry/pruner_test.go
@@ -9,18 +9,19 @@ import (
 
 func TestPrunerRemovesDead(t *testing.T) {
 	reg := New()
-	reg.Register(&ServerEntry{Name: "app/alive", Repo: "app", Port: 1001, PID: 1001})
-	reg.Register(&ServerEntry{Name: "app/dead", Repo: "app", Port: 1002, PID: 1002})
-	reg.Register(&ServerEntry{Name: "app/also-alive", Repo: "app", Port: 1003, PID: 1003})
+	pastGrace := time.Now().Add(-60 * time.Second)
+	reg.Register(&ServerEntry{Name: "app/alive", Repo: "app", Port: 1001, PID: 1001, RegisteredAt: pastGrace})
+	reg.Register(&ServerEntry{Name: "app/dead", Repo: "app", Port: 1002, PID: 1002, RegisteredAt: pastGrace})
+	reg.Register(&ServerEntry{Name: "app/also-alive", Repo: "app", Port: 1003, PID: 1003, RegisteredAt: pastGrace})
 
 	isAlive := func(pid int) bool { return pid != 1002 }
-	tcpAlive := func(port int) bool { return true }
+	// Port 1002 is also dead — distinguishes "truly dead" from "detached".
+	tcpCheck := func(port int) bool { return port != 1002 }
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	StartPruner(ctx, reg, 20*time.Millisecond, isAlive, tcpAlive, nil)
-
-	time.Sleep(60 * time.Millisecond)
+	// Tick past the failure threshold so the dead/unreachable entry deregisters.
+	for i := 0; i < tcpFailThreshold; i++ {
+		pruneOnce(reg, isAlive, tcpCheck)
+	}
 
 	if reg.Count() != 2 {
 		t.Errorf("expected 2 servers after pruning, got %d", reg.Count())
@@ -30,6 +31,118 @@ func TestPrunerRemovesDead(t *testing.T) {
 	}
 	if reg.Get("app/alive") == nil {
 		t.Error("alive server should remain")
+	}
+}
+
+// A batch-mode entry carries both a PID and a clientID. When the tracked
+// process exits but the port is still serving (detached case), the registry
+// pruner must keep the entry alive — the session pruner alone would not
+// notice until the `mdp run` client disconnected.
+func TestPrunerKeepsBatchEntryWhenProcessDeadButPortAlive(t *testing.T) {
+	reg := New()
+	reg.Register(&ServerEntry{
+		Name:         "app/batch-detached",
+		Repo:         "app",
+		Port:         5010,
+		PID:          99999,
+		ClientID:     "batch-run-session",
+		RegisteredAt: time.Now().Add(-60 * time.Second),
+	})
+
+	isAlive := func(pid int) bool { return false }
+	tcpAlive := func(port int) bool { return true }
+
+	for i := 0; i < 10; i++ {
+		pruneOnce(reg, isAlive, tcpAlive)
+	}
+
+	if reg.Get("app/batch-detached") == nil {
+		t.Fatal("batch-mode detached service should persist while port is reachable")
+	}
+}
+
+// Detached services (process exits but port still serves) must be kept in the
+// registry — this is the whole point of the health-check fallback.
+func TestPrunerKeepsEntryWhenProcessDeadButProbePasses(t *testing.T) {
+	reg := New()
+	reg.Register(&ServerEntry{
+		Name:         "app/detached",
+		Repo:         "app",
+		Port:         5000,
+		PID:          99999,
+		RegisteredAt: time.Now().Add(-60 * time.Second),
+	})
+
+	isAlive := func(pid int) bool { return false }       // process exited
+	tcpAlive := func(port int) bool { return true }      // but port still up
+
+	for i := 0; i < 10; i++ {
+		pruneOnce(reg, isAlive, tcpAlive)
+	}
+
+	if reg.Get("app/detached") == nil {
+		t.Fatal("detached service should persist while port is reachable")
+	}
+	if got := reg.Get("app/detached").ConsecutiveFailures; got != 0 {
+		t.Errorf("failure counter should stay at 0, got %d", got)
+	}
+}
+
+func TestPrunerUsesCustomHealthCheck(t *testing.T) {
+	reg := New()
+	reg.Register(&ServerEntry{
+		Name:         "app/custom",
+		Repo:         "app",
+		Port:         5001,
+		PID:          0,
+		RegisteredAt: time.Now().Add(-60 * time.Second),
+		HealthCheck:  func() bool { return false },
+	})
+
+	isAlive := func(pid int) bool { return true }
+	tcpAlive := func(port int) bool { return true } // default TCP would say healthy
+
+	for i := 0; i < tcpFailThreshold; i++ {
+		pruneOnce(reg, isAlive, tcpAlive)
+	}
+
+	if reg.Get("app/custom") != nil {
+		t.Error("custom health check returning false should override default TCP probe and trigger pruning")
+	}
+}
+
+// Detached service whose port later goes away must be pruned after the
+// failure threshold.
+func TestPrunerDeregistersDetachedWhenPortDies(t *testing.T) {
+	reg := New()
+	reg.Register(&ServerEntry{
+		Name:         "app/detached",
+		Repo:         "app",
+		Port:         5002,
+		PID:          99999,
+		RegisteredAt: time.Now().Add(-60 * time.Second),
+	})
+
+	isAlive := func(pid int) bool { return false }
+	var alive bool
+	tcpCheck := func(port int) bool { return alive }
+
+	// Port up initially — entry should persist across many ticks.
+	alive = true
+	for i := 0; i < 5; i++ {
+		pruneOnce(reg, isAlive, tcpCheck)
+	}
+	if reg.Get("app/detached") == nil {
+		t.Fatal("entry should still exist while port is reachable")
+	}
+
+	// Port goes down — after threshold consecutive failures, prune.
+	alive = false
+	for i := 0; i < tcpFailThreshold; i++ {
+		pruneOnce(reg, isAlive, tcpCheck)
+	}
+	if reg.Get("app/detached") != nil {
+		t.Error("entry should be pruned once port stops responding")
 	}
 }
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -18,7 +18,8 @@ type ServerEntry struct {
 	TLSKeyPath          string // optional: key file path forwarded by mdp run
 	ClientID            string // identifies the mdp run process that registered this server
 	RegisteredAt        time.Time
-	ConsecutiveFailures int // TCP liveness check failure counter (PID=0 servers only)
+	ConsecutiveFailures int          // TCP liveness check failure counter (PID=0 servers only)
+	HealthCheck         func() bool  // optional; nil falls back to TCPCheck(Port)
 }
 
 // Registry holds all registered dev servers in memory.


### PR DESCRIPTION
Fixes the case where `command: docker compose up -d` (and other detached commands) were torn down as soon as the command process exited, releasing the proxy port even though the real service was still listening. The registry pruner now falls back to a port probe after process death, and single-mode `mdp run` holds the client session open while the port keeps answering. Adds a new `health_check` field to `mdp.yaml` — `tcp`, `http`, `command`, or the `docker` shorthand (runs `docker compose ps -q` in the service's dir) — with the default probe staying at TCP on the service's port.