### PR TITLE
fix!: register multi-port services under the parent service key

### DIFF
--- a/cmd/mdp/peers.go
+++ b/cmd/mdp/peers.go
@@ -81,17 +81,36 @@ func effectiveGroup(repo, defaultGroup string, linkMap map[string]string) string
 // (value, true) when the peer is registered and the requested key resolves;
 // (zero, false) otherwise. defaultGroup is the caller's group; linkMap
 // (optional, may be nil) overrides the lookup group for specific peer repos.
+//
+// The `kind` query param distinguishes port vs env lookups so the
+// orchestrator can return 409 on the ambiguous case (bare .port ref against
+// a service with >1 proxy). A 409 is logged at Warn so the user sees a
+// clear migration message instead of silently falling through to the
+// inline :-default.
 func resolvePeer(client *http.Client, controlURL, defaultGroup string, linkMap map[string]string, ref peerRef) (string, bool) {
 	q := url.Values{}
 	q.Set("group", effectiveGroup(ref.repo, defaultGroup, linkMap))
 	q.Set("repo", ref.repo)
 	q.Set("svc", ref.svc) // unused by current handler, kept for future indexing
 	q.Set("service", ref.svc)
+	if ref.isEnv {
+		q.Set("kind", "env")
+	} else {
+		q.Set("kind", "port")
+	}
 	resp, err := client.Get(controlURL + "/__mdp/peers?" + q.Encode())
 	if err != nil {
 		return "", false
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusConflict {
+		var body struct {
+			Error string `json:"error"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		slog.Warn("cross-repo ref ambiguous", "ref", ref.signature(), "err", body.Error)
+		return "", false
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", false
 	}

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -362,12 +362,8 @@ func launchBatchService(
 				continue
 			}
 			if pm.Proxy > 0 {
-				serviceName := pm.Name
-				if serviceName == "" {
-					serviceName = pm.Env
-				}
 				registrations = append(registrations, regEntry{
-					serverName: fmt.Sprintf("%s/%s", a.svcGroup, serviceName),
+					serverName: fmt.Sprintf("%s/%s", a.svcGroup, a.name),
 					port:       port,
 					proxyPort:  pm.Proxy,
 				})

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -225,7 +225,7 @@ func TestLaunchBatchServiceSkipsUDPPortsFromProbe(t *testing.T) {
 				"JAEGER_AGENT_PORT": {Value: "auto"},
 			},
 			Ports: []config.PortMapping{
-				{Env: "API_PORT", Proxy: 4000, Name: "api"},
+				{Env: "API_PORT", Proxy: 4000},
 				{Env: "JAEGER_AGENT_PORT", Protocol: "udp"},
 			},
 		},
@@ -288,7 +288,7 @@ func TestLaunchBatchServiceSkipsProxylessPorts(t *testing.T) {
 				"DB_PORT":  {Value: "auto"},
 			},
 			Ports: []config.PortMapping{
-				{Env: "API_PORT", Proxy: 4000, Name: "api"},
+				{Env: "API_PORT", Proxy: 4000},
 				{Env: "DB_PORT"}, // no proxy — should be skipped
 			},
 		},
@@ -312,8 +312,8 @@ func TestLaunchBatchServiceSkipsProxylessPorts(t *testing.T) {
 	if got, _ := body["port"].(float64); int(got) != 40001 {
 		t.Errorf("port = %v, want 40001", body["port"])
 	}
-	if got, _ := body["name"].(string); got != "main/api" {
-		t.Errorf("name = %v, want main/api", body["name"])
+	if got, _ := body["name"].(string); got != "main/infra" {
+		t.Errorf("name = %v, want main/infra", body["name"])
 	}
 }
 

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -275,9 +275,10 @@ services:
     ports:
       - env: API_PORT
         proxy: 4000         # HTTP — registered with the 4000 proxy
-        name: api
       - env: DB_PORT        # no proxy — DB port is internal only
 ```
+
+Every proxy-bearing port of a multi-port service registers under the parent service's key (`<group>/<service>`). The registered entry's `env` map carries all of the service's resolved env vars, so cross-repo refs select a specific port by env-var name: `@<repo>.<service>.env.<ENV_VAR>`. The bare form `@<repo>.<service>.port` is ambiguous when a service has more than one proxy-bearing port and will be rejected with a 409 — use the `.env.<KEY>` form. Two ports of the same service cannot share a `proxy:` value (the second would silently overwrite the first; mdp rejects the config at load time).
 
 Other services reference the named ports as `${svc.NAME}`, where `NAME` is the port mapping's `env` key:
 
@@ -309,10 +310,8 @@ services:
     ports:
       - env: API_PORT
         proxy: 4000
-        name: api
       - env: AUTH_PORT
         proxy: 5000
-        name: auth
 ```
 
 **Custom regex mode** (mapping form) — provide any Go-regexp pattern with named captures `name` and `msg`. Useful for kubectl, honcho/foreman, bracket-prefixed tools, or anything else that multiplexes logs over one stream.
@@ -419,9 +418,8 @@ Entries in `services.<name>.ports[]`.
 | Key | Type | Required | Notes |
 |---|---|---|---|
 | `env` | string | yes | Env var name that will hold the allocated port. Reference from other services' `env` with `${svc.NAME}`, or from `global.env` with `${svc.env.NAME}`. |
-| `proxy` | int | no (default `0`) | Proxy port to register this port on. `0` = no proxy (use for DB / non-HTTP ports). |
-| `name` | string | no | Display name in the TUI and server registry. Defaults to the `env` value. Not allowed with `protocol: udp`. |
-| `protocol` | string | no (default `tcp`) | Transport protocol. `udp` marks the port as UDP: allocation uses a UDP-aware free-port check, and the `depends_on` readiness probe skips it (TCP probes never succeed on UDP). Incompatible with `proxy` and `name`. |
+| `proxy` | int | no (default `0`) | Proxy port to register this port on. `0` = no proxy (use for DB / non-HTTP ports). Two ports of the same service cannot share a `proxy:` value. |
+| `protocol` | string | no (default `tcp`) | Transport protocol. `udp` marks the port as UDP: allocation uses a UDP-aware free-port check, and the `depends_on` readiness probe skips it (TCP probes never succeed on UDP). Incompatible with `proxy`. |
 
 ```yaml
 services:
@@ -435,16 +433,14 @@ services:
     ports:
       - env: API_PORT
         proxy: 4000
-        name: api
       - env: WS_PORT
         proxy: 4001
-        name: websocket
       - env: DB_PORT     # internal only, no proxy
       - env: JAEGER_AGENT_PORT
         protocol: udp    # UDP-only; compose publishes "${JAEGER_AGENT_PORT}:6831/udp"
 ```
 
-In the TUI this service appears as `<group>/api`, `<group>/websocket`, and `<group>/DB_PORT` (falling back to the env name when `name` is omitted). UDP mappings are not registered against any proxy and do not appear in the TUI.
+In the TUI this service appears as `<group>/infra` on both the 4000 and 4001 proxies — the parent service key is the registered identity. Internal-only ports (no `proxy:`) and UDP mappings are not registered against any proxy and do not appear in the TUI.
 
 ## Interpolation
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -19,11 +19,9 @@ services:
       AUTH_PORT: auto
     ports:
       - env: API_PORT
-        proxy: 4000
-        name: api          # registered as "<branch>/api"
+        proxy: 4000        # registered as "<branch>/infra" on the 4000 proxy
       - env: AUTH_PORT
-        proxy: 5000
-        name: auth
+        proxy: 5000        # registered as "<branch>/infra" on the 5000 proxy
 ```
 
 In your `docker-compose.yml`, reference the environment variables:
@@ -51,7 +49,7 @@ mdp run --log-split=compose -- docker compose up
 
 For non-compose multiplexers (kubectl, honcho/foreman, bracket-prefixed tools), use the regex form — see [`log_split`](./mdp-yaml-reference.md#log_split--demultiplex-combined-stream-logs) in the reference.
 
-**Non-HTTP ports (no proxy):** omit `proxy:` (and optionally `name:`) on a `ports:` entry to allocate a free port for `${svc.env.VAR}` interpolation without starting a reverse-proxy listener for it. Useful for databases, caches, and other non-HTTP services other services just need to connect to directly.
+**Non-HTTP ports (no proxy):** omit `proxy:` on a `ports:` entry to allocate a free port for `${svc.env.VAR}` interpolation without starting a reverse-proxy listener for it. Useful for databases, caches, and other non-HTTP services other services just need to connect to directly.
 
 ```yaml
 db:
@@ -84,7 +82,7 @@ services:
       - "${JAEGER_AGENT_PORT}:6831/udp"
 ```
 
-UDP mappings are allocation-only: `proxy:` and `name:` are rejected at config load.
+UDP mappings are allocation-only: `proxy:` is rejected at config load.
 
 ## HTTPS
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -283,12 +283,18 @@ func DefaultSetHandler(reg *registry.Registry) http.HandlerFunc {
 
 // ConfigResponse is the JSON shape for GET /__mdp/config.
 type ConfigResponse struct {
-	Port       int             `json:"port"`
-	CookieName string          `json:"cookieName"`
-	Label      string          `json:"label"`
-	Default    string          `json:"default"`
-	Siblings   []SiblingProxy  `json:"siblings,omitempty"`
+	Port       int                 `json:"port"`
+	CookieName string              `json:"cookieName"`
+	Label      string              `json:"label"`
+	Default    string              `json:"default"`
+	Siblings   []SiblingProxy      `json:"siblings,omitempty"`
 	Groups     map[string][]string `json:"groups,omitempty"`
+	// GroupPortMaps maps {group → {proxyPort → serviceName}} for use by the
+	// widget when pinning sibling proxies on group switch. Computed
+	// per-proxy-registry so multi-port services (where one service spans
+	// several proxies) resolve deterministically: each proxy reports the
+	// service in that group registered on *that* proxy.
+	GroupPortMaps map[string]map[string]string `json:"groupPortMaps,omitempty"`
 }
 
 // SiblingProxy describes another proxy managed by the same orchestrator.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,15 +177,23 @@ func (h *HealthCheck) Validate() error {
 	return nil
 }
 
-// PortMapping maps an auto-assigned port env var to a proxy and service name.
+// PortMapping declares one auto-assigned port for a multi-port service.
 // Proxy is optional: omit it for non-HTTP ports (databases, caches, etc.) that
 // need a free port allocated for ${svc.env} interpolation but should not be
 // registered with an HTTP reverse-proxy listener.
+//
+// All proxy-bearing ports of a service register under the parent service's
+// key (`<group>/<service-key>`); individual ports are addressed by env-var
+// key via `@<repo>.<svc>.env.<KEY>` for cross-repo refs.
+//
+// Name is no longer supported; it's kept on the struct purely to detect
+// stale configs at Load time and emit a migration error. Remove on the
+// next major bump.
 type PortMapping struct {
 	Env      string `yaml:"env"`
 	Proxy    int    `yaml:"proxy"`
-	Name     string `yaml:"name"`
 	Protocol string `yaml:"protocol"` // "tcp" (default) or "udp"
+	Name     string `yaml:"name"`     // removed; Load errors when set
 }
 
 // EnvProtocols returns a {env var → normalized protocol} map for every entry
@@ -235,8 +243,16 @@ func Load(path string) (*Config, error) {
 		if svc.Scheme == "" && svc.TLSCert != "" {
 			svc.Scheme = "https"
 		}
-		// Normalize + validate port mapping protocols.
+		// Normalize + validate port mapping protocols, and reject same-proxy
+		// duplicates within a service. Without this check, two ports declaring
+		// the same `proxy:` would silently overwrite each other in the registry
+		// (entries are keyed by service name, which is shared across a
+		// service's ports).
+		seenProxy := map[int]string{}
 		for i, pm := range svc.Ports {
+			if pm.Name != "" {
+				return nil, fmt.Errorf("service %q: port %q sets removed `name:` field — drop it; multi-port services now register under the parent service key (e.g. \"<group>/%s\"). See docs/mdp-yaml-reference.md#ports--multi-port-services", name, pm.Env, name)
+			}
 			proto := strings.ToLower(pm.Protocol)
 			switch proto {
 			case "", "tcp":
@@ -245,11 +261,14 @@ func Load(path string) (*Config, error) {
 				if pm.Proxy > 0 {
 					return nil, fmt.Errorf("service %q: protocol: udp is incompatible with a non-zero proxy port (env %q)", name, pm.Env)
 				}
-				if pm.Name != "" {
-					return nil, fmt.Errorf("service %q: name: has no effect on UDP port mappings (env %q)", name, pm.Env)
-				}
 			default:
 				return nil, fmt.Errorf("service %q: unknown protocol %q for port mapping %q (expected \"tcp\" or \"udp\")", name, pm.Protocol, pm.Env)
+			}
+			if pm.Proxy > 0 {
+				if prev, ok := seenProxy[pm.Proxy]; ok {
+					return nil, fmt.Errorf("service %q: ports %q and %q both declare proxy: %d (one proxy per service-port)", name, prev, pm.Env, pm.Proxy)
+				}
+				seenProxy[pm.Proxy] = pm.Env
 			}
 			svc.Ports[i].Protocol = proto
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,10 +60,8 @@ services:
     ports:
       - env: API_PORT
         proxy: 4000
-        name: api
       - env: AUTH_PORT
         proxy: 5000
-        name: auth
 `), 0644)
 
 	cfg, err := Load(path)
@@ -74,7 +72,7 @@ services:
 	if len(infra.Ports) != 2 {
 		t.Fatalf("expected 2 port mappings, got %d", len(infra.Ports))
 	}
-	if infra.Ports[0].Name != "api" || infra.Ports[0].Proxy != 4000 {
+	if infra.Ports[0].Env != "API_PORT" || infra.Ports[0].Proxy != 4000 {
 		t.Errorf("ports[0] = %+v", infra.Ports[0])
 	}
 }
@@ -127,7 +125,6 @@ services:
         protocol: UDP
       - env: API_PORT
         proxy: 4000
-        name: api
 `), 0644)
 
 	cfg, err := Load(path)
@@ -193,7 +190,10 @@ services:
 	}
 }
 
-func TestLoadRejectsUDPWithName(t *testing.T) {
+// The `name:` field on port mappings was removed; configs that still set it
+// must fail loudly so users don't silently get re-routed under the parent
+// service key without noticing.
+func TestLoadRejectsRemovedPortName(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mdp.yaml")
 	os.WriteFile(path, []byte(`
@@ -201,19 +201,48 @@ services:
   infra:
     command: docker compose up
     env:
-      X: auto
+      API_PORT: auto
     ports:
-      - env: X
-        protocol: udp
-        name: x
+      - env: API_PORT
+        proxy: 4000
+        name: api
 `), 0644)
 
 	_, err := Load(path)
 	if err == nil {
-		t.Fatal("expected error for udp+name, got nil")
+		t.Fatal("expected error for removed name: field, got nil")
 	}
-	if !strings.Contains(err.Error(), "name") {
-		t.Errorf("error = %v, want it to mention name", err)
+	if !strings.Contains(err.Error(), "name:") {
+		t.Errorf("error = %v, want it to mention the removed name: field", err)
+	}
+}
+
+// Multi-port services register every proxy-bearing port under the parent
+// service's name, so two ports sharing a proxy would silently overwrite each
+// other in the registry. Reject the config instead.
+func TestLoadRejectsSameProxyTwice(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  infra:
+    command: docker compose up
+    env:
+      API_PORT: auto
+      DEBUG_PORT: auto
+    ports:
+      - env: API_PORT
+        proxy: 4000
+      - env: DEBUG_PORT
+        proxy: 4000
+`), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for duplicate proxy, got nil")
+	}
+	if !strings.Contains(err.Error(), "4000") {
+		t.Errorf("error = %v, want it to mention the duplicated proxy port", err)
 	}
 }
 

--- a/internal/orchestrator/controlapi.go
+++ b/internal/orchestrator/controlapi.go
@@ -292,6 +292,13 @@ func (c *ControlAPI) handleListServices(w http.ResponseWriter, r *http.Request) 
 // service's port and exposed env vars. Lookup keys are (group, repo, service);
 // service may be the bare service name or "<group>/<service>" form (the way
 // it was registered by mdp run).
+//
+// `kind` ("port" or "env") tells the handler which form the caller is using.
+// For "port", a service with multiple registrations (multi-port) is ambiguous
+// because each registration has a different backend Port — 409 Conflict
+// surfaces this loudly instead of silently returning whichever entry the
+// proxy map iterates first. For "env", all matches share the same Env map
+// (it's the parent service's resolved env), so the first match is sufficient.
 func (c *ControlAPI) handlePeerLookup(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	group, repo, service := q.Get("group"), q.Get("repo"), q.Get("service")
@@ -299,14 +306,25 @@ func (c *ControlAPI) handlePeerLookup(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "group, repo, and service query params are required"})
 		return
 	}
-	entry := c.orch.findPeer(group, repo, service)
-	if entry == nil {
+	kind := q.Get("kind")
+	if kind == "" {
+		kind = "port"
+	}
+	entries := c.orch.findPeers(group, repo, service)
+	if len(entries) == 0 {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "peer not found"})
 		return
 	}
+	if kind == "port" && len(entries) > 1 {
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"error": fmt.Sprintf("service %q registers on %d proxies; bare .port ref is ambiguous — use @<repo>.%s.env.<KEY> instead", service, len(entries), service),
+		})
+		return
+	}
+	e := entries[0]
 	writeJSON(w, http.StatusOK, map[string]any{
-		"port": entry.Port,
-		"env":  entry.Env,
+		"port": e.Port,
+		"env":  e.Env,
 	})
 }
 

--- a/internal/orchestrator/controlapi_test.go
+++ b/internal/orchestrator/controlapi_test.go
@@ -2,10 +2,13 @@ package orchestrator
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/derekgould/multi-dev-proxy/internal/config"
@@ -378,25 +381,78 @@ func TestControlAPIPeerLookup(t *testing.T) {
 	})
 }
 
-func TestControlAPIRegisterAcceptsRepoAndEnv(t *testing.T) {
+// A multi-port service registers on >1 proxy under the same name. Bare
+// .port lookups are ambiguous in that case (each registration has a
+// different backend port), so the handler should reject the lookup loudly
+// rather than silently returning whichever entry the proxy map iterates
+// first. Env lookups still succeed because every match shares the parent
+// service's resolved env map.
+func TestControlAPIPeerLookupAmbiguousPort(t *testing.T) {
 	o := New(&config.Config{}, "", "")
+	env := map[string]string{"DASH_PORT": "11111", "JAEGER_PORT": "22222"}
+
+	o.mu.Lock()
+	regA := registry.New()
+	regA.Register(&registry.ServerEntry{Name: "dev/infra", Repo: "platform", Group: "dev", Port: 11111, Env: env})
+	o.proxies[5601] = &ProxyInstance{Port: 5601, Registry: regA, CookieName: "__mdp_upstream_5601", cancel: func() {}}
+
+	regB := registry.New()
+	regB.Register(&registry.ServerEntry{Name: "dev/infra", Repo: "platform", Group: "dev", Port: 22222, Env: env})
+	o.proxies[16686] = &ProxyInstance{Port: 16686, Registry: regB, CookieName: "__mdp_upstream_16686", cancel: func() {}}
+	o.mu.Unlock()
 	handler := NewControlAPI(o, nil).Handler()
 
-	body := bytes.NewBufferString(`{
+	t.Run("bare port lookup is 409", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/__mdp/peers?group=dev&repo=platform&service=infra&kind=port", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusConflict {
+			t.Fatalf("expected 409, got %d; body: %s", rec.Code, rec.Body.String())
+		}
+		var body map[string]string
+		json.NewDecoder(rec.Body).Decode(&body)
+		if !strings.Contains(body["error"], "env.<KEY>") {
+			t.Errorf("error = %q, want it to point at env.<KEY> migration", body["error"])
+		}
+	})
+
+	t.Run("env lookup still 200", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/__mdp/peers?group=dev&repo=platform&service=infra&kind=env", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+		}
+		var body map[string]any
+		json.NewDecoder(rec.Body).Decode(&body)
+		envBody, _ := body["env"].(map[string]any)
+		if envBody["DASH_PORT"] != "11111" {
+			t.Errorf("env.DASH_PORT = %v, want 11111", envBody["DASH_PORT"])
+		}
+	})
+}
+
+func TestControlAPIRegisterAcceptsRepoAndEnv(t *testing.T) {
+	o := New(&config.Config{}, "", "")
+	t.Cleanup(func() { o.Shutdown(context.Background()) })
+	handler := NewControlAPI(o, nil).Handler()
+
+	proxyPort := freeTCPPort(t)
+	body := bytes.NewBufferString(fmt.Sprintf(`{
 		"name": "dev/api",
 		"port": 9001,
-		"proxyPort": 4000,
+		"proxyPort": %d,
 		"group": "dev",
 		"repo": "backend",
 		"env": {"AUTH_TOKEN": "secret"}
-	}`)
+	}`, proxyPort))
 	req := httptest.NewRequest("POST", "/__mdp/register", body)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
 	}
-	pi := o.GetProxy(4000)
+	pi := o.GetProxy(proxyPort)
 	if pi == nil {
 		t.Fatal("proxy not created")
 	}

--- a/internal/orchestrator/integration_test.go
+++ b/internal/orchestrator/integration_test.go
@@ -380,8 +380,8 @@ func TestMultiPortServiceRegistersAll(t *testing.T) {
 					"WS_PORT":  {Value: "auto"},
 				},
 				Ports: []config.PortMapping{
-					{Env: "API_PORT", Proxy: proxyA, Name: "api"},
-					{Env: "WS_PORT", Proxy: proxyB, Name: "ws"},
+					{Env: "API_PORT", Proxy: proxyA},
+					{Env: "WS_PORT", Proxy: proxyB},
 				},
 			},
 		},
@@ -396,12 +396,12 @@ func TestMultiPortServiceRegistersAll(t *testing.T) {
 	}
 
 	piA := o.GetProxy(proxyA)
-	if piA == nil || piA.Registry.Get("test/api") == nil {
-		t.Errorf("expected test/api registered on proxy %d", proxyA)
+	if piA == nil || piA.Registry.Get("test/myapp") == nil {
+		t.Errorf("expected test/myapp registered on proxy %d", proxyA)
 	}
 	piB := o.GetProxy(proxyB)
-	if piB == nil || piB.Registry.Get("test/ws") == nil {
-		t.Errorf("expected test/ws registered on proxy %d", proxyB)
+	if piB == nil || piB.Registry.Get("test/myapp") == nil {
+		t.Errorf("expected test/myapp registered on proxy %d", proxyB)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -229,11 +230,12 @@ func (o *Orchestrator) createProxyLocked(port int, label string) (*ProxyInstance
 		o.mu.RLock()
 		defer o.mu.RUnlock()
 		resp := api.ConfigResponse{
-			Port:       port,
-			CookieName: cookieName,
-			Label:      label,
-			Default:    reg.GetDefault(),
-			Groups:     o.groupsLocked(),
+			Port:          port,
+			CookieName:    cookieName,
+			Label:         label,
+			Default:       reg.GetDefault(),
+			Groups:        o.groupsLocked(),
+			GroupPortMaps: o.groupPortMapsLocked(),
 		}
 		for _, pi := range o.proxies {
 			if pi.Port == port {
@@ -482,25 +484,52 @@ func (o *Orchestrator) groupsLocked() map[string][]string {
 	return groups
 }
 
-// findPeer searches every proxy's registry for a service matching the given
+// groupPortMapsLocked returns {group → {proxyPort → serviceName}} for the
+// widget. For each proxy, picks the first registry entry whose Group matches
+// — that's the upstream the proxy would route to if its cookie were set to
+// any member of that group. Multi-port services collapse cleanly: each
+// proxy gets the same service name (and a different backend port), so
+// pinning the cookie on every relevant proxy lands the user on the right
+// upstream regardless of which port they entered through.
+func (o *Orchestrator) groupPortMapsLocked() map[string]map[string]string {
+	out := make(map[string]map[string]string)
+	for _, pi := range o.proxies {
+		seenInProxy := map[string]bool{}
+		for _, entry := range pi.Registry.List() {
+			if entry.Group == "" || seenInProxy[entry.Group] {
+				continue
+			}
+			seenInProxy[entry.Group] = true
+			if out[entry.Group] == nil {
+				out[entry.Group] = map[string]string{}
+			}
+			out[entry.Group][strconv.Itoa(pi.Port)] = entry.Name
+		}
+	}
+	return out
+}
+
+// findPeers searches every proxy's registry for services matching the given
 // (group, repo, service) tuple. The service argument may be the bare service
 // name as it appears in mdp.yaml (e.g. "api") or the registered "<group>/<svc>"
-// form. Returns nil if no match exists.
-func (o *Orchestrator) findPeer(group, repo, service string) *registry.ServerEntry {
+// form. Returns every match — a multi-port service registers one entry per
+// proxy-bearing port, all under the same name, and the caller decides how
+// to handle multiple matches.
+func (o *Orchestrator) findPeers(group, repo, service string) []registry.ServerEntry {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
+	var out []registry.ServerEntry
 	for _, pi := range o.proxies {
 		for _, entry := range pi.Registry.List() {
 			if entry.Group != group || entry.Repo != repo {
 				continue
 			}
 			if entry.Name == service || entry.Name == group+"/"+service {
-				e := entry
-				return &e
+				out = append(out, entry)
 			}
 		}
 	}
-	return nil
+	return out
 }
 
 // SwitchGroup sets the default upstream on every proxy that has a service

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -327,11 +327,7 @@ func (o *Orchestrator) startMultiPortService(ctx context.Context, name string, s
 			// register against a reverse-proxy listener.
 			continue
 		}
-		serviceName := pm.Name
-		if serviceName == "" {
-			serviceName = pm.Env
-		}
-		serverName := fmt.Sprintf("%s/%s", group, serviceName)
+		serverName := fmt.Sprintf("%s/%s", group, name)
 		entry := &registry.ServerEntry{
 			Name:        serverName,
 			Repo:        o.repo,

--- a/internal/orchestrator/runner_test.go
+++ b/internal/orchestrator/runner_test.go
@@ -704,20 +704,21 @@ func TestStartConfigServicesRegistersWithOrchRepo(t *testing.T) {
 		t.Fatalf("StartConfigServices: %v", err)
 	}
 
-	entry := o.findPeer("main", "backend", "api")
-	if entry == nil {
-		t.Fatal("findPeer(main, backend, api) returned nil; expected to match registered service")
+	entries := o.findPeers("main", "backend", "api")
+	if len(entries) == 0 {
+		t.Fatal("findPeers(main, backend, api) returned nothing; expected to match registered service")
 	}
+	entry := entries[0]
 	if entry.Port != servicePort {
-		t.Errorf("findPeer port = %d, want %d", entry.Port, servicePort)
+		t.Errorf("findPeers port = %d, want %d", entry.Port, servicePort)
 	}
 	if got := entry.Env["AUTH_TOKEN"]; got != "secret-xyz" {
-		t.Errorf("findPeer Env[AUTH_TOKEN] = %q, want secret-xyz (Env must be populated for @<repo>.svc.env.VAR lookups)", got)
+		t.Errorf("findPeers Env[AUTH_TOKEN] = %q, want secret-xyz (Env must be populated for @<repo>.svc.env.VAR lookups)", got)
 	}
 
 	// Must NOT match when queried with the service name as the repo —
 	// that's the value the old bug stored in Repo.
-	if entry := o.findPeer("main", "api", "api"); entry != nil {
-		t.Errorf("findPeer(main, api, api) returned %+v; expected nil", entry)
+	if got := o.findPeers("main", "api", "api"); len(got) != 0 {
+		t.Errorf("findPeers(main, api, api) returned %d entries; expected 0", len(got))
 	}
 }

--- a/internal/ui/widget.js
+++ b/internal/ui/widget.js
@@ -60,8 +60,11 @@
 			});
 	}
 
-	// Build port map from config: find the group the active server belongs to,
-	// then map each sibling proxy port to the group member on that port.
+	// Build port map from config: locate the group containing activeName,
+	// then map each proxy port (current + siblings) to the service registered
+	// on that proxy for that group. Driven by config.groupPortMaps so
+	// multi-port services — where one service spans several proxies — pin
+	// the cookie correctly on every relevant proxy.
 	function buildPortMap(activeName) {
 		if (!config || !activeName) return null;
 		const groups = config.groups || {};
@@ -73,18 +76,15 @@
 			}
 		}
 		if (!groupName) return null;
-		const members = groups[groupName];
+		const portMap = (config.groupPortMaps || {})[groupName] || {};
 		const ports = {};
-		// Current proxy port → active server
+		// Current proxy port → active server (may differ from portMap entry
+		// when the user has manually overridden the cookie on this proxy).
 		ports[String(config.port)] = activeName;
-		// Sibling proxy ports → one unique group member per sibling.
-		// Keep assignment stable by iterating members in declared order.
-		const remainingMembers = members.filter((m) => m !== activeName);
 		if (config.siblings) {
 			for (const sib of config.siblings) {
-				const next = remainingMembers.shift();
-				if (!next) break;
-				ports[String(sib.port)] = next;
+				const name = portMap[String(sib.port)];
+				if (name) ports[String(sib.port)] = name;
 			}
 		}
 		return Object.keys(ports).length > 0 ? ports : null;

--- a/testbed/mdp.yaml
+++ b/testbed/mdp.yaml
@@ -80,7 +80,6 @@ services:
     ports:
       - env: PORT
         proxy: 3001
-        name: api-main
 
   # === feature-a branch ===
   web-feature-a:


### PR DESCRIPTION
## Summary

Cross-repo `@<repo>.<svc>...` refs were broken for multi-port services because each port was registering under its own `name:` (`<group>/api`, `<group>/server`, etc.) instead of the parent service key, so lookups for `@ent-platform.platform-admin-api.env.SERVER_PORT` couldn't find the right entry. This change removes `PortMapping.Name`, registers every proxy-bearing port under `<group>/<service-key>`, exposes `groupPortMaps` (`{group: {proxyPort: serviceName}}`) on `/__mdp/config` so the widget can pin sibling proxies deterministically when one service spans several proxies, and rejects ambiguous bare-`.port` cross-repo refs with a 409 pointing users at the `.env.<KEY>` form.

Stale configs that still set `name:` are rejected at load time with a migration error rather than silently re-routing, and two ports of the same service sharing a `proxy:` value are now also rejected (they would have silently overwritten each other in the registry). Tests, the testbed config, and docs are updated to match; an unrelated test (`TestControlAPIRegisterAcceptsRepoAndEnv`) was made port-agnostic via `freeTCPPort` so it no longer conflicts with a locally-running proxy.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual: rebuild + reinstall `mdp`, drop `name:` from `ent-platform/budapest/mdp.yaml`, restart backend, restart frontend with `mdp run --link ent-platform=<branch>`, confirm `cross-repo link connected` log appears and `VITE_API_URL` resolves to the dynamic port