### PR TITLE
feat: cross-repo @<repo> env references via orchestrator

### DIFF
--- a/cmd/mdp/peers.go
+++ b/cmd/mdp/peers.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/derekgould/multi-dev-proxy/internal/config"
+	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
+)
+
+// peerRef identifies one cross-repo @-reference: a (repo, svc, key) tuple
+// looked up against the orchestrator's registry, plus the rendered "current"
+// value from the most recent lookup. Used by the peer-watcher to detect
+// changes.
+type peerRef struct {
+	repo    string
+	svc     string
+	isEnv   bool
+	key     string
+	current string
+	found   bool
+}
+
+func (r peerRef) signature() string {
+	t := "port"
+	if r.isEnv {
+		t = "env"
+	}
+	return fmt.Sprintf("@%s.%s.%s.%s", r.repo, r.svc, t, r.key)
+}
+
+// extractPeerRefs returns every distinct @-reference appearing in the given
+// service's env entries. The current/found fields are zero-valued; populate
+// them via resolvePeer.
+func extractPeerRefs(svc config.ServiceConfig) []peerRef {
+	seen := map[string]peerRef{}
+
+	add := func(c envexpand.CrossRepoRef) {
+		p := peerRef{repo: c.Repo, svc: c.Svc, isEnv: c.IsEnv, key: c.Key}
+		seen[p.signature()] = p
+	}
+
+	for _, entry := range svc.Env {
+		if entry.Ref != "" {
+			if c, ok := envexpand.ParseCrossRepoBareRef(entry.Ref); ok {
+				add(c)
+			}
+			continue
+		}
+		for _, c := range envexpand.ScanCrossRepoRefs(entry.Value) {
+			add(c)
+		}
+	}
+
+	out := make([]peerRef, 0, len(seen))
+	for _, p := range seen {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].signature() < out[j].signature() })
+	return out
+}
+
+// resolvePeer queries the orchestrator for one peer reference. Returns
+// (value, true) when the peer is registered and the requested key resolves;
+// (zero, false) otherwise.
+func resolvePeer(client *http.Client, controlURL, group string, ref peerRef) (string, bool) {
+	q := url.Values{}
+	q.Set("group", group)
+	q.Set("repo", ref.repo)
+	q.Set("svc", ref.svc) // unused by current handler, kept for future indexing
+	q.Set("service", ref.svc)
+	resp, err := client.Get(controlURL + "/__mdp/peers?" + q.Encode())
+	if err != nil {
+		return "", false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+	var body struct {
+		Port int               `json:"port"`
+		Env  map[string]string `json:"env"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", false
+	}
+	if ref.isEnv {
+		val, ok := body.Env[ref.key]
+		return val, ok
+	}
+	if body.Port == 0 {
+		return "", false
+	}
+	return strconv.Itoa(body.Port), true
+}
+
+// newPeerResolver returns an envexpand.Resolver bound to one (group, controlURL)
+// pair. It is safe to call concurrently.
+func newPeerResolver(client *http.Client, controlURL, group string) envexpand.Resolver {
+	return func(repo, svc string, isEnv bool, key string) (string, bool) {
+		return resolvePeer(client, controlURL, group, peerRef{repo: repo, svc: svc, isEnv: isEnv, key: key})
+	}
+}
+
+// refreshPeerRefs queries the orchestrator for every ref and writes the
+// current/found fields. Returns whether any value changed since the last
+// refresh.
+func refreshPeerRefs(client *http.Client, controlURL, group string, refs []peerRef) (changed bool, updated []peerRef) {
+	updated = make([]peerRef, len(refs))
+	for i, r := range refs {
+		val, ok := resolvePeer(client, controlURL, group, r)
+		if val != r.current || ok != r.found {
+			changed = true
+		}
+		r.current = val
+		r.found = ok
+		updated[i] = r
+	}
+	return changed, updated
+}
+
+// watchPeerRefs polls the orchestrator on interval. When ANY watched ref's
+// resolved value changes, it sends on changed once and exits. The caller
+// re-invokes the watcher after restarting the dependent service.
+func watchPeerRefs(ctx context.Context, client *http.Client, controlURL, group string, refs []peerRef, interval time.Duration, changed chan<- []peerRef) {
+	if len(refs) == 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	current := refs
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			didChange, next := refreshPeerRefs(client, controlURL, group, current)
+			if didChange {
+				slog.Info("peer state changed", "refs", peerRefSignatures(next))
+				select {
+				case changed <- next:
+				case <-ctx.Done():
+				}
+				return
+			}
+			current = next
+		}
+	}
+}
+
+func peerRefSignatures(refs []peerRef) []string {
+	out := make([]string, len(refs))
+	for i, r := range refs {
+		out[i] = r.signature()
+	}
+	return out
+}

--- a/cmd/mdp/peers_test.go
+++ b/cmd/mdp/peers_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/derekgould/multi-dev-proxy/internal/config"
+)
+
+func TestExtractPeerRefs(t *testing.T) {
+	defStr := "fallback"
+	svc := config.ServiceConfig{
+		Env: map[string]config.EnvValue{
+			"PLAIN":      {Value: "literal"},
+			"LOCAL":      {Value: "${api.port}"},
+			"REMOTE_INT": {Value: "https://localhost:${@backend.api.port}"},
+			"REMOTE_REF": {Ref: "@backend.db.env.URL"},
+			"DUP":        {Ref: "@backend.api.port", Default: &defStr},
+		},
+	}
+	got := extractPeerRefs(svc)
+
+	want := map[string]bool{
+		"@backend.api.port.port": true,
+		"@backend.db.env.URL":    true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d distinct refs, got %d: %v", len(want), len(got), peerRefSignatures(got))
+	}
+	for _, p := range got {
+		if !want[p.signature()] {
+			t.Errorf("unexpected ref %q in result", p.signature())
+		}
+	}
+}
+
+func TestExtractPeerRefsIgnoresLocal(t *testing.T) {
+	svc := config.ServiceConfig{
+		Env: map[string]config.EnvValue{
+			"X": {Ref: "api.port"}, // local, no '@'
+			"Y": {Value: "${api.port}"},
+		},
+	}
+	if got := extractPeerRefs(svc); len(got) != 0 {
+		t.Errorf("expected 0 refs (all local), got %v", peerRefSignatures(got))
+	}
+}
+
+func TestResolvePeerSucceedsAndFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("repo") == "backend" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"port": 9001,
+				"env":  map[string]string{"AUTH_TOKEN": "secret"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	got, ok := resolvePeer(http.DefaultClient, srv.URL, "dev", peerRef{repo: "backend", svc: "api", isEnv: false, key: "port"})
+	if !ok || got != "9001" {
+		t.Errorf("port lookup: got=%q ok=%v, want 9001 true", got, ok)
+	}
+
+	got, ok = resolvePeer(http.DefaultClient, srv.URL, "dev", peerRef{repo: "backend", svc: "api", isEnv: true, key: "AUTH_TOKEN"})
+	if !ok || got != "secret" {
+		t.Errorf("env lookup: got=%q ok=%v, want secret true", got, ok)
+	}
+
+	_, ok = resolvePeer(http.DefaultClient, srv.URL, "dev", peerRef{repo: "missing", svc: "api", isEnv: false, key: "port"})
+	if ok {
+		t.Error("expected 404 to return ok=false")
+	}
+}
+
+func TestWatchPeerRefsFiresOnChange(t *testing.T) {
+	var port atomic.Int64
+	port.Store(9001)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"port": port.Load(),
+			"env":  map[string]string{},
+		})
+	}))
+	defer srv.Close()
+
+	// Seed with an initial value of 9001 so the first poll is a no-op.
+	refs := []peerRef{{repo: "backend", svc: "api", key: "port", current: "9001", found: true}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	changed := make(chan []peerRef, 1)
+	go watchPeerRefs(ctx, http.DefaultClient, srv.URL, "dev", refs, 20*time.Millisecond, changed)
+
+	// Confirm watcher does NOT fire while the value is unchanged.
+	select {
+	case <-changed:
+		t.Fatal("watcher fired on unchanged value")
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	// Flip the port; watcher should fire.
+	port.Store(9999)
+
+	select {
+	case got := <-changed:
+		if got[0].current != "9999" {
+			t.Errorf("updated current = %q, want 9999", got[0].current)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not fire after value changed")
+	}
+}
+
+func TestNewPeerResolverIntegratesWithEnvexpand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"port": 9001,
+			"env":  map[string]string{"URL": "http://backend"},
+		})
+	}))
+	defer srv.Close()
+
+	resolver := newPeerResolver(http.DefaultClient, srv.URL, "dev")
+	if val, ok := resolver("backend", "api", false, "port"); !ok || val != "9001" {
+		t.Errorf("port: got=%q ok=%v", val, ok)
+	}
+	if val, ok := resolver("backend", "api", true, "URL"); !ok || val != "http://backend" {
+		t.Errorf("env: got=%q ok=%v", val, ok)
+	}
+}

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -153,7 +153,7 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 			envProtocols := svc.EnvProtocols()
 			portAssignments := make(map[string]int)
 			for envName, value := range svc.Env {
-				if value == "auto" {
+				if value.Ref == "" && value.Value == "auto" {
 					finder := ports.FindFreePort
 					if envProtocols[envName] == "udp" {
 						finder = ports.FindFreeUDPPort
@@ -187,7 +187,20 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 		allocations = append(allocations, batchAlloc{name: name, svc: svc, svcGroup: svcGroup, assignedPort: assignedPort})
 	}
 
-	if err := exportBatchEnvFiles(cfg, allocations, portMap); err != nil {
+	repo := detect.DetectRepo(filepath.Dir(configPath))
+
+	// Build a resolver per allocation so that services with a `group:` override
+	// query the orchestrator under their own group, not the workspace's
+	// top-level group. The watcher already keys on a.svcGroup, so a mismatched
+	// startup resolver would silently produce stale env values that never
+	// self-correct.
+	allocResolvers := make([]envexpand.Resolver, len(allocations))
+	for i := range allocations {
+		allocResolvers[i] = newPeerResolver(client, controlURL, allocations[i].svcGroup)
+	}
+	globalResolver := newPeerResolver(client, controlURL, group)
+
+	if err := exportBatchEnvFiles(cfg, allocations, portMap, allocResolvers, globalResolver); err != nil {
 		return err
 	}
 
@@ -201,9 +214,9 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 	states := depwait.NewStates(names)
 
 	rt := defaultBatchRuntime()
-	for _, a := range allocations {
+	for i := range allocations {
 		bt.wg.Add(1)
-		go launchBatchService(batchCtx, bt, client, controlURL, clientID, a, states, rt)
+		go launchBatchService(batchCtx, bt, client, controlURL, clientID, repo, &allocations[i], states, rt, portMap, allocResolvers[i])
 	}
 
 	slog.Info("batch services started", "group", group)
@@ -259,14 +272,20 @@ type batchAlloc struct {
 // service's declared dependencies, registers upstreams with the orchestrator,
 // starts the process, polls TCP readiness, and signals its depwait.State.
 // Runs inside bt.wg so shutdown blocks until each service's cmd exits.
+//
+// If the service references cross-repo peers via @<repo>.<svc>... refs, this
+// function also supervises peer state and restarts the cmd whenever a watched
+// peer's port or env value changes.
 func launchBatchService(
 	ctx context.Context,
 	bt *batchTracker,
 	client *http.Client,
-	controlURL, clientID string,
-	a batchAlloc,
+	controlURL, clientID, repo string,
+	a *batchAlloc,
 	states map[string]*depwait.State,
 	rt batchRuntime,
+	portMap envexpand.PortMap,
+	resolver envexpand.Resolver,
 ) {
 	defer bt.wg.Done()
 	state := states[a.name]
@@ -327,13 +346,16 @@ func launchBatchService(
 
 	registerAll := func() ([]string, error) {
 		registered := make([]string, 0, len(registrations))
+		envMap := envSliceToMap(a.env)
 		for _, r := range registrations {
 			payload := map[string]any{
 				"name":      r.serverName,
 				"port":      r.port,
 				"proxyPort": r.proxyPort,
 				"group":     a.svcGroup,
+				"repo":      repo,
 				"clientID":  clientID,
+				"env":       envMap,
 			}
 			if a.svc.Scheme != "" {
 				payload["scheme"] = a.svc.Scheme
@@ -444,12 +466,11 @@ func launchBatchService(
 		}
 	}
 
-	// Signal dependents now; the rest of this goroutine just drains the cmd.
+	// Signal dependents now; the rest of this goroutine just drains the cmd
+	// and (if this service has cross-repo peers) restarts it on peer change.
 	signalReady()
 
-	if waitErr := cmd.Wait(); waitErr != nil {
-		slog.Error("service process exited", "name", a.name, "command", a.svc.Command, "err", waitErr)
-	}
+	superviseProcess(ctx, cmd, bt, client, controlURL, a, registered, registerAll, portMap, resolver, pw, pwErr)
 
 	for i, raw := range a.svc.Shutdown {
 		parts, err := orchestrator.SplitHookArgs(raw)
@@ -463,7 +484,7 @@ func launchBatchService(
 		slog.Info("service hook", "name", a.name, "phase", "shutdown", "step", i+1, "cmd", raw)
 		hCtx, hCancel := context.WithTimeout(context.Background(), shutdownHookTimeout)
 		h := exec.CommandContext(hCtx, parts[0], parts[1:]...)
-		h.Env = append(os.Environ(), env...)
+		h.Env = append(os.Environ(), a.env...)
 		if a.svc.Dir != "" {
 			h.Dir = a.svc.Dir
 		}
@@ -481,20 +502,133 @@ func launchBatchService(
 
 const shutdownHookTimeout = 30 * time.Second
 
-// buildBatchEnv builds the environment for a batch-mode service.
-func buildBatchEnv(a batchAlloc, portMap envexpand.PortMap) ([]string, error) {
+// peerWatchInterval is how often supervisor goroutines poll the orchestrator
+// for cross-repo peer state changes. Package-level so tests can shorten it.
+var peerWatchInterval = 2 * time.Second
+
+// superviseProcess waits for cmd to exit, restarting it whenever a watched
+// cross-repo peer's port or env value changes. Returns when the cmd exits
+// without a peer-triggered restart, or when ctx is cancelled.
+func superviseProcess(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	bt *batchTracker,
+	client *http.Client,
+	controlURL string,
+	a *batchAlloc,
+	registered []string,
+	registerAll func() ([]string, error),
+	portMap envexpand.PortMap,
+	resolver envexpand.Resolver,
+	pw, pwErr *prefixWriter,
+) {
+	peerRefs := extractPeerRefs(a.svc)
+	// Seed peerRefs with the values we resolved at startup so the watcher
+	// only fires on a *change*, not on first sight.
+	if len(peerRefs) > 0 {
+		_, peerRefs = refreshPeerRefs(client, controlURL, a.svcGroup, peerRefs)
+	}
+
+	for {
+		watchCtx, watchCancel := context.WithCancel(ctx)
+		peerCh := make(chan []peerRef, 1)
+		if len(peerRefs) > 0 {
+			go watchPeerRefs(watchCtx, client, controlURL, a.svcGroup, peerRefs, peerWatchInterval, peerCh)
+		}
+
+		cmdExit := make(chan error, 1)
+		go func(c *exec.Cmd) { cmdExit <- c.Wait() }(cmd)
+
+		var restart bool
+		select {
+		case <-ctx.Done():
+			watchCancel()
+			cmd.Process.Signal(syscall.SIGTERM)
+			<-cmdExit
+		case waitErr := <-cmdExit:
+			watchCancel()
+			if waitErr != nil {
+				slog.Error("service process exited", "name", a.name, "command", a.svc.Command, "err", waitErr)
+			}
+		case updated := <-peerCh:
+			watchCancel()
+			slog.Info("peer changed; restarting service", "name", a.name)
+			cmd.Process.Signal(syscall.SIGTERM)
+			select {
+			case <-cmdExit:
+			case <-time.After(5 * time.Second):
+				cmd.Process.Kill()
+				<-cmdExit
+			}
+			peerRefs = updated
+			restart = true
+		}
+
+		if !restart {
+			return
+		}
+
+		newEnv, err := buildBatchEnv(*a, portMap, resolver)
+		if err != nil {
+			slog.Error("rebuild env failed; not restarting", "name", a.name, "err", err)
+			return
+		}
+		a.env = newEnv
+		if a.svc.EnvFile != "" {
+			if err := envexport.WritePerService(a.svc.EnvFile, newEnv); err != nil {
+				slog.Warn("rewrite env file failed", "name", a.name, "err", err)
+			}
+		}
+		if _, err := registerAll(); err != nil {
+			slog.Error("re-register failed; not restarting", "name", a.name, "err", err)
+			return
+		}
+		newCmd, err := startBatchCommand(bt, a.svc.Command, a.svc.Dir, newEnv, pw, pwErr)
+		if err != nil {
+			slog.Error("restart failed", "name", a.name, "err", err)
+			return
+		}
+		for _, sn := range registered {
+			updatePIDWithOrchestrator(controlURL, sn, newCmd.Process.Pid)
+		}
+		cmd = newCmd
+	}
+}
+
+// buildBatchEnv builds the environment for a batch-mode service. resolver is
+// invoked for cross-repo @-references; pass nil to forbid them (any @ ref
+// without an inline default will then error).
+func buildBatchEnv(a batchAlloc, portMap envexpand.PortMap, resolver envexpand.Resolver) ([]string, error) {
 	env := []string{"MDP=1"}
 	if len(a.svc.Ports) == 0 && a.assignedPort > 0 {
 		env = append(env, fmt.Sprintf("PORT=%d", a.assignedPort))
 	}
-	for k, v := range a.svc.Env {
-		if v == "auto" {
+	for k, entry := range a.svc.Env {
+		if entry.Ref != "" {
+			val, err := envexpand.LookupRefWith(entry.Ref, entry.DefaultValue(), entry.HasDefault(), portMap, nil, resolver)
+			if err != nil {
+				if entry.HasDefault() {
+					env = append(env, k+"="+entry.DefaultValue())
+					continue
+				}
+				if envexpand.IsCrossRepoBareRef(entry.Ref) {
+					// Cross-repo peer not running and no default — omit
+					// (graceful degradation per user spec).
+					slog.Warn("peer ref unresolved; omitting env var", "service", a.name, "key", k, "ref", entry.Ref)
+					continue
+				}
+				return nil, fmt.Errorf("env %s.%s: %w", a.name, k, err)
+			}
+			env = append(env, k+"="+val)
+			continue
+		}
+		if entry.Value == "auto" {
 			if port, ok := a.portAssignments[k]; ok {
 				env = append(env, fmt.Sprintf("%s=%d", k, port))
 			}
 			continue
 		}
-		expanded, err := envexpand.Expand(v, portMap)
+		expanded, err := envexpand.ExpandWith(entry.Value, portMap, nil, resolver)
 		if err != nil {
 			return nil, fmt.Errorf("env expansion for %s.%s: %w", a.name, k, err)
 		}
@@ -506,10 +640,20 @@ func buildBatchEnv(a batchAlloc, portMap envexpand.PortMap) ([]string, error) {
 // exportBatchEnvFiles builds each allocation's env up front and writes the
 // global + per-service env files before any service launches. Env is stored
 // on allocations[i].env for the launch goroutine to consume.
-func exportBatchEnvFiles(cfg *config.Config, allocations []batchAlloc, portMap envexpand.PortMap) error {
+//
+// allocResolvers[i] is the cross-repo @-ref resolver for allocations[i] (built
+// from that allocation's own group so a per-service `group:` override resolves
+// against the right peers). globalResolver is used for global env entries,
+// which sit at the workspace level and use the top-level group. Either may be
+// nil to disable cross-repo resolution.
+func exportBatchEnvFiles(cfg *config.Config, allocations []batchAlloc, portMap envexpand.PortMap, allocResolvers []envexpand.Resolver, globalResolver envexpand.Resolver) error {
 	envMap := envexpand.EnvMap{}
 	for i, a := range allocations {
-		env, err := buildBatchEnv(a, portMap)
+		var r envexpand.Resolver
+		if i < len(allocResolvers) {
+			r = allocResolvers[i]
+		}
+		env, err := buildBatchEnv(a, portMap, r)
 		if err != nil {
 			return err
 		}
@@ -517,7 +661,7 @@ func exportBatchEnvFiles(cfg *config.Config, allocations []batchAlloc, portMap e
 		envMap[a.name] = envSliceToMap(env)
 	}
 	if cfg.Global.EnvFile != "" {
-		if err := envexport.WriteGlobal(cfg.Global.EnvFile, cfg.Global.Env, portMap, envMap); err != nil {
+		if err := envexport.WriteGlobalWith(cfg.Global.EnvFile, cfg.Global.Env, portMap, envMap, globalResolver); err != nil {
 			return fmt.Errorf("write global env file: %w", err)
 		}
 	}
@@ -567,24 +711,24 @@ func startBatchCommand(bt *batchTracker, command, dir string, env []string, stdo
 }
 
 var serviceColors = []string{
-	"1;34",  // blue
-	"1;32",  // green
-	"1;35",  // purple
-	"1;33",  // yellow
-	"1;31",  // red
-	"0;96",  // teal
-	"1;95",  // pink
-	"1;36",  // cyan
-	"0;93",  // bright yellow
-	"0;92",  // bright green
-	"0;94",  // bright blue
-	"0;91",  // bright red
-	"0;95",  // bright magenta
-	"0;33",  // dark yellow / orange
-	"0;35",  // dark magenta
-	"0;36",  // dark cyan
-	"0;34",  // dark blue
-	"0;32",  // dark green
+	"1;34",     // blue
+	"1;32",     // green
+	"1;35",     // purple
+	"1;33",     // yellow
+	"1;31",     // red
+	"0;96",     // teal
+	"1;95",     // pink
+	"1;36",     // cyan
+	"0;93",     // bright yellow
+	"0;92",     // bright green
+	"0;94",     // bright blue
+	"0;91",     // bright red
+	"0;95",     // bright magenta
+	"0;33",     // dark yellow / orange
+	"0;35",     // dark magenta
+	"0;36",     // dark cyan
+	"0;34",     // dark blue
+	"0;32",     // dark green
 	"38;5;208", // orange 256-color
 	"38;5;171", // orchid
 	"38;5;81",  // sky blue

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -223,9 +223,9 @@ func TestLaunchBatchServiceSkipsUDPPortsFromProbe(t *testing.T) {
 		svcGroup: "main",
 		svc: config.ServiceConfig{
 			// Commandless → external service code path.
-			Env: map[string]string{
-				"API_PORT":          "auto",
-				"JAEGER_AGENT_PORT": "auto",
+			Env: map[string]config.EnvValue{
+				"API_PORT":          {Value: "auto"},
+				"JAEGER_AGENT_PORT": {Value: "auto"},
 			},
 			Ports: []config.PortMapping{
 				{Env: "API_PORT", Proxy: 4000, Name: "api"},
@@ -239,7 +239,7 @@ func TestLaunchBatchServiceSkipsUDPPortsFromProbe(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"infra"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", a, states, rt)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
 
 	probeMu.Lock()
 	defer probeMu.Unlock()
@@ -286,9 +286,9 @@ func TestLaunchBatchServiceSkipsProxylessPorts(t *testing.T) {
 		svcGroup: "main",
 		svc: config.ServiceConfig{
 			// Command empty → no process launched.
-			Env: map[string]string{
-				"API_PORT": "auto",
-				"DB_PORT":  "auto",
+			Env: map[string]config.EnvValue{
+				"API_PORT": {Value: "auto"},
+				"DB_PORT":  {Value: "auto"},
 			},
 			Ports: []config.PortMapping{
 				{Env: "API_PORT", Proxy: 4000, Name: "api"},
@@ -301,7 +301,7 @@ func TestLaunchBatchServiceSkipsProxylessPorts(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"infra"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", a, states, rt)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
 
 	registerMu.Lock()
 	defer registerMu.Unlock()
@@ -373,7 +373,7 @@ func TestLaunchBatchServiceWaitsForDependencies(t *testing.T) {
 
 	for _, a := range allocs {
 		bt.wg.Add(1)
-		go launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", a, states, rt)
+		go launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
 	}
 
 	waitFor := func(name string, dur time.Duration) bool {
@@ -443,7 +443,7 @@ func TestLaunchBatchServiceReturnsOnContextCancel(t *testing.T) {
 	bt.wg.Add(1)
 	done := make(chan struct{})
 	go func() {
-		launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", a, states, rt)
+		launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
 		close(done)
 	}()
 
@@ -500,7 +500,7 @@ func TestLaunchBatchServiceHookOrdering(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"web"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", a, states, rt)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -553,7 +553,7 @@ func TestLaunchBatchServiceSetupFailureSkipsRegistration(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"web"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", a, states, rt)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
 
 	regMu.Lock()
 	defer regMu.Unlock()
@@ -692,6 +692,169 @@ func TestRunProxiedSetsMDPEnv(t *testing.T) {
 	}
 }
 
+func TestBuildBatchEnvCrossRepoResolverHits(t *testing.T) {
+	resolver := func(repo, svc string, isEnv bool, key string) (string, bool) {
+		if repo == "backend" && svc == "api" && !isEnv && key == "port" {
+			return "9999", true
+		}
+		if repo == "backend" && svc == "api" && isEnv && key == "URL" {
+			return "http://backend", true
+		}
+		return "", false
+	}
+	a := batchAlloc{
+		name:         "frontend",
+		svcGroup:     "test",
+		assignedPort: 3000,
+		svc: config.ServiceConfig{
+			Env: map[string]config.EnvValue{
+				"API_URL":     {Value: "http://localhost:${@backend.api.port}"},
+				"AUTH":        {Ref: "@backend.api.env.URL"},
+				"FALLBACK":    {Value: "${@backend.unknown.port:-7777}"},
+				"OMIT":        {Ref: "@backend.unknown.port"},
+				"OMIT_INTERP": {Value: "x=${@backend.unknown.env.X:-}"},
+			},
+		},
+	}
+	env, err := buildBatchEnv(a, envexpand.PortMap{}, resolver)
+	if err != nil {
+		t.Fatalf("buildBatchEnv: %v", err)
+	}
+	got := map[string]string{}
+	for _, kv := range env {
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			got[kv[:i]] = kv[i+1:]
+		}
+	}
+	if got["API_URL"] != "http://localhost:9999" {
+		t.Errorf("API_URL = %q", got["API_URL"])
+	}
+	if got["AUTH"] != "http://backend" {
+		t.Errorf("AUTH = %q", got["AUTH"])
+	}
+	if got["FALLBACK"] != "7777" {
+		t.Errorf("FALLBACK = %q", got["FALLBACK"])
+	}
+	if _, exists := got["OMIT"]; exists {
+		t.Errorf("OMIT should be omitted; got %q", got["OMIT"])
+	}
+	if got["OMIT_INTERP"] != "x=" {
+		t.Errorf("OMIT_INTERP = %q, want x=", got["OMIT_INTERP"])
+	}
+}
+
+func TestSuperviseProcessRestartsOnPeerChange(t *testing.T) {
+	// Stand up a fake control API that returns a port we can flip.
+	var port atomic.Int64
+	port.Store(9001)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/__mdp/peers" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"port": port.Load(),
+				"env":  map[string]string{},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Speed up the watcher so the test stays fast.
+	prev := peerWatchInterval
+	peerWatchInterval = 20 * time.Millisecond
+	t.Cleanup(func() { peerWatchInterval = prev })
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "log")
+	// `exec sleep` replaces the shell so SIGKILL targets the sleep directly,
+	// otherwise cmd.Wait blocks on the inherited stdout pipe until sleep exits.
+	command := "sh -c 'echo $TARGET_PORT >> " + logPath + "; exec sleep 60'"
+
+	a := &batchAlloc{
+		name:     "frontend",
+		svcGroup: "dev",
+		svc: config.ServiceConfig{
+			Command: command,
+			Env: map[string]config.EnvValue{
+				"TARGET_PORT": {Ref: "@backend.api.port"},
+			},
+		},
+	}
+	resolver := newPeerResolver(http.DefaultClient, srv.URL, "dev")
+	initialEnv, err := buildBatchEnv(*a, envexpand.PortMap{}, resolver)
+	if err != nil {
+		t.Fatalf("initial env: %v", err)
+	}
+	a.env = initialEnv
+
+	bt := &batchTracker{}
+	pw := newPrefixWriter("test", "0;0", os.Stdout)
+	pwErr := newPrefixWriter("test", "0;0", os.Stderr)
+	cmd, err := startBatchCommand(bt, command, "", initialEnv, pw, pwErr)
+	if err != nil {
+		t.Fatalf("startBatchCommand: %v", err)
+	}
+
+	registerAll := func() ([]string, error) { return nil, nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		superviseProcess(ctx, cmd, bt, http.DefaultClient, srv.URL, a, nil, registerAll, envexpand.PortMap{}, resolver, pw, pwErr)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+		bt.killAll()
+		bt.wg.Wait()
+	})
+
+	// Wait for the initial run to write 9001.
+	waitFor := func(want string, dur time.Duration) bool {
+		deadline := time.Now().Add(dur)
+		for time.Now().Before(deadline) {
+			data, _ := os.ReadFile(logPath)
+			if strings.Contains(string(data), want) {
+				return true
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return false
+	}
+	if !waitFor("9001", 2*time.Second) {
+		t.Fatalf("initial cmd never wrote 9001; log=%q", readFile(t, logPath))
+	}
+
+	// Flip the peer port; the supervisor should kill the cmd and relaunch
+	// with TARGET_PORT=9999.
+	port.Store(9999)
+
+	if !waitFor("9999", 3*time.Second) {
+		t.Fatalf("restart cmd never wrote 9999; log=%q", readFile(t, logPath))
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, _ := os.ReadFile(path)
+	return string(data)
+}
+
+func TestBuildBatchEnvLocalRefMissingErrors(t *testing.T) {
+	a := batchAlloc{
+		name: "x",
+		svc: config.ServiceConfig{
+			Env: map[string]config.EnvValue{
+				"BAD": {Ref: "nope.port"}, // local; not present in portMap
+			},
+		},
+	}
+	if _, err := buildBatchEnv(a, envexpand.PortMap{}, nil); err == nil {
+		t.Fatal("expected error for unresolved local ref")
+	}
+}
+
 func TestExportBatchEnvFilesWritesGlobalAndPerService(t *testing.T) {
 	tmp := t.TempDir()
 	globalPath := filepath.Join(tmp, "global.env")
@@ -701,7 +864,7 @@ func TestExportBatchEnvFilesWritesGlobalAndPerService(t *testing.T) {
 	cfg := &config.Config{
 		Global: config.GlobalConfig{
 			EnvFile: globalPath,
-			Env: map[string]config.GlobalEnvValue{
+			Env: map[string]config.EnvValue{
 				"API_PORT": {Ref: "api.env.PORT"},
 				"API_URL":  {Value: "http://localhost:${api.PORT}"},
 				"WEB_MODE": {Ref: "web.env.MODE"},
@@ -716,7 +879,7 @@ func TestExportBatchEnvFilesWritesGlobalAndPerService(t *testing.T) {
 			assignedPort: 40100,
 			svc: config.ServiceConfig{
 				EnvFile: apiEnvPath,
-				Env:     map[string]string{"NAME": "api"},
+				Env:     map[string]config.EnvValue{"NAME": {Value: "api"}},
 			},
 		},
 		{
@@ -725,7 +888,7 @@ func TestExportBatchEnvFilesWritesGlobalAndPerService(t *testing.T) {
 			assignedPort: 40101,
 			svc: config.ServiceConfig{
 				EnvFile: webEnvPath,
-				Env:     map[string]string{"MODE": "dev"},
+				Env:     map[string]config.EnvValue{"MODE": {Value: "dev"}},
 			},
 		},
 	}
@@ -734,7 +897,7 @@ func TestExportBatchEnvFilesWritesGlobalAndPerService(t *testing.T) {
 		"web": {"port": 40101, "PORT": 40101},
 	}
 
-	if err := exportBatchEnvFiles(cfg, allocations, portMap); err != nil {
+	if err := exportBatchEnvFiles(cfg, allocations, portMap, nil, nil); err != nil {
 		t.Fatalf("exportBatchEnvFiles: %v", err)
 	}
 
@@ -788,10 +951,10 @@ func TestExportBatchEnvFilesSkipsWhenNoEnvFile(t *testing.T) {
 			name:         "api",
 			svcGroup:     "test",
 			assignedPort: 40200,
-			svc:          config.ServiceConfig{Env: map[string]string{"X": "y"}},
+			svc:          config.ServiceConfig{Env: map[string]config.EnvValue{"X": {Value: "y"}}},
 		},
 	}
-	if err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{}); err != nil {
+	if err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{}, nil, nil); err != nil {
 		t.Fatalf("exportBatchEnvFiles: %v", err)
 	}
 	entries, _ := os.ReadDir(tmp)
@@ -808,7 +971,7 @@ func TestExportBatchEnvFilesPropagatesExpansionError(t *testing.T) {
 	cfg := &config.Config{
 		Global: config.GlobalConfig{
 			EnvFile: filepath.Join(tmp, "global.env"),
-			Env:     map[string]config.GlobalEnvValue{"X": {Ref: "nope.env.MISSING"}},
+			Env:     map[string]config.EnvValue{"X": {Ref: "nope.env.MISSING"}},
 		},
 	}
 	allocations := []batchAlloc{
@@ -816,14 +979,79 @@ func TestExportBatchEnvFilesPropagatesExpansionError(t *testing.T) {
 			name:         "api",
 			svcGroup:     "test",
 			assignedPort: 40300,
-			svc:          config.ServiceConfig{Env: map[string]string{"A": "b"}},
+			svc:          config.ServiceConfig{Env: map[string]config.EnvValue{"A": {Value: "b"}}},
 		},
 	}
-	err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{"api": {"port": 40300, "PORT": 40300}})
+	err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{"api": {"port": 40300, "PORT": 40300}}, nil, nil)
 	if err == nil {
 		t.Fatal("expected error from unresolved ref")
 	}
 	if !strings.Contains(err.Error(), "write global env file") {
 		t.Errorf("expected wrapped global env file error, got: %v", err)
 	}
+}
+
+// TestExportBatchEnvFilesUsesPerAllocResolver verifies that each allocation's
+// resolver is the one used to resolve its env — i.e. a service overriding its
+// `group:` resolves cross-repo refs against that override, not the workspace's
+// top-level group. Regression test for a bug where one shared resolver was
+// reused for every allocation.
+func TestExportBatchEnvFilesUsesPerAllocResolver(t *testing.T) {
+	allocations := []batchAlloc{
+		{
+			name:     "frontend",
+			svcGroup: "feature-x",
+			svc: config.ServiceConfig{
+				Env: map[string]config.EnvValue{
+					"BACKEND_PORT": {Ref: "@backend.api.port"},
+				},
+			},
+		},
+		{
+			name:     "infra",
+			svcGroup: "shared",
+			svc: config.ServiceConfig{
+				Env: map[string]config.EnvValue{
+					"BACKEND_PORT": {Ref: "@backend.api.port"},
+				},
+			},
+		},
+	}
+
+	allocResolvers := []envexpand.Resolver{
+		// frontend resolver: only finds the peer in feature-x.
+		func(repo, svc string, isEnv bool, key string) (string, bool) {
+			if repo == "backend" && svc == "api" && key == "port" {
+				return "8001", true
+			}
+			return "", false
+		},
+		// infra resolver: only finds the peer in shared.
+		func(repo, svc string, isEnv bool, key string) (string, bool) {
+			if repo == "backend" && svc == "api" && key == "port" {
+				return "9001", true
+			}
+			return "", false
+		},
+	}
+
+	if err := exportBatchEnvFiles(&config.Config{}, allocations, envexpand.PortMap{}, allocResolvers, nil); err != nil {
+		t.Fatalf("exportBatchEnvFiles: %v", err)
+	}
+
+	if !contains(allocations[0].env, "BACKEND_PORT=8001") {
+		t.Errorf("frontend env did not get its own resolver's value 8001; got: %v", allocations[0].env)
+	}
+	if !contains(allocations[1].env, "BACKEND_PORT=9001") {
+		t.Errorf("infra env did not get its own resolver's value 9001; got: %v", allocations[1].env)
+	}
+}
+
+func contains(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
 }

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -58,7 +58,7 @@ services:
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `global.env_file` | string path | `""` (none) | Aggregate `.env` file to write at startup. Relative paths resolve against the `mdp.yaml` directory. `~` is expanded. Empty = no file written. |
-| `global.env` | map of name → scalar \| `{ref: …}` | `{}` | Env vars to write to `env_file`. Scalar values support `${svc.port}` / `${svc.env.VAR}` interpolation. The mapping form `{ref: svc.port}` or `{ref: svc.env.VAR}` passes the referenced value through without string-wrapping. Any other shape is a parse error. |
+| `global.env` | map of name → scalar \| `{ref: …, default: …}` | `{}` | Env vars to write to `env_file`. Scalar values support `${svc.port}` / `${svc.env.VAR}` / `${@repo.svc...}` interpolation with optional `:-default` fallback. The mapping form takes a `ref:` (e.g. `svc.port`, `@repo.svc.port`) and an optional `default:` used when the ref cannot be resolved. |
 
 ### Writing an aggregate `.env` for external tools
 
@@ -108,7 +108,7 @@ Keys under `services.<name>`.
 | `tls_cert` | string path | `""` | TLS certificate path. Relative paths resolve against the `mdp.yaml` directory. `~` is expanded. Setting this auto-infers `scheme: https`. |
 | `tls_key` | string path | `""` | TLS key path. Paired with `tls_cert`. |
 | `env_file` | string path | `""` | Path to write this service's resolved env vars as a `.env` file. Relative paths resolve against the service's `dir` if set, else the `mdp.yaml` directory. `~` is expanded. |
-| `env` | map of name → string | `{}` | Env vars for `command`, `setup`, and `shutdown`. Values support: literal strings, `auto` (allocates a port in the corresponding `ports[]` entry), `${svc.port}` (another service's primary port), and `${svc.NAMED_PORT}` (a named port from another service's `ports[]`). `${svc.env.VAR}` is **not** supported here — it only works in `global.env`. |
+| `env` | map of name → scalar \| `{ref: …, default: …}` | `{}` | Env vars for `command`, `setup`, and `shutdown`. Scalar values support: literal strings, `auto` (allocates a port in the corresponding `ports[]` entry), `${svc.port}` / `${svc.NAMED_PORT}` (own-mdp.yaml port references), `${@repo.svc.port}` / `${@repo.svc.env.VAR}` (cross-repo lookups via the orchestrator) with optional `:-default` fallback. The mapping form takes a `ref:` (e.g. `api.port`, `@backend.api.env.URL`) plus an optional `default:`. Cross-repo refs without a default are silently omitted when the peer is not registered. |
 | `ports` | list of [port mapping](#port-mapping) | `[]` | Multi-port mode. When present, `port` is ignored and ports are allocated per entry. |
 | `depends_on` | list of service names | `[]` | Wait for each dependency to be TCP-reachable on its assigned port(s) before starting. 60s per-dependency timeout. Unknown names and cycles are rejected at config load. |
 | `health_check` | [health check](#health_check) \| `"docker"` | nil (TCP on `port`) | Liveness probe used by the registry pruner. When unset, the default is a TCP dial of the service's registered port. See [Detached services and health checks](#detached-services-and-health-checks). |
@@ -439,9 +439,9 @@ global:
     ADMIN_TOKEN: "${api.env.ADMIN_TOKEN}"
 ```
 
-### `ref:` mapping form (global only)
+### `ref:` mapping form
 
-Scalar strings work in any `env`. The `ref:` mapping form is only valid inside `global.env` — use it when you want the referenced value without string-wrapping:
+Scalar strings work in any `env`. The `ref:` mapping form passes the referenced value through without string-wrapping. It works in both `global.env` and per-service `env`:
 
 ```yaml
 global:
@@ -457,7 +457,38 @@ global:
       ref: api.env.ADMIN_TOKEN
 ```
 
-Using `ref:` inside a service-level `env` is a parse error.
+### Cross-repo `@<repo>` references
+
+`mdp run` instances in different repos all register with the same singleton orchestrator. To reference a service running in *another* repo, prefix the reference with `@<repo-name>.`. The lookup is implicitly scoped to the same group (typically the git branch).
+
+```yaml
+# In frontend's mdp.yaml
+services:
+  web:
+    command: npm run dev
+    env:
+      # Interpolation form with optional :-default fallback.
+      API_URL: "http://localhost:${@backend.api.port:-3001}"
+
+      # Ref form with optional default: field.
+      AUTH_TOKEN:
+        ref: "@backend.api.env.AUTH_TOKEN"
+        default: "dev-token"
+```
+
+Resolution semantics:
+
+- The frontend resolves `@backend.*` against the orchestrator at startup. Whatever the backend is registered as (port, exposed env vars), the frontend gets — *for the same group*.
+- If the peer is unresolved AND a default is provided, the default is used.
+- If the peer is unresolved AND no default is provided:
+    - For `ref:` form, the env var is silently omitted (graceful "ignored" behavior).
+    - For `${...}` interpolation form, you must supply `:-default`; otherwise it is a hard error.
+- The supervisor watches each cross-repo peer for changes. When the peer's port or any referenced env var changes (or the peer (de)registers), the dependent service is killed and relaunched with refreshed values.
+
+Notes:
+
+- `@self` and other reserved names have no special meaning — `@<repo>` is just whichever string was registered as the peer's repo (typically the basename of the directory containing the peer's `mdp.yaml`).
+- Cross-group references are not supported. The peer must be in the same group as the resolver.
 
 ## Path resolution
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,65 +22,94 @@ type GlobalConfig struct {
 	// EnvFile, if non-empty, is a path where an aggregate .env file is written
 	// at startup. Values are resolved from Env (below).
 	EnvFile string `yaml:"env_file"`
-	// Env is an explicit map of env vars to write to EnvFile. Values may be
-	// scalar strings (supporting ${svc.key} and ${svc.env.VAR} interpolation)
-	// or mappings with a single `ref:` key that pass through another service's
-	// env var or port without string-wrapping it.
-	Env map[string]GlobalEnvValue `yaml:"env"`
+	// Env is an explicit map of env vars to write to EnvFile. See EnvValue.
+	Env map[string]EnvValue `yaml:"env"`
 }
 
-// GlobalEnvValue is either a literal value (possibly with ${...} refs) or a
-// pass-through reference to another service's env var or port.
-type GlobalEnvValue struct {
-	Value string // set when the YAML entry is a scalar string
-	Ref   string // set when the YAML entry is a mapping with `ref:`
+// EnvValue is one entry in either a global or per-service `env:` map.
+//
+// In YAML it accepts two shapes:
+//   - a scalar string — placed in Value and treated as a literal (with ${...}
+//     interpolation applied at resolve time)
+//   - a mapping with `ref:` and optional `default:` keys — placed in Ref
+//     (a bare reference like "svc.port" or "@repo.svc.env.VAR") and Default
+//     (used as a fallback when ref cannot be resolved)
+type EnvValue struct {
+	Value   string  // set when the YAML entry is a scalar string
+	Ref     string  // set when the YAML entry is a mapping with `ref:`
+	Default *string // optional fallback used when Ref cannot be resolved (nil = absent)
 }
 
-// UnmarshalYAML accepts either a scalar string or a mapping with a single
-// `ref:` key. Any other shape is a parse error so typos surface early.
-func (g *GlobalEnvValue) UnmarshalYAML(node *yaml.Node) error {
+// UnmarshalYAML accepts either a scalar string or a mapping with `ref:` and
+// optional `default:` keys. Any other shape is a parse error so typos surface
+// early.
+func (g *EnvValue) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.ScalarNode:
 		g.Value = node.Value
 		return nil
 	case yaml.MappingNode:
-		if len(node.Content) != 2 {
-			return fmt.Errorf("line %d: global env mapping must have exactly one key (`ref`)", node.Line)
+		var sawRef bool
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			keyNode := node.Content[i]
+			valNode := node.Content[i+1]
+			switch keyNode.Value {
+			case "ref":
+				var refStr string
+				if err := valNode.Decode(&refStr); err != nil {
+					return fmt.Errorf("line %d: `ref:` value must be a string: %w", valNode.Line, err)
+				}
+				if refStr == "" {
+					return fmt.Errorf("line %d: `ref:` value must not be empty", valNode.Line)
+				}
+				g.Ref = refStr
+				sawRef = true
+			case "default":
+				var defStr string
+				if err := valNode.Decode(&defStr); err != nil {
+					return fmt.Errorf("line %d: `default:` value must be a string: %w", valNode.Line, err)
+				}
+				g.Default = &defStr
+			default:
+				return fmt.Errorf("line %d: unknown key %q in env entry (only `ref` and `default` are supported)", keyNode.Line, keyNode.Value)
+			}
 		}
-		key := node.Content[0].Value
-		if key != "ref" {
-			return fmt.Errorf("line %d: unknown key %q in global env entry (only `ref` is supported)", node.Line, key)
+		if !sawRef {
+			return fmt.Errorf("line %d: env mapping must include `ref:`", node.Line)
 		}
-		val := node.Content[1]
-		var refStr string
-		if err := val.Decode(&refStr); err != nil {
-			return fmt.Errorf("line %d: `ref:` value must be a string: %w", val.Line, err)
-		}
-		if refStr == "" {
-			return fmt.Errorf("line %d: `ref:` value must not be empty", val.Line)
-		}
-		g.Ref = refStr
 		return nil
 	default:
-		return fmt.Errorf("line %d: global env entry must be a string or mapping with `ref:`", node.Line)
+		return fmt.Errorf("line %d: env entry must be a string or mapping with `ref:`", node.Line)
 	}
+}
+
+// HasDefault reports whether a fallback was explicitly set in YAML.
+func (g EnvValue) HasDefault() bool { return g.Default != nil }
+
+// DefaultValue returns the fallback string, or "" if no default was set.
+// Use HasDefault to distinguish the absent case.
+func (g EnvValue) DefaultValue() string {
+	if g.Default == nil {
+		return ""
+	}
+	return *g.Default
 }
 
 // ServiceConfig defines a single service in the config file.
 type ServiceConfig struct {
-	Command  string            `yaml:"command"`
-	Setup    []string          `yaml:"setup"`    // commands run sequentially before Command
-	Shutdown []string          `yaml:"shutdown"` // commands run sequentially after Command exits
-	Dir      string            `yaml:"dir"`
-	Proxy    int               `yaml:"proxy"`
-	Port     int               `yaml:"port"`
-	Group    string            `yaml:"group"`
-	Scheme   string            `yaml:"scheme"`   // "http" or "https"; defaults to "http"
-	TLSCert  string            `yaml:"tls_cert"` // path to TLS certificate file
-	TLSKey   string            `yaml:"tls_key"`  // path to TLS key file
-	EnvFile  string            `yaml:"env_file"` // optional path for exported .env file
-	Env      map[string]string `yaml:"env"`
-	Ports    []PortMapping     `yaml:"ports"`
+	Command  string              `yaml:"command"`
+	Setup    []string            `yaml:"setup"`    // commands run sequentially before Command
+	Shutdown []string            `yaml:"shutdown"` // commands run sequentially after Command exits
+	Dir      string              `yaml:"dir"`
+	Proxy    int                 `yaml:"proxy"`
+	Port     int                 `yaml:"port"`
+	Group    string              `yaml:"group"`
+	Scheme   string              `yaml:"scheme"`   // "http" or "https"; defaults to "http"
+	TLSCert  string              `yaml:"tls_cert"` // path to TLS certificate file
+	TLSKey   string              `yaml:"tls_key"`  // path to TLS key file
+	EnvFile  string              `yaml:"env_file"` // optional path for exported .env file
+	Env      map[string]EnvValue `yaml:"env"`
+	Ports    []PortMapping       `yaml:"ports"`
 
 	// DependsOn names other services that must be ready before this service
 	// starts. Names must match keys in the top-level services map.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,7 +42,7 @@ services:
 	if fe.Dir != expectedDir {
 		t.Errorf("frontend dir = %q, want %q", fe.Dir, expectedDir)
 	}
-	if fe.Env["NEXT_PUBLIC_API_URL"] != "https://localhost:4000" {
+	if fe.Env["NEXT_PUBLIC_API_URL"].Value != "https://localhost:4000" {
 		t.Errorf("frontend env = %v", fe.Env)
 	}
 }
@@ -504,18 +504,55 @@ func TestLoadGlobalEnvRejectsEmptyRef(t *testing.T) {
 	}
 }
 
-func TestLoadGlobalEnvRejectsExtraKeys(t *testing.T) {
+func TestLoadGlobalEnvAcceptsRefAndDefault(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mdp.yaml")
 	os.WriteFile(path, []byte(`
 global:
   env:
     FOO:
-      ref: api.env.PORT
-      default: 1234
+      ref: "@backend.api.port"
+      default: "1234"
 `), 0644)
-	if _, err := Load(path); err == nil {
-		t.Fatal("expected error for extra key, got nil")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := cfg.Global.Env["FOO"]
+	if got.Ref != "@backend.api.port" {
+		t.Errorf("ref = %q", got.Ref)
+	}
+	if !got.HasDefault() || got.DefaultValue() != "1234" {
+		t.Errorf("default = %v / %q", got.HasDefault(), got.DefaultValue())
+	}
+}
+
+func TestLoadServiceEnvAcceptsRefAndDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  frontend:
+    command: ./serve
+    env:
+      API_URL:
+        ref: "@backend.api.env.URL"
+        default: "http://localhost:3001"
+      PLAIN: "literal value"
+`), 0644)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fe := cfg.Services["frontend"]
+	if fe.Env["API_URL"].Ref != "@backend.api.env.URL" {
+		t.Errorf("ref = %q", fe.Env["API_URL"].Ref)
+	}
+	if fe.Env["API_URL"].DefaultValue() != "http://localhost:3001" {
+		t.Errorf("default = %q", fe.Env["API_URL"].DefaultValue())
+	}
+	if fe.Env["PLAIN"].Value != "literal value" {
+		t.Errorf("plain = %q", fe.Env["PLAIN"].Value)
 	}
 }
 

--- a/internal/envexpand/envexpand.go
+++ b/internal/envexpand/envexpand.go
@@ -1,5 +1,6 @@
-// Package envexpand resolves ${service.port} and ${service.env.VAR} references
-// in mdp.yaml env values.
+// Package envexpand resolves ${service.port}, ${service.env.VAR}, and
+// ${@repo.service.key} references in mdp.yaml env values, with optional
+// POSIX-style ${ref:-default} fallback syntax.
 package envexpand
 
 import (
@@ -19,60 +20,124 @@ type PortMap map[string]map[string]int
 // Used to resolve ${service.env.VAR} references.
 type EnvMap map[string]map[string]string
 
-// refPattern matches ${svc.key} (port lookup) or ${svc.env.VAR} (env var
-// lookup). Group 2 is "env." when present; group 3 is the final segment.
-var refPattern = regexp.MustCompile(`\$\{([A-Za-z0-9_-]+)\.(env\.)?([A-Za-z0-9_]+)\}`)
+// Resolver resolves a cross-repo @-reference (e.g. ${@backend.api.port}).
+// Implementations typically query the orchestrator for the named peer's port
+// or env var. Returns (value, true) on success; (zero, false) if the peer is
+// not available — the caller then uses the inline :-default if present, or
+// records an unresolved-reference error.
+type Resolver func(repo, svc string, isEnv bool, key string) (string, bool)
 
-// bareRefPattern is refPattern without the ${} wrapping, anchored, for
-// validating the bare ref form accepted by LookupRef.
-var bareRefPattern = regexp.MustCompile(`^([A-Za-z0-9_-]+)\.(env\.)?([A-Za-z0-9_]+)$`)
+// refPattern matches the ${...} reference forms accepted in env values:
+//
+//	${svc.key}, ${svc.env.VAR}, ${@repo.svc.key}, ${@repo.svc.env.VAR}
+//
+// each optionally followed by :-default fallback text (anything up to '}').
+//
+//	group 2: repo name (without leading '@'), or empty for local refs
+//	group 3: service name
+//	group 4: literal "env." marker (empty for port refs)
+//	group 5: key (port name or env-var name)
+//	group 6: raw ":-default" (empty when no fallback)
+//	group 7: default text only
+var refPattern = regexp.MustCompile(`\$\{(@([A-Za-z0-9_-]+)\.)?([A-Za-z0-9_-]+)\.(env\.)?([A-Za-z0-9_]+)(:-([^}]*))?\}`)
 
-// Expand replaces ${service.key} port references in value using pm. It does
-// NOT resolve ${service.env.VAR} — any such reference is an error. Use
-// ExpandAll when env-var references are allowed.
+// bareRefPattern is refPattern without the ${} wrapping or :-default support,
+// anchored, for validating the bare ref form accepted by LookupRef.
+var bareRefPattern = regexp.MustCompile(`^(@([A-Za-z0-9_-]+)\.)?([A-Za-z0-9_-]+)\.(env\.)?([A-Za-z0-9_]+)$`)
+
+// Expand replaces ${service.key} port references in value using pm. Env-var
+// references and cross-repo @-references are not permitted; either is treated
+// as unresolved unless an inline :-default is supplied.
 func Expand(value string, pm PortMap) (string, error) {
-	return ExpandAll(value, pm, nil)
+	return expandInternal(value, pm, nil, nil)
 }
 
 // ExpandAll replaces every ${svc.key} or ${svc.env.VAR} reference in value.
 // - ${svc.key} resolves via pm (port lookup). Key "port" falls back to "PORT".
-// - ${svc.env.VAR} resolves via em. A nil em disables env-var lookups and any
-//   such reference is treated as unresolved.
-// Returns an error if any reference cannot be resolved.
+// - ${svc.env.VAR} resolves via em. A nil em rejects env-var references.
+// Cross-repo @-references are not resolved here; use ExpandWith for those.
+// Inline :-default fallbacks substitute when the underlying reference is
+// unresolved.
 func ExpandAll(value string, pm PortMap, em EnvMap) (string, error) {
+	return expandInternal(value, pm, em, nil)
+}
+
+// ExpandWith is the most permissive form: it accepts all reference shapes,
+// including cross-repo @-references that the supplied resolver looks up.
+// A nil resolver makes @-references behave the same as in ExpandAll (rejected
+// unless an inline :-default is present).
+func ExpandWith(value string, pm PortMap, em EnvMap, resolver Resolver) (string, error) {
+	return expandInternal(value, pm, em, resolver)
+}
+
+// LookupRef resolves a single bare reference string (no ${} wrapping) of the
+// form "svc.key" or "svc.env.VAR". Used to implement the `ref:` config form.
+func LookupRef(ref string, pm PortMap, em EnvMap) (string, error) {
+	return LookupRefWith(ref, "", false, pm, em, nil)
+}
+
+// LookupRefWith resolves a bare reference, optionally substituting fallback
+// when the reference cannot be resolved. resolver handles "@repo.svc.key"
+// refs; pass nil to reject them.
+func LookupRefWith(ref, fallback string, hasFallback bool, pm PortMap, em EnvMap, resolver Resolver) (string, error) {
+	if !bareRefPattern.MatchString(ref) {
+		return "", fmt.Errorf("invalid ref %q: must be svc.key, svc.env.VAR, or @repo.svc[.env].key", ref)
+	}
+	wrapped := "${" + ref
+	if hasFallback {
+		wrapped += ":-" + fallback
+	}
+	wrapped += "}"
+	return expandInternal(wrapped, pm, em, resolver)
+}
+
+func expandInternal(value string, pm PortMap, em EnvMap, resolver Resolver) (string, error) {
 	var firstErr error
 	out := refPattern.ReplaceAllStringFunc(value, func(match string) string {
 		m := refPattern.FindStringSubmatch(match)
-		svc, isEnv, key := m[1], m[2] != "", m[3]
-		if isEnv {
-			if em == nil {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("unresolved reference %s: env-var references are not allowed here", match)
-				}
-				return match
+		repo, svc, isEnv, key := m[2], m[3], m[4] != "", m[5]
+		hasDefault := m[6] != ""
+		defaultVal := m[7]
+
+		fallback := func(reason string) string {
+			if hasDefault {
+				return defaultVal
 			}
-			vars, ok := em[svc]
-			if !ok {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("unresolved reference %s: no such service", match)
-				}
-				return match
+			if firstErr == nil {
+				firstErr = fmt.Errorf("unresolved reference %s: %s", match, reason)
 			}
-			val, ok := vars[key]
+			return match
+		}
+
+		if repo != "" {
+			if resolver == nil {
+				return fallback(fmt.Sprintf("cross-repo (@%s.) references are not allowed here", repo))
+			}
+			val, ok := resolver(repo, svc, isEnv, key)
 			if !ok {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("unresolved reference %s: service has no env var %q", match, key)
-				}
-				return match
+				return fallback("peer not found")
 			}
 			return val
 		}
+
+		if isEnv {
+			if em == nil {
+				return fallback("env-var references are not allowed here")
+			}
+			vars, ok := em[svc]
+			if !ok {
+				return fallback("no such service")
+			}
+			val, ok := vars[key]
+			if !ok {
+				return fallback(fmt.Sprintf("service has no env var %q", key))
+			}
+			return val
+		}
+
 		port, ok := lookup(pm, svc, key)
 		if !ok {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("unresolved reference %s: no such service or port", match)
-			}
-			return match
+			return fallback("no such service or port")
 		}
 		return strconv.Itoa(port)
 	})
@@ -82,14 +147,55 @@ func ExpandAll(value string, pm PortMap, em EnvMap) (string, error) {
 	return out, nil
 }
 
-// LookupRef resolves a single bare reference string (no ${} wrapping) of the
-// form "svc.env.VAR" or "svc.key". Used to implement the `ref:` config form.
-func LookupRef(ref string, pm PortMap, em EnvMap) (string, error) {
-	if !bareRefPattern.MatchString(ref) {
-		return "", fmt.Errorf("invalid ref %q: must be svc.key or svc.env.VAR", ref)
+// HasCrossRepoRef reports whether value contains any ${@repo.svc...} reference.
+// Useful for callers that want to short-circuit the orchestrator query when a
+// value has only local references.
+func HasCrossRepoRef(value string) bool {
+	matches := refPattern.FindAllStringSubmatch(value, -1)
+	for _, m := range matches {
+		if m[2] != "" {
+			return true
+		}
 	}
-	// Wrap and reuse the same resolver — guarantees identical error messages.
-	return ExpandAll("${"+ref+"}", pm, em)
+	return false
+}
+
+// IsCrossRepoBareRef reports whether ref (the bare `ref:` form) targets a
+// cross-repo peer (i.e. starts with @<repo>.).
+func IsCrossRepoBareRef(ref string) bool {
+	m := bareRefPattern.FindStringSubmatch(ref)
+	return m != nil && m[2] != ""
+}
+
+// CrossRepoRef is a parsed @<repo>.<svc>[.env].<key> reference.
+type CrossRepoRef struct {
+	Repo  string
+	Svc   string
+	IsEnv bool
+	Key   string
+}
+
+// ScanCrossRepoRefs returns every ${@repo.svc.key} reference embedded in
+// value, in source order. Returns nil if none are present.
+func ScanCrossRepoRefs(value string) []CrossRepoRef {
+	var out []CrossRepoRef
+	for _, m := range refPattern.FindAllStringSubmatch(value, -1) {
+		if m[2] == "" {
+			continue
+		}
+		out = append(out, CrossRepoRef{Repo: m[2], Svc: m[3], IsEnv: m[4] != "", Key: m[5]})
+	}
+	return out
+}
+
+// ParseCrossRepoBareRef parses a bare ref of the form @repo.svc[.env].key.
+// Returns (ref, true) if it is a cross-repo bare ref; (zero, false) otherwise.
+func ParseCrossRepoBareRef(ref string) (CrossRepoRef, bool) {
+	m := bareRefPattern.FindStringSubmatch(ref)
+	if m == nil || m[2] == "" {
+		return CrossRepoRef{}, false
+	}
+	return CrossRepoRef{Repo: m[2], Svc: m[3], IsEnv: m[4] != "", Key: m[5]}, true
 }
 
 func lookup(pm PortMap, svc, key string) (int, bool) {

--- a/internal/envexpand/envexpand_test.go
+++ b/internal/envexpand/envexpand_test.go
@@ -282,10 +282,10 @@ func TestExpandFirstUnresolvedReferenceWins(t *testing.T) {
 func TestExpandRefAtStartMiddleEnd(t *testing.T) {
 	pm := PortMap{"svc": {"port": 7777, "PORT": 7777}}
 	cases := map[string]string{
-		"${svc.port} end":       "7777 end",
-		"start ${svc.port}":     "start 7777",
-		"a ${svc.port} b":       "a 7777 b",
-		"${svc.port}":           "7777",
+		"${svc.port} end":   "7777 end",
+		"start ${svc.port}": "start 7777",
+		"a ${svc.port} b":   "a 7777 b",
+		"${svc.port}":       "7777",
 	}
 	for in, want := range cases {
 		t.Run(in, func(t *testing.T) {
@@ -318,5 +318,162 @@ func TestExpandMultiPortNoPortKeyErrors(t *testing.T) {
 	_, err := Expand("${infra.port}", pm)
 	if err == nil {
 		t.Fatal("expected error: multi-port service with no 'port' or 'PORT' entry should not resolve ${svc.port}")
+	}
+}
+
+func TestExpandWithCrossRepoRefs(t *testing.T) {
+	resolver := func(repo, svc string, isEnv bool, key string) (string, bool) {
+		// Stand-in for the orchestrator: returns canned data for repo "backend"
+		// and rejects everything else.
+		if repo != "backend" {
+			return "", false
+		}
+		if svc == "api" && !isEnv && key == "port" {
+			return "9999", true
+		}
+		if svc == "api" && isEnv && key == "AUTH_TOKEN" {
+			return "secret-xyz", true
+		}
+		return "", false
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"@repo.svc.port", "${@backend.api.port}", "9999"},
+		{"@repo.svc.env.VAR", "token=${@backend.api.env.AUTH_TOKEN}", "token=secret-xyz"},
+		{"missing peer with default", "${@backend.unknown.port:-3001}", "3001"},
+		{"missing peer empty default", "${@unknown.x.port:-}", ""},
+		{"mixed local and remote", "L=${api.port} R=${@backend.api.port}", "L=8080 R=9999"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandWith(tt.in, PortMap{"api": {"PORT": 8080}}, EnvMap{}, resolver)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandWithCrossRepoUnresolvedErrors(t *testing.T) {
+	resolver := func(repo, svc string, isEnv bool, key string) (string, bool) {
+		return "", false
+	}
+	_, err := ExpandWith("${@backend.api.port}", PortMap{}, EnvMap{}, resolver)
+	if err == nil {
+		t.Fatal("expected error for unresolved cross-repo ref without default")
+	}
+	if !strings.Contains(err.Error(), "peer not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExpandWithCrossRepoNoResolverErrors(t *testing.T) {
+	_, err := ExpandWith("${@backend.api.port}", PortMap{}, EnvMap{}, nil)
+	if err == nil {
+		t.Fatal("expected error: nil resolver should reject @-refs without default")
+	}
+	if !strings.Contains(err.Error(), "cross-repo") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExpandLocalRefDefault(t *testing.T) {
+	got, err := Expand("${missing.port:-1234}", PortMap{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "1234" {
+		t.Errorf("got %q, want 1234", got)
+	}
+}
+
+func TestExpandAllLocalEnvDefault(t *testing.T) {
+	got, err := ExpandAll("${api.env.MISSING:-fallback}", PortMap{}, EnvMap{"api": {}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "fallback" {
+		t.Errorf("got %q, want fallback", got)
+	}
+}
+
+func TestLookupRefWithCrossRepo(t *testing.T) {
+	resolver := func(repo, svc string, isEnv bool, key string) (string, bool) {
+		if repo == "backend" && svc == "api" && !isEnv && key == "port" {
+			return "9999", true
+		}
+		return "", false
+	}
+	got, err := LookupRefWith("@backend.api.port", "", false, PortMap{}, EnvMap{}, resolver)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "9999" {
+		t.Errorf("got %q, want 9999", got)
+	}
+}
+
+func TestLookupRefWithFallback(t *testing.T) {
+	resolver := func(repo, svc string, isEnv bool, key string) (string, bool) {
+		return "", false
+	}
+	got, err := LookupRefWith("@backend.api.port", "3001", true, PortMap{}, EnvMap{}, resolver)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "3001" {
+		t.Errorf("got %q, want 3001 (fallback)", got)
+	}
+}
+
+func TestLookupRefRejectsInvalid(t *testing.T) {
+	cases := []string{"@.svc.port", "@repo.svc", "@repo..port", "@repo.svc."}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := LookupRefWith(in, "", false, PortMap{}, EnvMap{}, nil); err == nil {
+				t.Errorf("expected error for %q", in)
+			}
+		})
+	}
+}
+
+func TestHasCrossRepoRef(t *testing.T) {
+	cases := map[string]bool{
+		"plain":                     false,
+		"${api.port}":               false,
+		"${api.env.VAR}":            false,
+		"${@backend.api.port}":      true,
+		"L=${api.port} R=${@b.x.y}": true,
+		"${@b.x.y:-default}":        true,
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := HasCrossRepoRef(in); got != want {
+				t.Errorf("HasCrossRepoRef(%q) = %v, want %v", in, got, want)
+			}
+		})
+	}
+}
+
+func TestIsCrossRepoBareRef(t *testing.T) {
+	cases := map[string]bool{
+		"api.port":             false,
+		"api.env.VAR":          false,
+		"@backend.api.port":    true,
+		"@backend.api.env.VAR": true,
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := IsCrossRepoBareRef(in); got != want {
+				t.Errorf("IsCrossRepoBareRef(%q) = %v, want %v", in, got, want)
+			}
+		})
 	}
 }

--- a/internal/envexport/envexport.go
+++ b/internal/envexport/envexport.go
@@ -35,24 +35,38 @@ func WritePerService(path string, env []string) error {
 }
 
 // WriteGlobal resolves each entry in globalEnv against pm/em and writes the
-// result to path. `ref:` entries are resolved via envexpand.LookupRef; scalar
-// entries are run through envexpand.ExpandAll.
-func WriteGlobal(path string, globalEnv map[string]config.GlobalEnvValue, pm envexpand.PortMap, em envexpand.EnvMap) error {
+// result to path. Cross-repo @-references are not supported; use
+// WriteGlobalWith to enable them.
+func WriteGlobal(path string, globalEnv map[string]config.EnvValue, pm envexpand.PortMap, em envexpand.EnvMap) error {
+	return WriteGlobalWith(path, globalEnv, pm, em, nil)
+}
+
+// WriteGlobalWith is WriteGlobal with a Resolver for cross-repo @-references.
+// Unresolved cross-repo refs without a default are omitted from the output
+// (graceful degradation); unresolved local refs without a default error.
+func WriteGlobalWith(path string, globalEnv map[string]config.EnvValue, pm envexpand.PortMap, em envexpand.EnvMap, resolver envexpand.Resolver) error {
 	pairs := make(map[string]string, len(globalEnv))
 	for k, entry := range globalEnv {
-		var (
-			v   string
-			err error
-		)
 		if entry.Ref != "" {
-			v, err = envexpand.LookupRef(entry.Ref, pm, em)
-		} else {
-			v, err = envexpand.ExpandAll(entry.Value, pm, em)
+			val, err := envexpand.LookupRefWith(entry.Ref, entry.DefaultValue(), entry.HasDefault(), pm, em, resolver)
+			if err != nil {
+				if entry.HasDefault() {
+					pairs[k] = entry.DefaultValue()
+					continue
+				}
+				if envexpand.IsCrossRepoBareRef(entry.Ref) {
+					continue // omit unresolved cross-repo refs without default
+				}
+				return fmt.Errorf("global env %q: %w", k, err)
+			}
+			pairs[k] = val
+			continue
 		}
+		val, err := envexpand.ExpandWith(entry.Value, pm, em, resolver)
 		if err != nil {
 			return fmt.Errorf("global env %q: %w", k, err)
 		}
-		pairs[k] = v
+		pairs[k] = val
 	}
 	return writeFile(path, pairs)
 }

--- a/internal/envexport/envexport_test.go
+++ b/internal/envexport/envexport_test.go
@@ -71,7 +71,7 @@ func TestWriteGlobalResolvesRefsAndInterpolations(t *testing.T) {
 		"api": {"PORT": "8080", "NAME": "api"},
 		"db":  {"DB_PORT": "5432"},
 	}
-	global := map[string]config.GlobalEnvValue{
+	global := map[string]config.EnvValue{
 		"API_PORT": {Ref: "api.env.PORT"},
 		"DB_PORT":  {Ref: "db.env.DB_PORT"},
 		"API_URL":  {Value: "http://localhost:${api.PORT}"},
@@ -97,7 +97,7 @@ func TestWriteGlobalResolvesRefsAndInterpolations(t *testing.T) {
 func TestWriteGlobalFailsOnUnresolvedRef(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".env")
-	global := map[string]config.GlobalEnvValue{
+	global := map[string]config.EnvValue{
 		"FOO": {Ref: "nope.env.MISSING"},
 	}
 	err := WriteGlobal(path, global, envexpand.PortMap{}, envexpand.EnvMap{})
@@ -112,7 +112,7 @@ func TestWriteGlobalFailsOnUnresolvedRef(t *testing.T) {
 func TestWriteGlobalFailsOnBadInterpolation(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".env")
-	global := map[string]config.GlobalEnvValue{
+	global := map[string]config.EnvValue{
 		"FOO": {Value: "${nope.port}"},
 	}
 	err := WriteGlobal(path, global, envexpand.PortMap{}, envexpand.EnvMap{})

--- a/internal/orchestrator/controlapi.go
+++ b/internal/orchestrator/controlapi.go
@@ -40,6 +40,7 @@ func (c *ControlAPI) Handler() http.Handler {
 	mux.HandleFunc("GET /__mdp/groups", c.handleListGroups)
 	mux.HandleFunc("POST /__mdp/groups/{name}/switch", c.handleSwitchGroup)
 	mux.HandleFunc("GET /__mdp/services", c.handleListServices)
+	mux.HandleFunc("GET /__mdp/peers", c.handlePeerLookup)
 	mux.HandleFunc("POST /__mdp/heartbeat", c.handleHeartbeat)
 	mux.HandleFunc("POST /__mdp/disconnect", c.handleDisconnect)
 	mux.HandleFunc("GET /__mdp/shutdown/watch", c.handleShutdownWatch)
@@ -85,11 +86,11 @@ func (c *ControlAPI) handleHealth(w http.ResponseWriter, r *http.Request) {
 func (c *ControlAPI) handleListProxies(w http.ResponseWriter, r *http.Request) {
 	proxies := c.orch.ListProxies()
 	type proxyJSON struct {
-		Port       int                      `json:"port"`
-		Label      string                   `json:"label"`
-		CookieName string                   `json:"cookieName"`
-		Default    string                   `json:"default"`
-		Servers    []map[string]any         `json:"servers"`
+		Port       int              `json:"port"`
+		Label      string           `json:"label"`
+		CookieName string           `json:"cookieName"`
+		Default    string           `json:"default"`
+		Servers    []map[string]any `json:"servers"`
 	}
 	result := make([]proxyJSON, 0, len(proxies))
 	for _, pi := range proxies {
@@ -115,16 +116,17 @@ func (c *ControlAPI) handleListProxies(w http.ResponseWriter, r *http.Request) {
 }
 
 type controlRegisterBody struct {
-	Name        string `json:"name"`
-	Port        int    `json:"port"`
-	PID         int    `json:"pid"`
-	ProxyPort   int    `json:"proxyPort"`
-	Group       string `json:"group"`
-	Repo        string `json:"repo"`
-	Scheme      string `json:"scheme"`
-	TLSCertPath string `json:"tlsCertPath"`
-	TLSKeyPath  string `json:"tlsKeyPath"`
-	ClientID    string `json:"clientID"`
+	Name        string            `json:"name"`
+	Port        int               `json:"port"`
+	PID         int               `json:"pid"`
+	ProxyPort   int               `json:"proxyPort"`
+	Group       string            `json:"group"`
+	Repo        string            `json:"repo"`
+	Scheme      string            `json:"scheme"`
+	TLSCertPath string            `json:"tlsCertPath"`
+	TLSKeyPath  string            `json:"tlsKeyPath"`
+	ClientID    string            `json:"clientID"`
+	Env         map[string]string `json:"env"`
 }
 
 func (c *ControlAPI) handleRegister(w http.ResponseWriter, r *http.Request) {
@@ -173,6 +175,7 @@ func (c *ControlAPI) handleRegister(w http.ResponseWriter, r *http.Request) {
 		TLSCertPath: body.TLSCertPath,
 		TLSKeyPath:  body.TLSKeyPath,
 		ClientID:    body.ClientID,
+		Env:         body.Env,
 	}
 	if err := c.orch.Register(body.ProxyPort, entry); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -283,6 +286,28 @@ func (c *ControlAPI) handleListServices(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 	writeJSON(w, http.StatusOK, result)
+}
+
+// handlePeerLookup answers cross-repo @-references by returning the matching
+// service's port and exposed env vars. Lookup keys are (group, repo, service);
+// service may be the bare service name or "<group>/<service>" form (the way
+// it was registered by mdp run).
+func (c *ControlAPI) handlePeerLookup(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	group, repo, service := q.Get("group"), q.Get("repo"), q.Get("service")
+	if group == "" || repo == "" || service == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "group, repo, and service query params are required"})
+		return
+	}
+	entry := c.orch.findPeer(group, repo, service)
+	if entry == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "peer not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"port": entry.Port,
+		"env":  entry.Env,
+	})
 }
 
 func (c *ControlAPI) handleHeartbeat(w http.ResponseWriter, r *http.Request) {

--- a/internal/orchestrator/controlapi_test.go
+++ b/internal/orchestrator/controlapi_test.go
@@ -129,14 +129,14 @@ func TestControlAPIRegisterAtomicOnTLSFailure(t *testing.T) {
 	o, handler := setupControlAPI(t)
 
 	payload := map[string]any{
-		"name":         "api/main",
-		"port":         5001,
-		"pid":          300,
-		"proxyPort":    3000,
-		"group":        "dev",
-		"scheme":       "https",
-		"tlsCertPath":  "/nonexistent/cert.pem",
-		"tlsKeyPath":   "/nonexistent/key.pem",
+		"name":        "api/main",
+		"port":        5001,
+		"pid":         300,
+		"proxyPort":   3000,
+		"group":       "dev",
+		"scheme":      "https",
+		"tlsCertPath": "/nonexistent/cert.pem",
+		"tlsKeyPath":  "/nonexistent/key.pem",
 	}
 	body, _ := json.Marshal(payload)
 	req := httptest.NewRequest("POST", "/__mdp/register", bytes.NewReader(body))
@@ -323,6 +323,92 @@ func TestControlAPIShutdown(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&body)
 	if body["ok"] != true {
 		t.Error("expected ok: true")
+	}
+}
+
+func TestControlAPIPeerLookup(t *testing.T) {
+	o := New(&config.Config{}, "")
+	o.mu.Lock()
+	reg := registry.New()
+	reg.Register(&registry.ServerEntry{
+		Name:  "dev/api",
+		Repo:  "backend",
+		Group: "dev",
+		Port:  9001,
+		Env:   map[string]string{"AUTH_TOKEN": "secret-xyz", "MODE": "test"},
+	})
+	o.proxies[4000] = &ProxyInstance{Port: 4000, Registry: reg, CookieName: "__mdp_upstream_4000", cancel: func() {}}
+	o.mu.Unlock()
+	handler := NewControlAPI(o, nil).Handler()
+
+	t.Run("port and env lookup", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/__mdp/peers?group=dev&repo=backend&service=api", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+		}
+		var body map[string]any
+		json.NewDecoder(rec.Body).Decode(&body)
+		if got, _ := body["port"].(float64); int(got) != 9001 {
+			t.Errorf("port = %v, want 9001", body["port"])
+		}
+		envBody, _ := body["env"].(map[string]any)
+		if envBody["AUTH_TOKEN"] != "secret-xyz" {
+			t.Errorf("env.AUTH_TOKEN = %v, want secret-xyz", envBody["AUTH_TOKEN"])
+		}
+	})
+
+	t.Run("missing peer 404", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/__mdp/peers?group=dev&repo=other&service=api", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+
+	t.Run("missing required params", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/__mdp/peers?group=dev", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rec.Code)
+		}
+	})
+}
+
+func TestControlAPIRegisterAcceptsRepoAndEnv(t *testing.T) {
+	o := New(&config.Config{}, "")
+	handler := NewControlAPI(o, nil).Handler()
+
+	body := bytes.NewBufferString(`{
+		"name": "dev/api",
+		"port": 9001,
+		"proxyPort": 4000,
+		"group": "dev",
+		"repo": "backend",
+		"env": {"AUTH_TOKEN": "secret"}
+	}`)
+	req := httptest.NewRequest("POST", "/__mdp/register", body)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	pi := o.GetProxy(4000)
+	if pi == nil {
+		t.Fatal("proxy not created")
+	}
+	entry := pi.Registry.Get("dev/api")
+	if entry == nil {
+		t.Fatal("entry not registered")
+	}
+	if entry.Repo != "backend" {
+		t.Errorf("repo = %q, want backend", entry.Repo)
+	}
+	if entry.Env["AUTH_TOKEN"] != "secret" {
+		t.Errorf("env.AUTH_TOKEN = %q, want secret", entry.Env["AUTH_TOKEN"])
 	}
 }
 

--- a/internal/orchestrator/integration_test.go
+++ b/internal/orchestrator/integration_test.go
@@ -375,7 +375,10 @@ func TestMultiPortServiceRegistersAll(t *testing.T) {
 		Services: map[string]config.ServiceConfig{
 			"myapp": {
 				Command: "true", // exits immediately; registration happens after cmd.Start
-				Env:     map[string]string{"API_PORT": "auto", "WS_PORT": "auto"},
+				Env: map[string]config.EnvValue{
+					"API_PORT": {Value: "auto"},
+					"WS_PORT":  {Value: "auto"},
+				},
 				Ports: []config.PortMapping{
 					{Env: "API_PORT", Proxy: proxyA, Name: "api"},
 					{Env: "WS_PORT", Proxy: proxyB, Name: "ws"},

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -478,6 +478,27 @@ func (o *Orchestrator) groupsLocked() map[string][]string {
 	return groups
 }
 
+// findPeer searches every proxy's registry for a service matching the given
+// (group, repo, service) tuple. The service argument may be the bare service
+// name as it appears in mdp.yaml (e.g. "api") or the registered "<group>/<svc>"
+// form. Returns nil if no match exists.
+func (o *Orchestrator) findPeer(group, repo, service string) *registry.ServerEntry {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	for _, pi := range o.proxies {
+		for _, entry := range pi.Registry.List() {
+			if entry.Group != group || entry.Repo != repo {
+				continue
+			}
+			if entry.Name == service || entry.Name == group+"/"+service {
+				e := entry
+				return &e
+			}
+		}
+	}
+	return nil
+}
+
 // SwitchGroup sets the default upstream on every proxy that has a service
 // in the named group.
 func (o *Orchestrator) SwitchGroup(groupName string) error {

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -67,7 +67,7 @@ func (o *Orchestrator) StartConfigServices(ctx context.Context, group string) er
 			envProtocols := svc.EnvProtocols()
 			portAssignments := make(map[string]int)
 			for envName, value := range svc.Env {
-				if value == "auto" {
+				if value.Ref == "" && value.Value == "auto" {
 					finder := ports.FindFreePort
 					if envProtocols[envName] == "udp" {
 						finder = ports.FindFreeUDPPort
@@ -393,16 +393,33 @@ func (o *Orchestrator) launchProcess(ctx context.Context, name string, svc confi
 	return nil
 }
 
-func buildEnv(configEnv map[string]string, portAssignments map[string]int, portMap envexpand.PortMap) ([]string, error) {
+func buildEnv(configEnv map[string]config.EnvValue, portAssignments map[string]int, portMap envexpand.PortMap) ([]string, error) {
 	var env []string
-	for k, v := range configEnv {
-		if v == "auto" {
+	for k, entry := range configEnv {
+		if entry.Ref != "" {
+			val, err := envexpand.LookupRefWith(entry.Ref, entry.DefaultValue(), entry.HasDefault(), portMap, nil, nil)
+			if err != nil {
+				if entry.HasDefault() {
+					env = append(env, k+"="+entry.DefaultValue())
+					continue
+				}
+				if envexpand.IsCrossRepoBareRef(entry.Ref) {
+					// Cross-repo refs not supported in orchestrator-managed
+					// services (yet); silently omit when unresolved.
+					continue
+				}
+				return nil, fmt.Errorf("env %q: %w", k, err)
+			}
+			env = append(env, k+"="+val)
+			continue
+		}
+		if entry.Value == "auto" {
 			if port, ok := portAssignments[k]; ok {
 				env = append(env, k+"="+strconv.Itoa(port))
 			}
 			continue
 		}
-		expanded, err := envexpand.Expand(v, portMap)
+		expanded, err := envexpand.Expand(entry.Value, portMap)
 		if err != nil {
 			return nil, fmt.Errorf("env %q: %w", k, err)
 		}

--- a/internal/orchestrator/runner_test.go
+++ b/internal/orchestrator/runner_test.go
@@ -15,6 +15,16 @@ import (
 	"github.com/derekgould/multi-dev-proxy/internal/ports"
 )
 
+// scalarEnv builds a config.EnvValue map from a plain string map; every value
+// becomes a literal scalar entry (no `ref:` form).
+func scalarEnv(m map[string]string) map[string]config.EnvValue {
+	out := make(map[string]config.EnvValue, len(m))
+	for k, v := range m {
+		out[k] = config.EnvValue{Value: v}
+	}
+	return out
+}
+
 func TestSplitHookArgs(t *testing.T) {
 	tests := []struct {
 		in      string
@@ -100,7 +110,7 @@ func TestBuildEnv(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env, err := buildEnv(tt.configEnv, tt.ports, tt.portMap)
+			env, err := buildEnv(scalarEnv(tt.configEnv), tt.ports, tt.portMap)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -121,7 +131,7 @@ func TestBuildEnv(t *testing.T) {
 }
 
 func TestBuildEnvUnresolvedReferenceErrors(t *testing.T) {
-	_, err := buildEnv(map[string]string{"X": "${nope.port}"}, nil, envexpand.PortMap{})
+	_, err := buildEnv(scalarEnv(map[string]string{"X": "${nope.port}"}), nil, envexpand.PortMap{})
 	if err == nil {
 		t.Fatal("expected error for unresolved reference, got nil")
 	}
@@ -129,11 +139,11 @@ func TestBuildEnvUnresolvedReferenceErrors(t *testing.T) {
 
 func TestBuildEnvMultiPortWithCrossServiceRef(t *testing.T) {
 	env, err := buildEnv(
-		map[string]string{
+		scalarEnv(map[string]string{
 			"API_PORT":  "auto",
 			"AUTH_PORT": "auto",
 			"DB_URL":    "postgres://localhost:${db.port}/app",
-		},
+		}),
 		map[string]int{"API_PORT": 4001, "AUTH_PORT": 5001},
 		envexpand.PortMap{"db": {"port": 5432, "PORT": 5432}},
 	)
@@ -141,9 +151,9 @@ func TestBuildEnvMultiPortWithCrossServiceRef(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	want := map[string]bool{
-		"API_PORT=4001":                              true,
-		"AUTH_PORT=5001":                             true,
-		"DB_URL=postgres://localhost:5432/app":       true,
+		"API_PORT=4001":                        true,
+		"AUTH_PORT=5001":                       true,
+		"DB_URL=postgres://localhost:5432/app": true,
 	}
 	for _, e := range env {
 		delete(want, e)
@@ -155,7 +165,7 @@ func TestBuildEnvMultiPortWithCrossServiceRef(t *testing.T) {
 
 func TestBuildEnvAutoWithoutAssignmentIsSkipped(t *testing.T) {
 	env, err := buildEnv(
-		map[string]string{"PORT": "auto"},
+		scalarEnv(map[string]string{"PORT": "auto"}),
 		map[string]int{},
 		envexpand.PortMap{},
 	)
@@ -185,7 +195,7 @@ func TestStartConfigServicesWritesEnvFiles(t *testing.T) {
 		PortRange: "30000-31000",
 		Global: config.GlobalConfig{
 			EnvFile: globalEnvPath,
-			Env: map[string]config.GlobalEnvValue{
+			Env: map[string]config.EnvValue{
 				"API_PORT": {Ref: "api.env.PORT"},
 				"API_URL":  {Value: "http://localhost:${api.PORT}"},
 				"WEB_MODE": {Ref: "web.env.MODE"},
@@ -196,12 +206,12 @@ func TestStartConfigServicesWritesEnvFiles(t *testing.T) {
 				Port:    30123,
 				Dir:     apiEnvDir,
 				EnvFile: apiEnvPath,
-				Env:     map[string]string{"NAME": "api", "MODE": "test"},
+				Env:     scalarEnv(map[string]string{"NAME": "api", "MODE": "test"}),
 			},
 			"web": {
 				Port:    30124,
 				EnvFile: webEnvPath,
-				Env:     map[string]string{"MODE": "dev"},
+				Env:     scalarEnv(map[string]string{"MODE": "dev"}),
 			},
 		},
 	}
@@ -259,7 +269,7 @@ func TestStartConfigServicesSkipsWhenNoEnvFile(t *testing.T) {
 	cfg := &config.Config{
 		PortRange: "30000-31000",
 		Services: map[string]config.ServiceConfig{
-			"api": {Port: 30125, Env: map[string]string{"X": "y"}},
+			"api": {Port: 30125, Env: scalarEnv(map[string]string{"X": "y"})},
 		},
 	}
 	o := New(cfg, "")
@@ -281,10 +291,10 @@ func TestStartConfigServicesGlobalRefErrorFailsFast(t *testing.T) {
 		PortRange: "30000-31000",
 		Global: config.GlobalConfig{
 			EnvFile: globalEnvPath,
-			Env:     map[string]config.GlobalEnvValue{"X": {Ref: "nope.env.MISSING"}},
+			Env:     map[string]config.EnvValue{"X": {Ref: "nope.env.MISSING"}},
 		},
 		Services: map[string]config.ServiceConfig{
-			"api": {Port: 30126, Env: map[string]string{"A": "b"}},
+			"api": {Port: 30126, Env: scalarEnv(map[string]string{"A": "b"})},
 		},
 	}
 	o := New(cfg, "")
@@ -578,10 +588,10 @@ func TestStartConfigServicesDispatchesUDPAllocator(t *testing.T) {
 		Services: map[string]config.ServiceConfig{
 			"infra": {
 				Command: "sleep 30",
-				Env: map[string]string{
+				Env: scalarEnv(map[string]string{
 					"TCP_PORT": "auto",
 					"UDP_PORT": "auto",
-				},
+				}),
 				Ports: []config.PortMapping{
 					{Env: "TCP_PORT"},
 					{Env: "UDP_PORT", Protocol: "udp"},
@@ -637,7 +647,7 @@ func TestStartMultiPortServiceSkipsRegistrationWhenProxyZero(t *testing.T) {
 		Services: map[string]config.ServiceConfig{
 			"infra": {
 				Command: "sleep 30",
-				Env:     map[string]string{"UDP_PORT": "auto"},
+				Env:     scalarEnv(map[string]string{"UDP_PORT": "auto"}),
 				Ports:   []config.PortMapping{{Env: "UDP_PORT", Protocol: "udp"}},
 			},
 		},

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -18,15 +18,16 @@ type ServerEntry struct {
 	TLSKeyPath          string // optional: key file path forwarded by mdp run
 	ClientID            string // identifies the mdp run process that registered this server
 	RegisteredAt        time.Time
-	ConsecutiveFailures int          // TCP liveness check failure counter (PID=0 servers only)
-	HealthCheck         func() bool  // optional; nil falls back to TCPCheck(Port)
+	ConsecutiveFailures int               // TCP liveness check failure counter (PID=0 servers only)
+	HealthCheck         func() bool       // optional; nil falls back to TCPCheck(Port)
+	Env                 map[string]string // resolved env vars exposed for cross-repo @-references
 }
 
 // Registry holds all registered dev servers in memory.
 type Registry struct {
-	mu             sync.RWMutex
-	servers        map[string]*ServerEntry
-	defaultServer  string
+	mu            sync.RWMutex
+	servers       map[string]*ServerEntry
+	defaultServer string
 }
 
 // New creates a new empty Registry.


### PR DESCRIPTION
## Summary

Lets `mdp.yaml` env values reference services running in *other* repos via `@<repo>.<svc>...`, scoped to the same group. The single orchestrator already sees every `mdp run` registration; this exposes that as a lookup endpoint and wires it into the env grammar.

- New syntax: `${@backend.api.port}` / `${@backend.api.env.URL}` interpolation with optional `:-default`, plus `ref: "@..."` mapping form (now allowed in per-service `env`) with sibling `default:`.
- `mdp run` resolves cross-repo refs at startup, watches each peer for port/env changes, and restarts the dependent service with refreshed env (always-on dynamic).
- Adds `Env`/`Repo` to `ServerEntry`, accepts both in the register payload, and adds `GET /__mdp/peers?group=&repo=&service=`.
- `ref:` with no resolved peer and no `default:` is silently omitted; local refs still error on unresolved.

## Test plan
- [x] `go test -race ./...`
- [x] Regression test for per-allocation resolver (services with `group:` overrides resolve against their own group).