### PR TITLE
feat: add Homebrew formula for Linux support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,24 @@ homebrew_casks:
         install: |
           system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/mdp"]
 
+brews:
+  - name: mdp
+    ids:
+      - mdp
+    repository:
+      owner: drgould
+      name: homebrew-mdp
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/drgould/multi-dev-proxy"
+    description: "Multi-dev proxy — run multiple dev servers behind one port"
+    license: "GPL-3.0"
+    skip_upload: auto
+    install: |
+      bin.install "mdp"
+    test: |
+      assert_match "mdp", shell_output("#{bin}/mdp --help")
+
 scoops:
   - name: mdp
     repository:


### PR DESCRIPTION
Adds a `brews:` block to `.goreleaser.yaml` alongside the existing `homebrew_casks:` block, so each release also publishes a cross-platform Homebrew formula to `drgould/homebrew-mdp`. This makes `brew install drgould/mdp/mdp` actually work on Linux (matching what the install docs already claim). The macOS cask is kept untouched so existing cask users need no migration; on macOS `brew install` will print a "treating as formula" warning and install via the formula.