### PR TITLE
chore: log cross-repo link connect/disconnect during mdp run

### DIFF
--- a/cmd/mdp/peers.go
+++ b/cmd/mdp/peers.go
@@ -121,14 +121,41 @@ func newPeerResolver(client *http.Client, controlURL, group string, linkMap map[
 	}
 }
 
+// logLinkTransition emits a "cross-repo link connected"/"disconnected"
+// slog.Info line. The resolved value is included only for port refs; env
+// refs may resolve to secrets (e.g. @backend.api.env.AUTH_TOKEN) so the
+// value is omitted in that case — the ref signature still identifies which
+// env var transitioned.
+func logLinkTransition(msg, serviceName string, r peerRef, group, value string) {
+	if r.isEnv {
+		slog.Info(msg, "service", serviceName, "ref", r.signature(), "group", group)
+		return
+	}
+	slog.Info(msg, "service", serviceName, "ref", r.signature(), "group", group, "value", value)
+}
+
 // refreshPeerRefs queries the orchestrator for every ref and writes the
 // current/found fields. Returns whether any value changed since the last
-// refresh. linkMap (optional) overrides the lookup group per peer repo.
-func refreshPeerRefs(client *http.Client, controlURL, defaultGroup string, linkMap map[string]string, refs []peerRef) (changed bool, updated []peerRef) {
+// refresh. Emits one slog.Info line per transition: "cross-repo link
+// connected" when a ref becomes resolvable, "cross-repo link disconnected"
+// when it stops resolving, and disconnect+connect (two lines) when the
+// resolved value changes. linkMap (optional) overrides the lookup group per
+// peer repo.
+func refreshPeerRefs(client *http.Client, controlURL, serviceName, defaultGroup string, linkMap map[string]string, refs []peerRef) (changed bool, updated []peerRef) {
 	updated = make([]peerRef, len(refs))
 	for i, r := range refs {
 		val, ok := resolvePeer(client, controlURL, defaultGroup, linkMap, r)
-		if val != r.current || ok != r.found {
+		group := effectiveGroup(r.repo, defaultGroup, linkMap)
+		switch {
+		case !r.found && ok:
+			logLinkTransition("cross-repo link connected", serviceName, r, group, val)
+			changed = true
+		case r.found && !ok:
+			logLinkTransition("cross-repo link disconnected", serviceName, r, group, r.current)
+			changed = true
+		case r.found && ok && val != r.current:
+			logLinkTransition("cross-repo link disconnected", serviceName, r, group, r.current)
+			logLinkTransition("cross-repo link connected", serviceName, r, group, val)
 			changed = true
 		}
 		r.current = val
@@ -142,7 +169,7 @@ func refreshPeerRefs(client *http.Client, controlURL, defaultGroup string, linkM
 // resolved value changes, it sends on changed once and exits. The caller
 // re-invokes the watcher after restarting the dependent service. linkMap
 // (optional) overrides the lookup group per peer repo.
-func watchPeerRefs(ctx context.Context, client *http.Client, controlURL, defaultGroup string, linkMap map[string]string, refs []peerRef, interval time.Duration, changed chan<- []peerRef) {
+func watchPeerRefs(ctx context.Context, client *http.Client, controlURL, serviceName, defaultGroup string, linkMap map[string]string, refs []peerRef, interval time.Duration, changed chan<- []peerRef) {
 	if len(refs) == 0 {
 		return
 	}
@@ -154,9 +181,8 @@ func watchPeerRefs(ctx context.Context, client *http.Client, controlURL, default
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			didChange, next := refreshPeerRefs(client, controlURL, defaultGroup, linkMap, current)
+			didChange, next := refreshPeerRefs(client, controlURL, serviceName, defaultGroup, linkMap, current)
 			if didChange {
-				slog.Info("peer state changed", "refs", peerRefSignatures(next))
 				select {
 				case changed <- next:
 				case <-ctx.Done():

--- a/cmd/mdp/peers_test.go
+++ b/cmd/mdp/peers_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -98,7 +101,7 @@ func TestWatchPeerRefsFiresOnChange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	changed := make(chan []peerRef, 1)
-	go watchPeerRefs(ctx, http.DefaultClient, srv.URL, "dev", nil, refs, 20*time.Millisecond, changed)
+	go watchPeerRefs(ctx, http.DefaultClient, srv.URL, "svc-a", "dev", nil, refs, 20*time.Millisecond, changed)
 
 	// Confirm watcher does NOT fire while the value is unchanged.
 	select {
@@ -157,6 +160,155 @@ func TestEffectiveGroup(t *testing.T) {
 	// `--link foo=` slipping past the parser somehow.
 	if g := effectiveGroup("backend", "feature-x", map[string]string{"backend": ""}); g != "feature-x" {
 		t.Errorf("empty override: got %q, want feature-x", g)
+	}
+}
+
+func TestRefreshPeerRefsLogsConnectDisconnect(t *testing.T) {
+	var available atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !available.Load() {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"port": 9001,
+			"env":  map[string]string{},
+		})
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	refs := []peerRef{{repo: "backend", svc: "api", key: "port"}}
+	links := map[string]string{"backend": "main"}
+
+	// 1. Peer not yet up — no transition, no log.
+	_, refs = refreshPeerRefs(http.DefaultClient, srv.URL, "svc-a", "feature-x", links, refs)
+	if buf.Len() != 0 {
+		t.Fatalf("expected no log while peer absent, got: %s", buf.String())
+	}
+
+	// 2. Peer comes up — expect "connected" line.
+	available.Store(true)
+	_, refs = refreshPeerRefs(http.DefaultClient, srv.URL, "svc-a", "feature-x", links, refs)
+	out := buf.String()
+	buf.Reset()
+	if !strings.Contains(out, "cross-repo link connected") {
+		t.Errorf("expected 'cross-repo link connected' log, got: %s", out)
+	}
+	for _, want := range []string{`service=svc-a`, `ref=@backend.api.port.port`, `group=main`, `value=9001`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("connect log missing %q; got: %s", want, out)
+		}
+	}
+
+	// 3. Peer stays up at same value — no log.
+	_, refs = refreshPeerRefs(http.DefaultClient, srv.URL, "svc-a", "feature-x", links, refs)
+	if buf.Len() != 0 {
+		t.Fatalf("expected no log on no-op refresh, got: %s", buf.String())
+	}
+
+	// 4. Peer goes down — expect "disconnected" line.
+	available.Store(false)
+	_, refs = refreshPeerRefs(http.DefaultClient, srv.URL, "svc-a", "feature-x", links, refs)
+	out = buf.String()
+	buf.Reset()
+	if !strings.Contains(out, "cross-repo link disconnected") {
+		t.Errorf("expected 'cross-repo link disconnected' log, got: %s", out)
+	}
+	for _, want := range []string{`service=svc-a`, `ref=@backend.api.port.port`, `group=main`, `value=9001`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("disconnect log missing %q; got: %s", want, out)
+		}
+	}
+	_ = refs
+}
+
+func TestRefreshPeerRefsRedactsEnvRefValues(t *testing.T) {
+	const secret = "sk_live_super_secret_token_value"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"port": 9001,
+			"env":  map[string]string{"AUTH_TOKEN": secret},
+		})
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// Connect transition: env ref. Value MUST NOT appear in the log.
+	refs := []peerRef{{repo: "backend", svc: "api", isEnv: true, key: "AUTH_TOKEN"}}
+	_, refs = refreshPeerRefs(http.DefaultClient, srv.URL, "svc-a", "dev", nil, refs)
+	connectOut := buf.String()
+	buf.Reset()
+	if !strings.Contains(connectOut, "cross-repo link connected") {
+		t.Fatalf("expected connect log, got: %s", connectOut)
+	}
+	if strings.Contains(connectOut, secret) {
+		t.Errorf("env ref secret leaked into connect log: %s", connectOut)
+	}
+	if strings.Contains(connectOut, "value=") {
+		t.Errorf("env ref connect log should omit value attr; got: %s", connectOut)
+	}
+
+	// Disconnect transition: still must not emit the value.
+	srv.Close()
+	_, _ = refreshPeerRefs(http.DefaultClient, srv.URL, "svc-a", "dev", nil, refs)
+	disconnectOut := buf.String()
+	if !strings.Contains(disconnectOut, "cross-repo link disconnected") {
+		t.Fatalf("expected disconnect log, got: %s", disconnectOut)
+	}
+	if strings.Contains(disconnectOut, secret) {
+		t.Errorf("env ref secret leaked into disconnect log: %s", disconnectOut)
+	}
+	if strings.Contains(disconnectOut, "value=") {
+		t.Errorf("env ref disconnect log should omit value attr; got: %s", disconnectOut)
+	}
+}
+
+func TestRefreshPeerRefsLogsValueChangeAsDisconnectReconnect(t *testing.T) {
+	var port atomic.Int64
+	port.Store(9001)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"port": port.Load(),
+			"env":  map[string]string{},
+		})
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	refs := []peerRef{{repo: "backend", svc: "api", key: "port", current: "9001", found: true}}
+
+	// Change the port value; expect both a disconnect (old value) and a
+	// connect (new value) line.
+	port.Store(9999)
+	_, _ = refreshPeerRefs(http.DefaultClient, srv.URL, "svc-a", "dev", nil, refs)
+
+	out := buf.String()
+	disc := strings.Index(out, "cross-repo link disconnected")
+	conn := strings.Index(out, "cross-repo link connected")
+	if disc < 0 || conn < 0 {
+		t.Fatalf("expected both disconnect and connect logs, got: %s", out)
+	}
+	if disc > conn {
+		t.Errorf("expected disconnect before connect in log output: %s", out)
+	}
+	if !strings.Contains(out[:conn], "value=9001") {
+		t.Errorf("disconnect log should carry old value=9001, got: %s", out)
+	}
+	if !strings.Contains(out[conn:], "value=9999") {
+		t.Errorf("connect log should carry new value=9999, got: %s", out)
 	}
 }
 

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -105,6 +106,14 @@ func runRun(cmd *cobra.Command, args []string) error {
 	linkMap, err := parseLinks(linkValues)
 	if err != nil {
 		return err
+	}
+	if len(linkMap) > 0 {
+		pairs := make([]string, 0, len(linkMap))
+		for repo, group := range linkMap {
+			pairs = append(pairs, repo+"="+group)
+		}
+		sort.Strings(pairs)
+		slog.Info("link flags parsed", "links", pairs)
 	}
 
 	if len(args) == 0 {
@@ -586,14 +595,14 @@ func superviseProcess(
 	// Seed peerRefs with the values we resolved at startup so the watcher
 	// only fires on a *change*, not on first sight.
 	if len(peerRefs) > 0 {
-		_, peerRefs = refreshPeerRefs(client, controlURL, a.svcGroup, linkMap, peerRefs)
+		_, peerRefs = refreshPeerRefs(client, controlURL, a.name, a.svcGroup, linkMap, peerRefs)
 	}
 
 	for {
 		watchCtx, watchCancel := context.WithCancel(ctx)
 		peerCh := make(chan []peerRef, 1)
 		if len(peerRefs) > 0 {
-			go watchPeerRefs(watchCtx, client, controlURL, a.svcGroup, linkMap, peerRefs, peerWatchInterval, peerCh)
+			go watchPeerRefs(watchCtx, client, controlURL, a.name, a.svcGroup, linkMap, peerRefs, peerWatchInterval, peerCh)
 		}
 
 		cmdExit := make(chan error, 1)


### PR DESCRIPTION
Adds visibility into cross-repo `@`-reference state during `mdp run`. At startup, any `--link repo=group` flags are confirmed via a `link flags parsed` info log. Then, per-ref `cross-repo link connected` / `disconnected` lines are emitted on every transition (including the initial seed), each tagged with `service`, `ref`, and the effective `group`. Value-only changes log as disconnect-then-connect so port changes are visible; for env refs the resolved value is omitted to avoid leaking secrets like `@backend.api.env.AUTH_TOKEN`.