### PR TITLE
feat: add protocol: udp to port mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ go.work.sum
 testbed/mdp
 testbed/go-websocket/go-websocket
 testbed/echo-api/echo-api
+testbed/udp-echo/udp-echo
 testbed/.certs/
 
 # Testbed Node.js

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -150,10 +150,15 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 		}
 
 		if len(svc.Ports) > 0 {
+			envProtocols := svc.EnvProtocols()
 			portAssignments := make(map[string]int)
 			for envName, value := range svc.Env {
 				if value == "auto" {
-					port, err := ports.FindFreePort(portRange, assignedPorts)
+					finder := ports.FindFreePort
+					if envProtocols[envName] == "udp" {
+						finder = ports.FindFreeUDPPort
+					}
+					port, err := finder(portRange, assignedPorts)
 					if err != nil {
 						return fmt.Errorf("find free port for %q.%s: %w", name, envName, err)
 					}
@@ -166,7 +171,7 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 				svcPorts[k] = v
 			}
 			portMap[name] = svcPorts
-			allocations = append(allocations, batchAlloc{name: name, svc: svc, svcGroup: svcGroup, portAssignments: portAssignments})
+			allocations = append(allocations, batchAlloc{name: name, svc: svc, svcGroup: svcGroup, portAssignments: portAssignments, portProtocols: envProtocols})
 			continue
 		}
 
@@ -244,9 +249,10 @@ type batchAlloc struct {
 	name            string
 	svc             config.ServiceConfig
 	svcGroup        string
-	assignedPort    int            // single-port only
-	portAssignments map[string]int // multi-port only
-	env             []string       // populated by exportBatchEnvFiles before fan-out
+	assignedPort    int               // single-port only
+	portAssignments map[string]int    // multi-port only
+	portProtocols   map[string]string // env → "tcp"/"udp"; only populated for multi-port
+	env             []string          // populated by exportBatchEnvFiles before fan-out
 }
 
 // launchBatchService is the per-service batch-mode launcher: it waits for the
@@ -299,6 +305,9 @@ func launchBatchService(
 					port:       port,
 					proxyPort:  pm.Proxy,
 				})
+			}
+			if pm.Protocol == "udp" {
+				continue
 			}
 			probePorts = append(probePorts, port)
 		}

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -188,6 +188,73 @@ func TestWatchHealthStaysOpenWhenHealthy(t *testing.T) {
 	}
 }
 
+func TestLaunchBatchServiceSkipsUDPPortsFromProbe(t *testing.T) {
+	// A port mapping with protocol: udp must never be TCP-probed — that's the
+	// whole point of declaring a port UDP in the first place. The probe list
+	// builder should exclude it, and the UDP port's proxy (always 0) should
+	// not be registered either.
+	var probedPorts []int
+	var probeMu sync.Mutex
+	rt := batchRuntime{
+		readyTimeout: time.Second,
+		readyPoll:    10 * time.Millisecond,
+		tcpCheck: func(p int) bool {
+			probeMu.Lock()
+			probedPorts = append(probedPorts, p)
+			probeMu.Unlock()
+			return true
+		},
+	}
+
+	var registerMu sync.Mutex
+	var registerCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/__mdp/register" {
+			registerMu.Lock()
+			registerCount++
+			registerMu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := batchAlloc{
+		name:     "infra",
+		svcGroup: "main",
+		svc: config.ServiceConfig{
+			// Commandless → external service code path.
+			Env: map[string]string{
+				"API_PORT":          "auto",
+				"JAEGER_AGENT_PORT": "auto",
+			},
+			Ports: []config.PortMapping{
+				{Env: "API_PORT", Proxy: 4000, Name: "api"},
+				{Env: "JAEGER_AGENT_PORT", Protocol: "udp"},
+			},
+		},
+		portAssignments: map[string]int{"API_PORT": 40001, "JAEGER_AGENT_PORT": 54321},
+		portProtocols:   map[string]string{"API_PORT": "tcp", "JAEGER_AGENT_PORT": "udp"},
+	}
+
+	bt := &batchTracker{}
+	bt.wg.Add(1)
+	states := depwait.NewStates([]string{"infra"})
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", a, states, rt)
+
+	probeMu.Lock()
+	defer probeMu.Unlock()
+	for _, p := range probedPorts {
+		if p == 54321 {
+			t.Errorf("TCP probe called on UDP port 54321; UDP ports must be excluded from the probe list")
+		}
+	}
+	registerMu.Lock()
+	defer registerMu.Unlock()
+	if registerCount != 1 {
+		t.Errorf("register called %d times, want 1 (only the TCP API_PORT should register)", registerCount)
+	}
+}
+
 func TestLaunchBatchServiceSkipsProxylessPorts(t *testing.T) {
 	// Commandless services still get TCP-probed; stub the check so the test
 	// doesn't block on unbound ports.

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -322,16 +322,18 @@ Entries in `services.<name>.ports[]`.
 |---|---|---|---|
 | `env` | string | yes | Env var name that will hold the allocated port. Reference from other services' `env` with `${svc.NAME}`, or from `global.env` with `${svc.env.NAME}`. |
 | `proxy` | int | no (default `0`) | Proxy port to register this port on. `0` = no proxy (use for DB / non-HTTP ports). |
-| `name` | string | no | Display name in the TUI and server registry. Defaults to the `env` value. |
+| `name` | string | no | Display name in the TUI and server registry. Defaults to the `env` value. Not allowed with `protocol: udp`. |
+| `protocol` | string | no (default `tcp`) | Transport protocol. `udp` marks the port as UDP: allocation uses a UDP-aware free-port check, and the `depends_on` readiness probe skips it (TCP probes never succeed on UDP). Incompatible with `proxy` and `name`. |
 
 ```yaml
 services:
   infra:
     command: docker compose up --wait
     env:
-      API_PORT: auto
-      WS_PORT:  auto
-      DB_PORT:  auto
+      API_PORT:          auto
+      WS_PORT:           auto
+      DB_PORT:           auto
+      JAEGER_AGENT_PORT: auto
     ports:
       - env: API_PORT
         proxy: 4000
@@ -340,9 +342,11 @@ services:
         proxy: 4001
         name: websocket
       - env: DB_PORT     # internal only, no proxy
+      - env: JAEGER_AGENT_PORT
+        protocol: udp    # UDP-only; compose publishes "${JAEGER_AGENT_PORT}:6831/udp"
 ```
 
-In the TUI this service appears as `<group>/api`, `<group>/websocket`, and `<group>/DB_PORT` (falling back to the env name when `name` is omitted).
+In the TUI this service appears as `<group>/api`, `<group>/websocket`, and `<group>/DB_PORT` (falling back to the env name when `name` is omitted). UDP mappings are not registered against any proxy and do not appear in the TUI.
 
 ## Interpolation
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -53,6 +53,30 @@ db:
     - env: DB_PORT    # allocated & interpolatable, no proxy
 ```
 
+**UDP ports:** add `protocol: udp` to a `ports:` entry so mdp allocates the host port with a UDP-aware free-port check and skips it in the `depends_on` readiness probe (TCP probes never succeed on UDP). This is what lets multiple worktrees run the same UDP-publishing compose stack in parallel — each gets its own random host port, and nothing collides.
+
+```yaml
+# mdp.yaml
+infra:
+  command: docker compose up --wait
+  env:
+    JAEGER_AGENT_PORT: auto
+  ports:
+    - env: JAEGER_AGENT_PORT
+      protocol: udp
+```
+
+```yaml
+# docker-compose.yml
+services:
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "${JAEGER_AGENT_PORT}:6831/udp"
+```
+
+UDP mappings are allocation-only: `proxy:` and `name:` are rejected at config load.
+
 ## HTTPS
 
 mdp inherits TLS certificates from the services it proxies. When a service registers with `--tls-cert` and `--tls-key`, the proxy automatically starts accepting HTTPS connections using that certificate. Each proxy port serves both HTTP and HTTPS on the same port.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,9 +92,28 @@ type ServiceConfig struct {
 // need a free port allocated for ${svc.env} interpolation but should not be
 // registered with an HTTP reverse-proxy listener.
 type PortMapping struct {
-	Env   string `yaml:"env"`
-	Proxy int    `yaml:"proxy"`
-	Name  string `yaml:"name"`
+	Env      string `yaml:"env"`
+	Proxy    int    `yaml:"proxy"`
+	Name     string `yaml:"name"`
+	Protocol string `yaml:"protocol"` // "tcp" (default) or "udp"
+}
+
+// EnvProtocols returns a {env var → normalized protocol} map for every entry
+// in Ports. Empty protocols are normalized to "tcp". Allocators use this to
+// decide whether a port should be verified via TCP or UDP probes.
+func (s ServiceConfig) EnvProtocols() map[string]string {
+	if len(s.Ports) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(s.Ports))
+	for _, pm := range s.Ports {
+		proto := strings.ToLower(pm.Protocol)
+		if proto == "" {
+			proto = "tcp"
+		}
+		m[pm.Env] = proto
+	}
+	return m
 }
 
 // Load reads and parses the config file at the given path.
@@ -125,6 +144,24 @@ func Load(path string) (*Config, error) {
 		// Infer scheme from cert presence.
 		if svc.Scheme == "" && svc.TLSCert != "" {
 			svc.Scheme = "https"
+		}
+		// Normalize + validate port mapping protocols.
+		for i, pm := range svc.Ports {
+			proto := strings.ToLower(pm.Protocol)
+			switch proto {
+			case "", "tcp":
+				// ok
+			case "udp":
+				if pm.Proxy > 0 {
+					return nil, fmt.Errorf("service %q: protocol: udp is incompatible with a non-zero proxy port (env %q)", name, pm.Env)
+				}
+				if pm.Name != "" {
+					return nil, fmt.Errorf("service %q: name: has no effect on UDP port mappings (env %q)", name, pm.Env)
+				}
+			default:
+				return nil, fmt.Errorf("service %q: unknown protocol %q for port mapping %q (expected \"tcp\" or \"udp\")", name, pm.Protocol, pm.Env)
+			}
+			svc.Ports[i].Protocol = proto
 		}
 		cfg.Services[name] = svc
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -112,6 +112,138 @@ services:
 	}
 }
 
+func TestLoadUDPPortMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  infra:
+    command: docker compose up
+    env:
+      JAEGER_AGENT_PORT: auto
+      API_PORT: auto
+    ports:
+      - env: JAEGER_AGENT_PORT
+        protocol: UDP
+      - env: API_PORT
+        proxy: 4000
+        name: api
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	infra := cfg.Services["infra"]
+	if len(infra.Ports) != 2 {
+		t.Fatalf("expected 2 port mappings, got %d", len(infra.Ports))
+	}
+	if infra.Ports[0].Protocol != "udp" {
+		t.Errorf("ports[0].Protocol = %q, want \"udp\" (normalized to lowercase)", infra.Ports[0].Protocol)
+	}
+	if infra.Ports[1].Protocol != "tcp" && infra.Ports[1].Protocol != "" {
+		t.Errorf("ports[1].Protocol = %q, want \"\" or \"tcp\"", infra.Ports[1].Protocol)
+	}
+}
+
+func TestLoadRejectsUnknownProtocol(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  infra:
+    command: docker compose up
+    env:
+      X: auto
+    ports:
+      - env: X
+        protocol: sctp
+`), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for unknown protocol, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown protocol") {
+		t.Errorf("error = %v, want it to mention \"unknown protocol\"", err)
+	}
+}
+
+func TestLoadRejectsUDPWithProxy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  infra:
+    command: docker compose up
+    env:
+      X: auto
+    ports:
+      - env: X
+        protocol: udp
+        proxy: 1234
+`), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for udp+proxy, got nil")
+	}
+	if !strings.Contains(err.Error(), "udp") || !strings.Contains(err.Error(), "proxy") {
+		t.Errorf("error = %v, want it to mention udp and proxy", err)
+	}
+}
+
+func TestLoadRejectsUDPWithName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  infra:
+    command: docker compose up
+    env:
+      X: auto
+    ports:
+      - env: X
+        protocol: udp
+        name: x
+`), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for udp+name, got nil")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error = %v, want it to mention name", err)
+	}
+}
+
+func TestEnvProtocols(t *testing.T) {
+	svc := ServiceConfig{
+		Ports: []PortMapping{
+			{Env: "A", Protocol: "udp"},
+			{Env: "B", Protocol: "tcp"},
+			{Env: "C"},
+		},
+	}
+	got := svc.EnvProtocols()
+	if got["A"] != "udp" {
+		t.Errorf("A = %q, want udp", got["A"])
+	}
+	if got["B"] != "tcp" {
+		t.Errorf("B = %q, want tcp", got["B"])
+	}
+	if got["C"] != "tcp" {
+		t.Errorf("C = %q, want tcp (default)", got["C"])
+	}
+}
+
+func TestEnvProtocolsEmpty(t *testing.T) {
+	svc := ServiceConfig{}
+	if got := svc.EnvProtocols(); got != nil {
+		t.Errorf("EnvProtocols() = %v, want nil for empty Ports", got)
+	}
+}
+
 func TestLoadDefaultPortRange(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mdp.yaml")

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -34,8 +34,9 @@ type serviceAlloc struct {
 	name            string
 	svc             config.ServiceConfig
 	assignedPort    int
-	portAssignments map[string]int // multi-port only
-	env             []string       // populated in the env-build phase
+	portAssignments map[string]int    // multi-port only
+	portProtocols   map[string]string // env → "tcp"/"udp"; only populated for multi-port
+	env             []string          // populated in the env-build phase
 }
 
 // StartConfigServices starts all services from the config under the given group name.
@@ -62,10 +63,15 @@ func (o *Orchestrator) StartConfigServices(ctx context.Context, group string) er
 			continue
 		}
 		if len(svc.Ports) > 0 {
+			envProtocols := svc.EnvProtocols()
 			portAssignments := make(map[string]int)
 			for envName, value := range svc.Env {
 				if value == "auto" {
-					port, err := ports.FindFreePort(portRange, assignedPorts)
+					finder := ports.FindFreePort
+					if envProtocols[envName] == "udp" {
+						finder = ports.FindFreeUDPPort
+					}
+					port, err := finder(portRange, assignedPorts)
 					if err != nil {
 						return fmt.Errorf("find free port for %s.%s: %w", name, envName, err)
 					}
@@ -78,7 +84,7 @@ func (o *Orchestrator) StartConfigServices(ctx context.Context, group string) er
 				svcPorts[k] = v
 			}
 			portMap[name] = svcPorts
-			allocations = append(allocations, serviceAlloc{name: name, svc: svc, portAssignments: portAssignments})
+			allocations = append(allocations, serviceAlloc{name: name, svc: svc, portAssignments: portAssignments, portProtocols: envProtocols})
 			continue
 		}
 		assignedPort := svc.Port
@@ -211,11 +217,14 @@ func envSliceToMap(env []string) map[string]string {
 // probePortsFor returns the TCP ports that should be polled to decide whether
 // a service has become ready. External services (no command) are probed too
 // so dependents only unblock once the externally-managed service is actually
-// reachable.
+// reachable. UDP ports are excluded — TCP probes never succeed on them.
 func probePortsFor(a serviceAlloc) []int {
 	if len(a.portAssignments) > 0 {
 		result := make([]int, 0, len(a.portAssignments))
-		for _, p := range a.portAssignments {
+		for env, p := range a.portAssignments {
+			if a.portProtocols[env] == "udp" {
+				continue
+			}
 			result = append(result, p)
 		}
 		return result
@@ -304,6 +313,12 @@ func (o *Orchestrator) startMultiPortService(ctx context.Context, name string, s
 	for _, pm := range svc.Ports {
 		port, ok := portAssignments[pm.Env]
 		if !ok {
+			continue
+		}
+		if pm.Proxy <= 0 {
+			// No proxy requested for this port (internal-only port, or a UDP
+			// mapping). Allocation + env injection is sufficient; nothing to
+			// register against a reverse-proxy listener.
 			continue
 		}
 		serviceName := pm.Name

--- a/internal/orchestrator/runner_test.go
+++ b/internal/orchestrator/runner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/derekgould/multi-dev-proxy/internal/config"
 	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
+	"github.com/derekgould/multi-dev-proxy/internal/ports"
 )
 
 func TestSplitHookArgs(t *testing.T) {
@@ -528,5 +529,138 @@ func TestStartConfigServicesFailsWhenDepTimesOut(t *testing.T) {
 	}
 	if status, _ := o.ServiceStatus("test/b"); status != "failed" {
 		t.Errorf("b status = %q, want 'failed' (dep failed)", status)
+	}
+}
+
+// swapFinders replaces ports.FindFreePort and ports.FindFreeUDPPort with
+// recording stubs. Returns pointers that can be inspected after the test runs.
+// Each finder returns an incrementing port from startPort so assignments are
+// deterministic and non-colliding across the test.
+func swapFinders(t *testing.T, startPort int) (tcpCalls, udpCalls *[]string) {
+	t.Helper()
+	origTCP := ports.FindFreePort
+	origUDP := ports.FindFreeUDPPort
+	var tcp, udp []string
+	tcpNext, udpNext := startPort, startPort+1000
+	var mu sync.Mutex
+	ports.FindFreePort = func(r ports.PortRange, exclude []int) (int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		tcp = append(tcp, "tcp")
+		p := tcpNext
+		tcpNext++
+		return p, nil
+	}
+	ports.FindFreeUDPPort = func(r ports.PortRange, exclude []int) (int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		udp = append(udp, "udp")
+		p := udpNext
+		udpNext++
+		return p, nil
+	}
+	t.Cleanup(func() {
+		ports.FindFreePort = origTCP
+		ports.FindFreeUDPPort = origUDP
+	})
+	return &tcp, &udp
+}
+
+func TestStartConfigServicesDispatchesUDPAllocator(t *testing.T) {
+	// Service with a UDP port mapping must allocate via FindFreeUDPPort, and
+	// a TCP mapping must allocate via FindFreePort.
+	swapTimeouts(t, 100*time.Millisecond, 10*time.Millisecond)
+	swapTCPCheck(t, func(int) bool { return true })
+	tcpCalls, udpCalls := swapFinders(t, 30000)
+
+	cfg := &config.Config{
+		PortRange: "10000-60000",
+		Services: map[string]config.ServiceConfig{
+			"infra": {
+				Command: "sleep 30",
+				Env: map[string]string{
+					"TCP_PORT": "auto",
+					"UDP_PORT": "auto",
+				},
+				Ports: []config.PortMapping{
+					{Env: "TCP_PORT"},
+					{Env: "UDP_PORT", Protocol: "udp"},
+				},
+			},
+		},
+	}
+	o := New(cfg, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan struct{})
+	go func() {
+		_ = o.StartConfigServices(ctx, "test")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("StartConfigServices did not return")
+	}
+
+	if len(*tcpCalls) != 1 {
+		t.Errorf("FindFreePort called %d times, want 1 (for TCP_PORT)", len(*tcpCalls))
+	}
+	if len(*udpCalls) != 1 {
+		t.Errorf("FindFreeUDPPort called %d times, want 1 (for UDP_PORT)", len(*udpCalls))
+	}
+}
+
+func TestProbePortsForExcludesUDP(t *testing.T) {
+	a := serviceAlloc{
+		portAssignments: map[string]int{"TCP_PORT": 40001, "UDP_PORT": 40002},
+		portProtocols:   map[string]string{"TCP_PORT": "tcp", "UDP_PORT": "udp"},
+	}
+	got := probePortsFor(a)
+	if len(got) != 1 || got[0] != 40001 {
+		t.Errorf("probePortsFor() = %v, want [40001] (UDP port excluded)", got)
+	}
+}
+
+func TestStartMultiPortServiceSkipsRegistrationWhenProxyZero(t *testing.T) {
+	// A port mapping with proxy:0 (such as a UDP-only allocation or an
+	// internal-only port) must not call Register — otherwise EnsureProxy(0)
+	// would spin up an ephemeral proxy that nothing ever reaches.
+	swapTimeouts(t, 100*time.Millisecond, 10*time.Millisecond)
+	swapTCPCheck(t, func(int) bool { return true })
+	swapFinders(t, 31000)
+
+	cfg := &config.Config{
+		PortRange: "10000-60000",
+		Services: map[string]config.ServiceConfig{
+			"infra": {
+				Command: "sleep 30",
+				Env:     map[string]string{"UDP_PORT": "auto"},
+				Ports:   []config.PortMapping{{Env: "UDP_PORT", Protocol: "udp"}},
+			},
+		},
+	}
+	o := New(cfg, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan struct{})
+	go func() {
+		_ = o.StartConfigServices(ctx, "test")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("StartConfigServices did not return")
+	}
+
+	// No proxy should have been created. ListProxies returns all proxy
+	// instances ever created by the orchestrator.
+	if got := len(o.ListProxies()); got != 0 {
+		t.Errorf("ListProxies() = %d, want 0 (UDP mapping should not create a proxy)", got)
 	}
 }

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -44,7 +44,7 @@ func ParseRange(s string) (PortRange, error) {
 	return PortRange{Start: start, End: end}, nil
 }
 
-// IsPortFree checks whether a port is available by attempting to bind to it.
+// IsPortFree checks whether a TCP port is available by attempting to bind to it.
 func IsPortFree(port int) bool {
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
@@ -54,9 +54,31 @@ func IsPortFree(port int) bool {
 	return true
 }
 
-// FindFreePort picks a random free port in r that is not in the exclude list.
-// Returns an error if no free port is found after 100 attempts.
-func FindFreePort(r PortRange, exclude []int) (int, error) {
+// IsUDPPortFree checks whether a UDP port is available by attempting to bind to it.
+func IsUDPPortFree(port int) bool {
+	pc, err := net.ListenPacket("udp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return false
+	}
+	pc.Close()
+	return true
+}
+
+// FindFreePort picks a random free TCP port in r that is not in the exclude list.
+// Declared as a var so tests can swap it without binding real sockets.
+var FindFreePort = func(r PortRange, exclude []int) (int, error) {
+	return findFreePort(r, exclude, IsPortFree)
+}
+
+// FindFreeUDPPort picks a random free UDP port in r that is not in the exclude list.
+// Declared as a var so tests can swap it without binding real sockets.
+var FindFreeUDPPort = func(r PortRange, exclude []int) (int, error) {
+	return findFreePort(r, exclude, IsUDPPortFree)
+}
+
+// findFreePort is the shared implementation used by FindFreePort and
+// FindFreeUDPPort.
+func findFreePort(r PortRange, exclude []int, isFree func(int) bool) (int, error) {
 	excluded := make(map[int]bool, len(exclude))
 	for _, p := range exclude {
 		excluded[p] = true
@@ -67,7 +89,7 @@ func FindFreePort(r PortRange, exclude []int) (int, error) {
 		if excluded[port] {
 			continue
 		}
-		if IsPortFree(port) {
+		if isFree(port) {
 			return port, nil
 		}
 	}

--- a/internal/ports/ports_test.go
+++ b/internal/ports/ports_test.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"net"
+	"strconv"
 	"testing"
 )
 
@@ -238,6 +239,50 @@ func TestFindFreePortExhausted(t *testing.T) {
 	}
 	if err != nil && !contains(err.Error(), "no free port found") {
 		t.Errorf("FindFreePort() error = %v, want error containing 'no free port found'", err)
+	}
+}
+
+func TestIsUDPPortFree(t *testing.T) {
+	t.Run("port is free when nothing is listening", func(t *testing.T) {
+		pc, err := net.ListenPacket("udp", ":0")
+		if err != nil {
+			t.Fatalf("failed to find free udp port: %v", err)
+		}
+		port := pc.LocalAddr().(*net.UDPAddr).Port
+		pc.Close()
+		if !IsUDPPortFree(port) {
+			t.Errorf("IsUDPPortFree(%d) = false, want true", port)
+		}
+	})
+
+	t.Run("port is not free when something is listening", func(t *testing.T) {
+		pc, err := net.ListenPacket("udp", ":0")
+		if err != nil {
+			t.Fatalf("failed to bind udp: %v", err)
+		}
+		defer pc.Close()
+		port := pc.LocalAddr().(*net.UDPAddr).Port
+		if IsUDPPortFree(port) {
+			t.Errorf("IsUDPPortFree(%d) = true, want false (port is in use)", port)
+		}
+	})
+}
+
+func TestFindFreeUDPPort(t *testing.T) {
+	r := PortRange{Start: 20000, End: 30000}
+	port, err := FindFreeUDPPort(r, nil)
+	if err != nil {
+		t.Fatalf("FindFreeUDPPort() error = %v", err)
+	}
+	if port < r.Start || port > r.End {
+		t.Errorf("FindFreeUDPPort() = %d, want port in range [%d, %d]", port, r.Start, r.End)
+	}
+	// The returned port should actually be UDP-bindable.
+	pc, err := net.ListenPacket("udp", ":"+strconv.Itoa(port))
+	if err != nil {
+		t.Errorf("FindFreeUDPPort() returned port %d that is not UDP-bindable: %v", port, err)
+	} else {
+		pc.Close()
 	}
 }
 

--- a/testbed/mdp.yaml
+++ b/testbed/mdp.yaml
@@ -8,6 +8,8 @@ global:
       ref: api-main.env.PORT
     DB_PORT:
       ref: db-main.env.DB_PORT
+    UDP_PORT:
+      ref: udp-echo-main.env.UDP_PORT
     # Scalar form — any string with ${svc.key} or ${svc.env.VAR} refs.
     API_URL: "http://localhost:${api-main.PORT}"
     DB_URL:  "postgres://localhost:${db-main.env.DB_PORT}/app"
@@ -43,6 +45,24 @@ services:
       DB_PORT: auto
     ports:
       - env: DB_PORT
+
+  # UDP echo: demonstrates `protocol: udp` — mdp allocates a UDP-bindable
+  # free port (via UDP-aware check, not TCP) and skips it in the depends_on
+  # readiness probe (TCP probes never succeed on UDP). Multi-worktree
+  # parallelism: each worktree gets its own random UDP_PORT and nothing
+  # collides on the host.
+  #
+  # Exercise it:
+  #   printf 'hello' | socat -t1 - UDP:127.0.0.1:$UDP_PORT
+  udp-echo-main:
+    command: ./udp-echo/udp-echo
+    group: main
+    env:
+      UDP_PORT: auto
+      NAME: "udp-echo / main"
+    ports:
+      - env: UDP_PORT
+        protocol: udp
 
   api-main:
     command: docker compose up --build --wait

--- a/testbed/run.sh
+++ b/testbed/run.sh
@@ -22,6 +22,9 @@ echo "Building mdp..."
 echo "Building testbed server..."
 (cd "$SCRIPT_DIR/server" && go build -o "$SCRIPT_DIR/server/server" .)
 
+echo "Building udp-echo..."
+(cd "$SCRIPT_DIR/udp-echo" && go build -o "$SCRIPT_DIR/udp-echo/udp-echo" .)
+
 echo "Generating TLS cert..."
 CERT_DIR="$SCRIPT_DIR/.certs"
 mkdir -p "$CERT_DIR"
@@ -65,9 +68,12 @@ printf "  Frontend:    \033[1;36mhttp://localhost:3000\033[0m (TLS on main)\n"
 printf "  Backend:     \033[1;36mhttp://localhost:3001\033[0m (Docker on main)\n"
 echo ""
 printf "  Groups:\n"
-printf "    \033[1;36mmain\033[0m       web (TLS) + api (Docker)\n"
+printf "    \033[1;36mmain\033[0m       web (TLS) + api (Docker) + udp-echo\n"
 printf "    \033[1;32mfeature-a\033[0m  web + api\n"
 printf "    \033[1;31mfeature-b\033[0m  web + api\n"
+echo ""
+printf "  UDP echo (main group): port shown as \$UDP_PORT in .mdp.env\n"
+printf "    printf 'hi' | socat -t1 - UDP:127.0.0.1:\$UDP_PORT\n"
 echo ""
 echo "  Press Ctrl+C to stop everything."
 echo ""

--- a/testbed/udp-echo/go.mod
+++ b/testbed/udp-echo/go.mod
@@ -1,0 +1,3 @@
+module testbed/udp-echo
+
+go 1.22

--- a/testbed/udp-echo/main.go
+++ b/testbed/udp-echo/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+// A tiny UDP echo server used by the testbed to demonstrate the
+// `protocol: udp` PortMapping field: mdp allocates the host port via a
+// UDP-aware free-port check and skips it in the depends_on readiness probe.
+//
+// Reads UDP_PORT (set by mdp via the `ports:` mapping), binds, echoes each
+// incoming datagram back to the sender, and prints one line per packet.
+//
+// Try it:
+//   printf 'hello' | socat -t1 - UDP:127.0.0.1:$UDP_PORT
+//   printf 'hello' | ncat -u --send-only 127.0.0.1 $UDP_PORT
+func main() {
+	port := os.Getenv("UDP_PORT")
+	if port == "" {
+		fmt.Fprintln(os.Stderr, "UDP_PORT not set")
+		os.Exit(1)
+	}
+	name := os.Getenv("NAME")
+	if name == "" {
+		name = "udp-echo"
+	}
+	addr := ":" + port
+	pc, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen udp %s: %v\n", addr, err)
+		os.Exit(1)
+	}
+	defer pc.Close()
+	fmt.Printf("[%s] listening on udp %s\n", name, addr)
+
+	buf := make([]byte, 2048)
+	for {
+		n, src, err := pc.ReadFrom(buf)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "read: %v\n", err)
+			return
+		}
+		ts := time.Now().Format("15:04:05.000")
+		fmt.Printf("[%s %s] %d bytes from %s: %q\n", name, ts, n, src, buf[:n])
+		if _, err := pc.WriteTo(buf[:n], src); err != nil {
+			fmt.Fprintf(os.Stderr, "write: %v\n", err)
+		}
+	}
+}


### PR DESCRIPTION
Declares `protocol: udp` on a `PortMapping` so mdp allocates the host port via a UDP-aware free-port check (not TCP) and skips it in the `depends_on` readiness probe — otherwise UDP-only ports wedge dependents forever. Unblocks multi-worktree parallel runs of compose stacks that publish UDP (e.g. Jaeger agent `6831:6831/udp`), since each worktree gets its own random host port. UDP forwarding was explored and rejected: a global-default-only routing model would make `mdp switch` cumbersome and ambiguous for the Jaeger-style use case — env-injection alone is sufficient. Includes docs updates, a testbed `udp-echo` service demonstrating the pattern, and unit tests for config validation, UDP free-port check, allocator dispatch, probe filtering, and the orchestrator-mode `Register` guard.