### PR TITLE
fix: cross-repo @-refs against orchestrator-managed services

### DIFF
--- a/cmd/mdp/root.go
+++ b/cmd/mdp/root.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -16,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/derekgould/multi-dev-proxy/internal/config"
+	"github.com/derekgould/multi-dev-proxy/internal/detect"
 	"github.com/derekgould/multi-dev-proxy/internal/orchestrator"
 	"github.com/derekgould/multi-dev-proxy/internal/tui"
 )
@@ -83,6 +85,7 @@ func runDaemonProcess(cmd *cobra.Command, controlPort int) error {
 			configPath = config.Find(cwd)
 		}
 	}
+	var repo string
 	if configPath != "" {
 		var err error
 		cfg, err = config.Load(configPath)
@@ -91,9 +94,10 @@ func runDaemonProcess(cmd *cobra.Command, controlPort int) error {
 		} else {
 			slog.Info("loaded config", "path", configPath)
 		}
+		repo = detect.DetectRepo(filepath.Dir(configPath))
 	}
 
-	orch := orchestrator.New(cfg, host)
+	orch := orchestrator.New(cfg, host, repo)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/orchestrator/controlapi_test.go
+++ b/internal/orchestrator/controlapi_test.go
@@ -14,7 +14,7 @@ import (
 
 func setupControlAPI(t *testing.T) (*Orchestrator, http.Handler) {
 	t.Helper()
-	o := New(&config.Config{}, "")
+	o := New(&config.Config{}, "", "")
 	o.mu.Lock()
 	reg := registry.New()
 	reg.Register(&registry.ServerEntry{Name: "app/dev", Repo: "app", Port: 4001, PID: 100, Group: "dev"})
@@ -98,7 +98,7 @@ func TestControlAPIRegisterDoesNotLoadCertWhenProxyBindFails(t *testing.T) {
 	defer busyLn.Close()
 	busyPort := busyLn.Addr().(*net.TCPAddr).Port
 
-	o := New(&config.Config{}, "127.0.0.1")
+	o := New(&config.Config{}, "127.0.0.1", "")
 	capi := NewControlAPI(o, nil)
 
 	// Use real cert paths so AddCert *would* succeed if it were called.
@@ -327,7 +327,7 @@ func TestControlAPIShutdown(t *testing.T) {
 }
 
 func TestControlAPIPeerLookup(t *testing.T) {
-	o := New(&config.Config{}, "")
+	o := New(&config.Config{}, "", "")
 	o.mu.Lock()
 	reg := registry.New()
 	reg.Register(&registry.ServerEntry{
@@ -379,7 +379,7 @@ func TestControlAPIPeerLookup(t *testing.T) {
 }
 
 func TestControlAPIRegisterAcceptsRepoAndEnv(t *testing.T) {
-	o := New(&config.Config{}, "")
+	o := New(&config.Config{}, "", "")
 	handler := NewControlAPI(o, nil).Handler()
 
 	body := bytes.NewBufferString(`{
@@ -413,7 +413,7 @@ func TestControlAPIRegisterAcceptsRepoAndEnv(t *testing.T) {
 }
 
 func TestControlAPIShutdownCallsCallback(t *testing.T) {
-	o := New(&config.Config{}, "")
+	o := New(&config.Config{}, "", "")
 	called := make(chan bool, 1)
 	capi := NewControlAPI(o, func() { called <- true })
 	handler := capi.Handler()

--- a/internal/orchestrator/integration_test.go
+++ b/internal/orchestrator/integration_test.go
@@ -35,7 +35,7 @@ func TestRegisterTLSEndToEnd(t *testing.T) {
 	certPath, keyPath, wantCN := writeSelfSignedCert(t)
 
 	proxyPort := freeTCPPort(t)
-	o := New(&config.Config{}, "127.0.0.1")
+	o := New(&config.Config{}, "127.0.0.1", "")
 	pi, err := o.EnsureProxy(proxyPort)
 	if err != nil {
 		t.Fatalf("EnsureProxy: %v", err)
@@ -115,7 +115,7 @@ func waitPortFree(t *testing.T, port int, timeout time.Duration) {
 func startOrchProxy(t *testing.T) (*Orchestrator, int) {
 	t.Helper()
 	port := freeTCPPort(t)
-	o := New(&config.Config{}, "127.0.0.1")
+	o := New(&config.Config{}, "127.0.0.1", "")
 	pi, err := o.EnsureProxy(port)
 	if err != nil {
 		t.Fatalf("EnsureProxy: %v", err)
@@ -386,7 +386,7 @@ func TestMultiPortServiceRegistersAll(t *testing.T) {
 			},
 		},
 	}
-	o := New(cfg, "127.0.0.1")
+	o := New(cfg, "127.0.0.1", "")
 	t.Cleanup(func() { o.Shutdown(context.Background()) })
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -62,6 +62,7 @@ type Orchestrator struct {
 	broadcaster *ui.Broadcaster
 	cfg         *config.Config
 	host        string
+	repo        string // repo name for orchestrator-managed services; "" if no config/remote
 
 	sessions     *SessionTracker
 	shutdownCh   chan struct{}
@@ -71,8 +72,10 @@ type Orchestrator struct {
 	certs  []tls.Certificate // dynamically loaded certs from services
 }
 
-// New creates a new Orchestrator.
-func New(cfg *config.Config, host string) *Orchestrator {
+// New creates a new Orchestrator. repo is the detected repository name for any
+// orchestrator-managed services (used to populate ServerEntry.Repo so cross-repo
+// peer lookups can match); pass "" when there is no config or no git remote.
+func New(cfg *config.Config, host, repo string) *Orchestrator {
 	if host == "" {
 		host = "0.0.0.0"
 	}
@@ -83,6 +86,7 @@ func New(cfg *config.Config, host string) *Orchestrator {
 		broadcaster: ui.NewBroadcaster(),
 		cfg:         cfg,
 		host:        host,
+		repo:        repo,
 		sessions:    NewSessionTracker(),
 		shutdownCh:  make(chan struct{}),
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func newTestOrch() *Orchestrator {
-	return New(&config.Config{}, "")
+	return New(&config.Config{}, "", "")
 }
 
 func TestNewSetsDefaults(t *testing.T) {
-	o := New(nil, "")
+	o := New(nil, "", "")
 	if o.host != "0.0.0.0" {
 		t.Errorf("expected default host 0.0.0.0, got %q", o.host)
 	}
@@ -26,7 +26,7 @@ func TestNewSetsDefaults(t *testing.T) {
 }
 
 func TestNewCustomHost(t *testing.T) {
-	o := New(nil, "127.0.0.1")
+	o := New(nil, "127.0.0.1", "")
 	if o.host != "127.0.0.1" {
 		t.Errorf("expected host 127.0.0.1, got %q", o.host)
 	}

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -287,13 +287,14 @@ func (o *Orchestrator) startSingleService(ctx context.Context, name string, svc 
 		}
 		entry := &registry.ServerEntry{
 			Name:        serverName,
-			Repo:        name,
+			Repo:        o.repo,
 			Group:       group,
 			Port:        assignedPort,
 			Scheme:      scheme,
 			TLSCertPath: svc.TLSCert,
 			TLSKeyPath:  svc.TLSKey,
 			HealthCheck: health.Build(svc.HealthCheck, assignedPort, svc.Dir),
+			Env:         envSliceToMap(env),
 		}
 		if err := o.Register(svc.Proxy, entry); err != nil {
 			return fmt.Errorf("register %s: %w", serverName, err)
@@ -333,10 +334,11 @@ func (o *Orchestrator) startMultiPortService(ctx context.Context, name string, s
 		serverName := fmt.Sprintf("%s/%s", group, serviceName)
 		entry := &registry.ServerEntry{
 			Name:        serverName,
-			Repo:        name,
+			Repo:        o.repo,
 			Group:       group,
 			Port:        port,
 			HealthCheck: health.Build(svc.HealthCheck, port, svc.Dir),
+			Env:         envSliceToMap(env),
 		}
 		if err := o.Register(pm.Proxy, entry); err != nil {
 			slog.Error("register multi-port service", "name", serverName, "err", err)

--- a/internal/orchestrator/runner_test.go
+++ b/internal/orchestrator/runner_test.go
@@ -215,7 +215,7 @@ func TestStartConfigServicesWritesEnvFiles(t *testing.T) {
 			},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -272,7 +272,7 @@ func TestStartConfigServicesSkipsWhenNoEnvFile(t *testing.T) {
 			"api": {Port: 30125, Env: scalarEnv(map[string]string{"X": "y"})},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err := o.StartConfigServices(ctx, "test"); err != nil {
@@ -297,7 +297,7 @@ func TestStartConfigServicesGlobalRefErrorFailsFast(t *testing.T) {
 			"api": {Port: 30126, Env: scalarEnv(map[string]string{"A": "b"})},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err := o.StartConfigServices(ctx, "test"); err == nil {
@@ -370,7 +370,7 @@ func TestStartConfigServicesRespectsDependsOn(t *testing.T) {
 			"b": {Command: "sleep 30", Port: 9902, DependsOn: []string{"a"}},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -419,7 +419,7 @@ func TestStartConfigServicesParallelForIndependentServices(t *testing.T) {
 			"z": {Command: "sleep 30", Port: 9913},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -446,7 +446,7 @@ func TestStartConfigServicesProbesExternalDependency(t *testing.T) {
 			"d":   {Command: "sleep 30", Port: 9952, DependsOn: []string{"ext"}},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -485,7 +485,7 @@ func TestStartConfigServicesMarksDependentFailedOnLaunchError(t *testing.T) {
 			},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -518,7 +518,7 @@ func TestStartConfigServicesFailsWhenDepTimesOut(t *testing.T) {
 			"b": {Command: "sleep 30", Port: 9922, DependsOn: []string{"a"}},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -599,7 +599,7 @@ func TestStartConfigServicesDispatchesUDPAllocator(t *testing.T) {
 			},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -652,7 +652,7 @@ func TestStartMultiPortServiceSkipsRegistrationWhenProxyZero(t *testing.T) {
 			},
 		},
 	}
-	o := New(cfg, "")
+	o := New(cfg, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -672,5 +672,52 @@ func TestStartMultiPortServiceSkipsRegistrationWhenProxyZero(t *testing.T) {
 	// instances ever created by the orchestrator.
 	if got := len(o.ListProxies()); got != 0 {
 		t.Errorf("ListProxies() = %d, want 0 (UDP mapping should not create a proxy)", got)
+	}
+}
+
+// Regression: orchestrator-managed services must register with the
+// orchestrator's repo name AND expose their resolved env vars (so cross-repo
+// @<repo>.svc.port and @<repo>.svc.env.VAR lookups from `mdp run` resolvers
+// can match). The pre-fix bug stored the YAML key in Repo and left Env nil.
+func TestStartConfigServicesRegistersWithOrchRepo(t *testing.T) {
+	swapTimeouts(t, 100*time.Millisecond, 10*time.Millisecond)
+	swapTCPCheck(t, func(int) bool { return true })
+
+	proxyPort := freeTCPPort(t)
+	servicePort := freeTCPPort(t)
+	cfg := &config.Config{
+		PortRange: "10000-60000",
+		Services: map[string]config.ServiceConfig{
+			"api": {
+				Port:  servicePort,
+				Proxy: proxyPort,
+				Env:   scalarEnv(map[string]string{"AUTH_TOKEN": "secret-xyz"}),
+			},
+		},
+	}
+	o := New(cfg, "", "backend")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	t.Cleanup(func() { o.Shutdown(context.Background()) })
+
+	if err := o.StartConfigServices(ctx, "main"); err != nil {
+		t.Fatalf("StartConfigServices: %v", err)
+	}
+
+	entry := o.findPeer("main", "backend", "api")
+	if entry == nil {
+		t.Fatal("findPeer(main, backend, api) returned nil; expected to match registered service")
+	}
+	if entry.Port != servicePort {
+		t.Errorf("findPeer port = %d, want %d", entry.Port, servicePort)
+	}
+	if got := entry.Env["AUTH_TOKEN"]; got != "secret-xyz" {
+		t.Errorf("findPeer Env[AUTH_TOKEN] = %q, want secret-xyz (Env must be populated for @<repo>.svc.env.VAR lookups)", got)
+	}
+
+	// Must NOT match when queried with the service name as the repo —
+	// that's the value the old bug stored in Repo.
+	if entry := o.findPeer("main", "api", "api"); entry != nil {
+		t.Errorf("findPeer(main, api, api) returned %+v; expected nil", entry)
 	}
 }


### PR DESCRIPTION
Cross-repo `@<repo>.svc.*` lookups against orchestrator-managed services (those started from the daemon's own `mdp.yaml`) silently fell back to `:-default` values. Two bugs in `internal/orchestrator/runner.go`: `ServerEntry.Repo` was set to the YAML service key (e.g. `"api"`) instead of the actual repo, and `ServerEntry.Env` was never populated — so both port and env-var refs missed in `findPeer`. Plumbed the detected repo through `orchestrator.New` from the daemon entry point, set `Repo: o.repo` and `Env: envSliceToMap(env)` at both registration sites (single-port and multi-port). Added a regression test that exercises both the Repo match and Env population, using `freeTCPPort(t)` plus orchestrator shutdown so it's idempotent across runs.