### PR TITLE
feat: --link flag to override peer-lookup group per repo

### DIFF
--- a/cmd/mdp/peers.go
+++ b/cmd/mdp/peers.go
@@ -67,12 +67,23 @@ func extractPeerRefs(svc config.ServiceConfig) []peerRef {
 	return out
 }
 
+// effectiveGroup returns the group to query for a given peer repo. linkMap
+// overrides the caller's group on a per-repo basis when --link <repo>=<group>
+// was passed at startup.
+func effectiveGroup(repo, defaultGroup string, linkMap map[string]string) string {
+	if g, ok := linkMap[repo]; ok && g != "" {
+		return g
+	}
+	return defaultGroup
+}
+
 // resolvePeer queries the orchestrator for one peer reference. Returns
 // (value, true) when the peer is registered and the requested key resolves;
-// (zero, false) otherwise.
-func resolvePeer(client *http.Client, controlURL, group string, ref peerRef) (string, bool) {
+// (zero, false) otherwise. defaultGroup is the caller's group; linkMap
+// (optional, may be nil) overrides the lookup group for specific peer repos.
+func resolvePeer(client *http.Client, controlURL, defaultGroup string, linkMap map[string]string, ref peerRef) (string, bool) {
 	q := url.Values{}
-	q.Set("group", group)
+	q.Set("group", effectiveGroup(ref.repo, defaultGroup, linkMap))
 	q.Set("repo", ref.repo)
 	q.Set("svc", ref.svc) // unused by current handler, kept for future indexing
 	q.Set("service", ref.svc)
@@ -102,20 +113,21 @@ func resolvePeer(client *http.Client, controlURL, group string, ref peerRef) (st
 }
 
 // newPeerResolver returns an envexpand.Resolver bound to one (group, controlURL)
-// pair. It is safe to call concurrently.
-func newPeerResolver(client *http.Client, controlURL, group string) envexpand.Resolver {
+// pair. linkMap (optional) routes cross-repo refs to a different group on a
+// per-repo basis. It is safe to call concurrently.
+func newPeerResolver(client *http.Client, controlURL, group string, linkMap map[string]string) envexpand.Resolver {
 	return func(repo, svc string, isEnv bool, key string) (string, bool) {
-		return resolvePeer(client, controlURL, group, peerRef{repo: repo, svc: svc, isEnv: isEnv, key: key})
+		return resolvePeer(client, controlURL, group, linkMap, peerRef{repo: repo, svc: svc, isEnv: isEnv, key: key})
 	}
 }
 
 // refreshPeerRefs queries the orchestrator for every ref and writes the
 // current/found fields. Returns whether any value changed since the last
-// refresh.
-func refreshPeerRefs(client *http.Client, controlURL, group string, refs []peerRef) (changed bool, updated []peerRef) {
+// refresh. linkMap (optional) overrides the lookup group per peer repo.
+func refreshPeerRefs(client *http.Client, controlURL, defaultGroup string, linkMap map[string]string, refs []peerRef) (changed bool, updated []peerRef) {
 	updated = make([]peerRef, len(refs))
 	for i, r := range refs {
-		val, ok := resolvePeer(client, controlURL, group, r)
+		val, ok := resolvePeer(client, controlURL, defaultGroup, linkMap, r)
 		if val != r.current || ok != r.found {
 			changed = true
 		}
@@ -128,8 +140,9 @@ func refreshPeerRefs(client *http.Client, controlURL, group string, refs []peerR
 
 // watchPeerRefs polls the orchestrator on interval. When ANY watched ref's
 // resolved value changes, it sends on changed once and exits. The caller
-// re-invokes the watcher after restarting the dependent service.
-func watchPeerRefs(ctx context.Context, client *http.Client, controlURL, group string, refs []peerRef, interval time.Duration, changed chan<- []peerRef) {
+// re-invokes the watcher after restarting the dependent service. linkMap
+// (optional) overrides the lookup group per peer repo.
+func watchPeerRefs(ctx context.Context, client *http.Client, controlURL, defaultGroup string, linkMap map[string]string, refs []peerRef, interval time.Duration, changed chan<- []peerRef) {
 	if len(refs) == 0 {
 		return
 	}
@@ -141,7 +154,7 @@ func watchPeerRefs(ctx context.Context, client *http.Client, controlURL, group s
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			didChange, next := refreshPeerRefs(client, controlURL, group, current)
+			didChange, next := refreshPeerRefs(client, controlURL, defaultGroup, linkMap, current)
 			if didChange {
 				slog.Info("peer state changed", "refs", peerRefSignatures(next))
 				select {

--- a/cmd/mdp/peers_test.go
+++ b/cmd/mdp/peers_test.go
@@ -65,17 +65,17 @@ func TestResolvePeerSucceedsAndFails(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	got, ok := resolvePeer(http.DefaultClient, srv.URL, "dev", peerRef{repo: "backend", svc: "api", isEnv: false, key: "port"})
+	got, ok := resolvePeer(http.DefaultClient, srv.URL, "dev", nil, peerRef{repo: "backend", svc: "api", isEnv: false, key: "port"})
 	if !ok || got != "9001" {
 		t.Errorf("port lookup: got=%q ok=%v, want 9001 true", got, ok)
 	}
 
-	got, ok = resolvePeer(http.DefaultClient, srv.URL, "dev", peerRef{repo: "backend", svc: "api", isEnv: true, key: "AUTH_TOKEN"})
+	got, ok = resolvePeer(http.DefaultClient, srv.URL, "dev", nil, peerRef{repo: "backend", svc: "api", isEnv: true, key: "AUTH_TOKEN"})
 	if !ok || got != "secret" {
 		t.Errorf("env lookup: got=%q ok=%v, want secret true", got, ok)
 	}
 
-	_, ok = resolvePeer(http.DefaultClient, srv.URL, "dev", peerRef{repo: "missing", svc: "api", isEnv: false, key: "port"})
+	_, ok = resolvePeer(http.DefaultClient, srv.URL, "dev", nil, peerRef{repo: "missing", svc: "api", isEnv: false, key: "port"})
 	if ok {
 		t.Error("expected 404 to return ok=false")
 	}
@@ -98,7 +98,7 @@ func TestWatchPeerRefsFiresOnChange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	changed := make(chan []peerRef, 1)
-	go watchPeerRefs(ctx, http.DefaultClient, srv.URL, "dev", refs, 20*time.Millisecond, changed)
+	go watchPeerRefs(ctx, http.DefaultClient, srv.URL, "dev", nil, refs, 20*time.Millisecond, changed)
 
 	// Confirm watcher does NOT fire while the value is unchanged.
 	select {
@@ -129,11 +129,56 @@ func TestNewPeerResolverIntegratesWithEnvexpand(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	resolver := newPeerResolver(http.DefaultClient, srv.URL, "dev")
+	resolver := newPeerResolver(http.DefaultClient, srv.URL, "dev", nil)
 	if val, ok := resolver("backend", "api", false, "port"); !ok || val != "9001" {
 		t.Errorf("port: got=%q ok=%v", val, ok)
 	}
 	if val, ok := resolver("backend", "api", true, "URL"); !ok || val != "http://backend" {
 		t.Errorf("env: got=%q ok=%v", val, ok)
+	}
+}
+
+func TestEffectiveGroup(t *testing.T) {
+	links := map[string]string{"backend": "main", "auth": "stable"}
+
+	if g := effectiveGroup("backend", "feature-x", links); g != "main" {
+		t.Errorf("override: got %q, want main", g)
+	}
+	if g := effectiveGroup("auth", "feature-x", links); g != "stable" {
+		t.Errorf("override: got %q, want stable", g)
+	}
+	if g := effectiveGroup("other", "feature-x", links); g != "feature-x" {
+		t.Errorf("no override: got %q, want feature-x", g)
+	}
+	if g := effectiveGroup("backend", "feature-x", nil); g != "feature-x" {
+		t.Errorf("nil map: got %q, want feature-x", g)
+	}
+	// Empty override value should not shadow the default — guards against
+	// `--link foo=` slipping past the parser somehow.
+	if g := effectiveGroup("backend", "feature-x", map[string]string{"backend": ""}); g != "feature-x" {
+		t.Errorf("empty override: got %q, want feature-x", g)
+	}
+}
+
+func TestResolvePeerUsesLinkMap(t *testing.T) {
+	var gotGroup atomic.Value // string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotGroup.Store(r.URL.Query().Get("group"))
+		json.NewEncoder(w).Encode(map[string]any{"port": 9001, "env": map[string]string{}})
+	}))
+	defer srv.Close()
+
+	links := map[string]string{"backend": "main"}
+
+	// Override applies for repo "backend".
+	resolvePeer(http.DefaultClient, srv.URL, "feature-x", links, peerRef{repo: "backend", svc: "api", key: "port"})
+	if g := gotGroup.Load().(string); g != "main" {
+		t.Errorf("backend lookup: queried group %q, want main", g)
+	}
+
+	// No override for repo "other" — falls back to caller's group.
+	resolvePeer(http.DefaultClient, srv.URL, "feature-x", links, peerRef{repo: "other", svc: "api", key: "port"})
+	if g := gotGroup.Load().(string); g != "feature-x" {
+		t.Errorf("other lookup: queried group %q, want feature-x", g)
 	}
 }

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -72,14 +72,43 @@ func init() {
 	runCmd.Flags().String("env", "PORT", "Environment variable name for the assigned port")
 	runCmd.Flags().Int("control-port", 13100, "Orchestrator control port")
 	runCmd.Flags().String("log-split", "", `Demultiplex combined-stream logs. Values: "compose" (docker-compose format) or "regex:<pattern>" with named captures 'name' and 'msg'.`)
+	runCmd.Flags().StringArray("link", nil, "Override the lookup group for cross-repo @<repo>.* env refs: repo=group (repeatable, last-wins per repo). Used when a peer service runs in a different group than the caller (e.g. backend on main, frontend on a feature branch).")
+}
+
+// parseLinks converts repeated `--link repo=group` values into a map. Empty
+// repo or group is rejected with a clear error. Last value wins on duplicate
+// repo keys.
+func parseLinks(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(values))
+	for _, v := range values {
+		idx := strings.IndexByte(v, '=')
+		if idx <= 0 || idx == len(v)-1 {
+			return nil, fmt.Errorf("--link %q must be in form repo=group", v)
+		}
+		repo := strings.TrimSpace(v[:idx])
+		group := strings.TrimSpace(v[idx+1:])
+		if repo == "" || group == "" {
+			return nil, fmt.Errorf("--link %q must be in form repo=group", v)
+		}
+		out[repo] = group
+	}
+	return out, nil
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
 	controlPort, _ := cmd.Flags().GetInt("control-port")
 	groupFlag, _ := cmd.Flags().GetString("group")
+	linkValues, _ := cmd.Flags().GetStringArray("link")
+	linkMap, err := parseLinks(linkValues)
+	if err != nil {
+		return err
+	}
 
 	if len(args) == 0 {
-		return runBatchMode(cmd, controlPort, groupFlag)
+		return runBatchMode(cmd, controlPort, groupFlag, linkMap)
 	}
 
 	tlsCert, _ := cmd.Flags().GetString("tls-cert")
@@ -104,7 +133,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	return runSingleMode(cmd, args, controlPort, groupFlag, tlsCert, tlsKey, logSplit)
 }
 
-func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
+func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap map[string]string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cannot determine working directory: %w", err)
@@ -204,9 +233,9 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 	// self-correct.
 	allocResolvers := make([]envexpand.Resolver, len(allocations))
 	for i := range allocations {
-		allocResolvers[i] = newPeerResolver(client, controlURL, allocations[i].svcGroup)
+		allocResolvers[i] = newPeerResolver(client, controlURL, allocations[i].svcGroup, linkMap)
 	}
-	globalResolver := newPeerResolver(client, controlURL, group)
+	globalResolver := newPeerResolver(client, controlURL, group, linkMap)
 
 	if err := exportBatchEnvFiles(cfg, allocations, portMap, allocResolvers, globalResolver); err != nil {
 		return err
@@ -224,7 +253,7 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string) error {
 	rt := defaultBatchRuntime()
 	for i := range allocations {
 		bt.wg.Add(1)
-		go launchBatchService(batchCtx, bt, client, controlURL, clientID, repo, &allocations[i], states, rt, portMap, allocResolvers[i])
+		go launchBatchService(batchCtx, bt, client, controlURL, clientID, repo, &allocations[i], states, rt, portMap, allocResolvers[i], linkMap)
 	}
 
 	slog.Info("batch services started", "group", group)
@@ -294,6 +323,7 @@ func launchBatchService(
 	rt batchRuntime,
 	portMap envexpand.PortMap,
 	resolver envexpand.Resolver,
+	linkMap map[string]string,
 ) {
 	defer bt.wg.Done()
 	state := states[a.name]
@@ -493,7 +523,7 @@ func launchBatchService(
 	// and (if this service has cross-repo peers) restarts it on peer change.
 	signalReady()
 
-	superviseProcess(ctx, cmd, bt, client, controlURL, a, registered, registerAll, portMap, resolver, pw, pwErr)
+	superviseProcess(ctx, cmd, bt, client, controlURL, a, registered, registerAll, portMap, resolver, linkMap, pw, pwErr)
 
 	for i, raw := range a.svc.Shutdown {
 		parts, err := orchestrator.SplitHookArgs(raw)
@@ -549,20 +579,21 @@ func superviseProcess(
 	registerAll func() ([]string, error),
 	portMap envexpand.PortMap,
 	resolver envexpand.Resolver,
+	linkMap map[string]string,
 	pw, pwErr *prefixWriter,
 ) {
 	peerRefs := extractPeerRefs(a.svc)
 	// Seed peerRefs with the values we resolved at startup so the watcher
 	// only fires on a *change*, not on first sight.
 	if len(peerRefs) > 0 {
-		_, peerRefs = refreshPeerRefs(client, controlURL, a.svcGroup, peerRefs)
+		_, peerRefs = refreshPeerRefs(client, controlURL, a.svcGroup, linkMap, peerRefs)
 	}
 
 	for {
 		watchCtx, watchCancel := context.WithCancel(ctx)
 		peerCh := make(chan []peerRef, 1)
 		if len(peerRefs) > 0 {
-			go watchPeerRefs(watchCtx, client, controlURL, a.svcGroup, peerRefs, peerWatchInterval, peerCh)
+			go watchPeerRefs(watchCtx, client, controlURL, a.svcGroup, linkMap, peerRefs, peerWatchInterval, peerCh)
 		}
 
 		cmdExit := make(chan error, 1)

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -236,7 +236,7 @@ func TestLaunchBatchServiceSkipsUDPPortsFromProbe(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"infra"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
 
 	probeMu.Lock()
 	defer probeMu.Unlock()
@@ -298,7 +298,7 @@ func TestLaunchBatchServiceSkipsProxylessPorts(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"infra"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "client-1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
 
 	registerMu.Lock()
 	defer registerMu.Unlock()
@@ -370,7 +370,7 @@ func TestLaunchBatchServiceWaitsForDependencies(t *testing.T) {
 
 	for _, a := range allocs {
 		bt.wg.Add(1)
-		go launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
+		go launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
 	}
 
 	waitFor := func(name string, dur time.Duration) bool {
@@ -440,7 +440,7 @@ func TestLaunchBatchServiceReturnsOnContextCancel(t *testing.T) {
 	bt.wg.Add(1)
 	done := make(chan struct{})
 	go func() {
-		launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
+		launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
 		close(done)
 	}()
 
@@ -497,7 +497,7 @@ func TestLaunchBatchServiceHookOrdering(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"web"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -550,7 +550,7 @@ func TestLaunchBatchServiceSetupFailureSkipsRegistration(t *testing.T) {
 	bt := &batchTracker{}
 	bt.wg.Add(1)
 	states := depwait.NewStates([]string{"web"})
-	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil)
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
 
 	regMu.Lock()
 	defer regMu.Unlock()
@@ -777,7 +777,7 @@ func TestSuperviseProcessRestartsOnPeerChange(t *testing.T) {
 			},
 		},
 	}
-	resolver := newPeerResolver(http.DefaultClient, srv.URL, "dev")
+	resolver := newPeerResolver(http.DefaultClient, srv.URL, "dev", nil)
 	initialEnv, err := buildBatchEnv(*a, envexpand.PortMap{}, resolver)
 	if err != nil {
 		t.Fatalf("initial env: %v", err)
@@ -797,7 +797,7 @@ func TestSuperviseProcessRestartsOnPeerChange(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		superviseProcess(ctx, cmd, bt, http.DefaultClient, srv.URL, a, nil, registerAll, envexpand.PortMap{}, resolver, pw, pwErr)
+		superviseProcess(ctx, cmd, bt, http.DefaultClient, srv.URL, a, nil, registerAll, envexpand.PortMap{}, resolver, nil, pw, pwErr)
 		close(done)
 	}()
 	t.Cleanup(func() {
@@ -1051,4 +1051,45 @@ func contains(env []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestParseLinks(t *testing.T) {
+	t.Run("nil and empty", func(t *testing.T) {
+		m, err := parseLinks(nil)
+		if err != nil || m != nil {
+			t.Errorf("nil input: got (%v, %v), want (nil, nil)", m, err)
+		}
+		m, err = parseLinks([]string{})
+		if err != nil || m != nil {
+			t.Errorf("empty input: got (%v, %v), want (nil, nil)", m, err)
+		}
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		m, err := parseLinks([]string{"backend=main", "auth=derek/foo"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m["backend"] != "main" || m["auth"] != "derek/foo" {
+			t.Errorf("got %v, want backend=main auth=derek/foo", m)
+		}
+	})
+
+	t.Run("last wins", func(t *testing.T) {
+		m, err := parseLinks([]string{"backend=stale", "backend=main"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m["backend"] != "main" {
+			t.Errorf("last-wins failed: got %q, want main", m["backend"])
+		}
+	})
+
+	t.Run("invalid forms", func(t *testing.T) {
+		for _, v := range []string{"", "backend", "=main", "backend=", " =main", "backend= "} {
+			if _, err := parseLinks([]string{v}); err == nil {
+				t.Errorf("%q: expected error, got nil", v)
+			}
+		}
+	})
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,6 +140,7 @@ mdp --stop
 | `--tls-key`        |               | TLS key file (paired with `--tls-cert`)          |
 | `--auto-tls`       | `false`       | Auto-detect TLS certs from mkcert                |
 | `--control-port`   | `13100`       | Orchestrator control port                        |
+| `--link`           |               | Override peer-lookup group: `repo=group` (repeatable). See [cross-repo refs](./mdp-yaml-reference.md#cross-group-lookups-via---link). |
 
 
 `**mdp register` flags:**

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -507,7 +507,7 @@ global:
 
 ### Cross-repo `@<repo>` references
 
-`mdp run` instances in different repos all register with the same singleton orchestrator. To reference a service running in *another* repo, prefix the reference with `@<repo-name>.`. The lookup is implicitly scoped to the same group (typically the git branch).
+`mdp run` instances in different repos all register with the same singleton orchestrator. To reference a service running in *another* repo, prefix the reference with `@<repo-name>.`. The lookup is scoped to the same group as the caller by default (typically the git branch); use `--link` to override the lookup group per peer repo (see below).
 
 ```yaml
 # In frontend's mdp.yaml
@@ -536,7 +536,27 @@ Resolution semantics:
 Notes:
 
 - `@self` and other reserved names have no special meaning — `@<repo>` is just whichever string was registered as the peer's repo (typically the basename of the directory containing the peer's `mdp.yaml`).
-- Cross-group references are not supported. The peer must be in the same group as the resolver.
+- Cross-group references require `--link <repo>=<group>`. Without it, the peer must be in the same group as the resolver.
+
+#### Cross-group lookups via `--link`
+
+Use `mdp run --link <repo>=<group>` to redirect cross-repo `@<repo>.*` references to a different group than the caller's. The flag is repeatable and last-wins per repo. Common case: a frontend on a feature branch wiring to a backend that runs on `main`.
+
+```sh
+# Frontend on branch derek/foo, backend on main:
+mdp run --link api=main
+```
+
+```yaml
+# In the frontend's mdp.yaml, no change needed:
+services:
+  web:
+    command: npm run dev
+    env:
+      VITE_API_URL: "http://localhost:${@api.server.port}"
+```
+
+The override applies to all `@<repo>.*` references resolved during this `mdp run` invocation, both at startup and during peer-change watching.
 
 ## Path resolution
 


### PR DESCRIPTION
Adds `--link <repo>=<group>` (repeatable) to `mdp run`, letting cross-repo `@<repo>.*` env-var references resolve against a different group than the caller's. Common case: a frontend on a feature branch wiring `VITE_API_URL` to a backend running on `main`.

The override threads through both startup resolution and the peer-change watcher, so restarts continue to track the right group. No `mdp.yaml` changes required.

Tests added for `parseLinks`, `effectiveGroup`, and `resolvePeer` group-routing; existing tests updated for new signatures. Docs in `cli.md` and `mdp-yaml-reference.md` updated.