### PR TITLE
ci: dispatch CI on release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   commitlint:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -22,6 +23,19 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Trigger CI on release PR
+        if: steps.rp.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PRS: ${{ steps.rp.outputs.prs }}
+        run: |
+          echo "$PRS" | jq -r '.[].number' | while read -r pr; do
+            head_ref=$(gh pr view "$pr" --json headRefName -q .headRefName)
+            echo "Dispatching ci.yml against $head_ref (PR #$pr)"
+            gh workflow run ci.yml --ref "$head_ref"
+          done
 
   goreleaser:
     needs: release-please


### PR DESCRIPTION
Release-please PRs never had CI checks because PRs created by the default \`GITHUB_TOKEN\` don't trigger downstream workflows. Adds a step to the release workflow that dispatches \`ci.yml\` against the release PR's head branch after release-please creates or updates it — \`workflow_dispatch\` is one of the two events GitHub exempts from that rule, so no PAT or App is needed. Also adds \`workflow_dispatch:\` to \`ci.yml\` and \`actions: write\` permission to the release workflow.