### PR TITLE
feat: select batch services with --service flag and MDP_SERVICES env

### DIFF
--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -74,6 +74,7 @@ func init() {
 	runCmd.Flags().Int("control-port", 13100, "Orchestrator control port")
 	runCmd.Flags().String("log-split", "", `Demultiplex combined-stream logs. Values: "compose" (docker-compose format) or "regex:<pattern>" with named captures 'name' and 'msg'.`)
 	runCmd.Flags().StringArray("link", nil, "Override the lookup group for cross-repo @<repo>.* env refs: repo=group (repeatable, last-wins per repo). Used when a peer service runs in a different group than the caller (e.g. backend on main, frontend on a feature branch).")
+	runCmd.Flags().StringSlice("service", nil, "Only start the listed services from mdp.yaml (repeatable or comma-separated). Transitive depends_on are auto-included. Falls back to env MDP_SERVICES. Default: start all.")
 }
 
 // parseLinks converts repeated `--link repo=group` values into a map. Empty
@@ -99,6 +100,77 @@ func parseLinks(values []string) (map[string]string, error) {
 	return out, nil
 }
 
+// resolveServiceSelection returns the set of service names to start, or nil to
+// mean "all services". Empty selection (after trimming) returns nil. Unknown
+// names return an error listing the valid names. The returned set is extended
+// with the transitive closure of each selected service's depends_on so the
+// existing dependency machinery has something to wait on.
+func resolveServiceSelection(cfg *config.Config, selection []string) (map[string]bool, error) {
+	cleaned := make([]string, 0, len(selection))
+	for _, s := range selection {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			cleaned = append(cleaned, s)
+		}
+	}
+	if len(cleaned) == 0 {
+		return nil, nil
+	}
+
+	var unknown []string
+	for _, name := range cleaned {
+		if _, ok := cfg.Services[name]; !ok {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) > 0 {
+		valid := make([]string, 0, len(cfg.Services))
+		for name := range cfg.Services {
+			valid = append(valid, name)
+		}
+		sort.Strings(valid)
+		sort.Strings(unknown)
+		return nil, fmt.Errorf("unknown service(s): %s — valid: %s", strings.Join(unknown, ", "), strings.Join(valid, ", "))
+	}
+
+	selected := make(map[string]bool, len(cleaned))
+	explicit := make(map[string]bool, len(cleaned))
+	for _, name := range cleaned {
+		explicit[name] = true
+		selected[name] = true
+	}
+
+	queue := append([]string(nil), cleaned...)
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		for _, dep := range cfg.Services[name].DependsOn {
+			if !selected[dep] {
+				if _, ok := cfg.Services[dep]; !ok {
+					// depends_on validation in config.Load already catches
+					// this, but guard anyway so we don't silently skip.
+					return nil, fmt.Errorf("service %q depends on unknown service %q", name, dep)
+				}
+				selected[dep] = true
+				queue = append(queue, dep)
+			}
+		}
+	}
+
+	var pulled []string
+	for name := range selected {
+		if !explicit[name] {
+			pulled = append(pulled, name)
+		}
+	}
+	if len(pulled) > 0 {
+		sort.Strings(pulled)
+		slog.Info("auto-included dependencies", "services", pulled)
+	}
+
+	return selected, nil
+}
+
 func runRun(cmd *cobra.Command, args []string) error {
 	controlPort, _ := cmd.Flags().GetInt("control-port")
 	groupFlag, _ := cmd.Flags().GetString("group")
@@ -117,7 +189,13 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 0 {
-		return runBatchMode(cmd, controlPort, groupFlag, linkMap)
+		selection, _ := cmd.Flags().GetStringSlice("service")
+		if len(selection) == 0 {
+			if env := os.Getenv("MDP_SERVICES"); env != "" {
+				selection = strings.Split(env, ",")
+			}
+		}
+		return runBatchMode(cmd, controlPort, groupFlag, linkMap, selection)
 	}
 
 	tlsCert, _ := cmd.Flags().GetString("tls-cert")
@@ -142,7 +220,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	return runSingleMode(cmd, args, controlPort, groupFlag, tlsCert, tlsKey, logSplit)
 }
 
-func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap map[string]string) error {
+func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap map[string]string, serviceSelection []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cannot determine working directory: %w", err)
@@ -155,6 +233,11 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
+	}
+
+	selected, err := resolveServiceSelection(cfg, serviceSelection)
+	if err != nil {
+		return err
 	}
 
 	group := groupFlag
@@ -180,13 +263,19 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 	var allocations []batchAlloc
 	portMap := envexpand.PortMap{}
 	var assignedPorts []int
-	for _, svc := range cfg.Services {
+	for name, svc := range cfg.Services {
+		if selected != nil && !selected[name] {
+			continue
+		}
 		if svc.Port > 0 {
 			assignedPorts = append(assignedPorts, svc.Port)
 		}
 	}
 
 	for name, svc := range cfg.Services {
+		if selected != nil && !selected[name] {
+			continue
+		}
 		if svc.Command == "" && svc.Port == 0 {
 			continue
 		}
@@ -246,7 +335,17 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 	}
 	globalResolver := newPeerResolver(client, controlURL, group, linkMap)
 
-	if err := exportBatchEnvFiles(cfg, allocations, portMap, allocResolvers, globalResolver); err != nil {
+	var skipped map[string]bool
+	if selected != nil {
+		skipped = make(map[string]bool, len(cfg.Services))
+		for name := range cfg.Services {
+			if !selected[name] {
+				skipped[name] = true
+			}
+		}
+	}
+
+	if err := exportBatchEnvFiles(cfg, allocations, portMap, allocResolvers, globalResolver, skipped); err != nil {
 		return err
 	}
 
@@ -711,7 +810,13 @@ func buildBatchEnv(a batchAlloc, portMap envexpand.PortMap, resolver envexpand.R
 // against the right peers). globalResolver is used for global env entries,
 // which sit at the workspace level and use the top-level group. Either may be
 // nil to disable cross-repo resolution.
-func exportBatchEnvFiles(cfg *config.Config, allocations []batchAlloc, portMap envexpand.PortMap, allocResolvers []envexpand.Resolver, globalResolver envexpand.Resolver) error {
+//
+// skipped, if non-nil, is the set of services excluded by --service selection.
+// Entries in cfg.Global.Env that reference a skipped service (and have no
+// default to fall back on) are omitted from the global env file with a warning,
+// matching the graceful-degradation behavior used for unresolved cross-repo
+// peers.
+func exportBatchEnvFiles(cfg *config.Config, allocations []batchAlloc, portMap envexpand.PortMap, allocResolvers []envexpand.Resolver, globalResolver envexpand.Resolver, skipped map[string]bool) error {
 	envMap := envexpand.EnvMap{}
 	for i, a := range allocations {
 		var r envexpand.Resolver
@@ -726,7 +831,8 @@ func exportBatchEnvFiles(cfg *config.Config, allocations []batchAlloc, portMap e
 		envMap[a.name] = envSliceToMap(env)
 	}
 	if cfg.Global.EnvFile != "" {
-		if err := envexport.WriteGlobalWith(cfg.Global.EnvFile, cfg.Global.Env, portMap, envMap, globalResolver); err != nil {
+		globalEnv := filterGlobalEnvForSkipped(cfg.Global.Env, skipped)
+		if err := envexport.WriteGlobalWith(cfg.Global.EnvFile, globalEnv, portMap, envMap, globalResolver); err != nil {
 			return fmt.Errorf("write global env file: %w", err)
 		}
 	}
@@ -739,6 +845,70 @@ func exportBatchEnvFiles(cfg *config.Config, allocations []batchAlloc, portMap e
 		}
 	}
 	return nil
+}
+
+// filterGlobalEnvForSkipped returns a copy of globalEnv with entries removed
+// whose Ref or Value references a local service in the skipped set without a
+// default fallback. Entries with defaults are kept (the resolver will use the
+// default). Returns globalEnv unchanged when skipped is empty.
+func filterGlobalEnvForSkipped(globalEnv map[string]config.EnvValue, skipped map[string]bool) map[string]config.EnvValue {
+	if len(skipped) == 0 || len(globalEnv) == 0 {
+		return globalEnv
+	}
+	out := make(map[string]config.EnvValue, len(globalEnv))
+	for k, entry := range globalEnv {
+		if entry.Ref != "" {
+			if entry.HasDefault() {
+				out[k] = entry
+				continue
+			}
+			if ref, ok := envexpand.ParseCrossRepoBareRef(entry.Ref); ok {
+				_ = ref
+				out[k] = entry
+				continue
+			}
+			// Local bare ref: svc.key or svc.env.VAR. Service name is everything
+			// before the first dot.
+			svc := entry.Ref
+			if i := strings.IndexByte(svc, '.'); i > 0 {
+				svc = svc[:i]
+			}
+			if skipped[svc] {
+				slog.Warn("omitting global env entry that references unselected service", "key", k, "ref", entry.Ref, "service", svc)
+				continue
+			}
+			out[k] = entry
+			continue
+		}
+		// Value form may embed ${svc.key} refs without defaults. Scan for any
+		// that point at skipped services.
+		if refsSkippedLocalSvcWithoutDefault(entry.Value, skipped) {
+			slog.Warn("omitting global env entry that references unselected service", "key", k, "value", entry.Value)
+			continue
+		}
+		out[k] = entry
+	}
+	return out
+}
+
+// globalEnvRefRE matches embedded ${...} references inside an env value. It is
+// intentionally permissive (a subset of envexpand.refPattern) so we can
+// extract just the service name and detect a :- default.
+var globalEnvRefRE = regexp.MustCompile(`\$\{(@[A-Za-z0-9_-]+\.)?([A-Za-z0-9_-]+)\.(?:env\.)?[A-Za-z0-9_]+(:-[^}]*)?\}`)
+
+func refsSkippedLocalSvcWithoutDefault(value string, skipped map[string]bool) bool {
+	for _, m := range globalEnvRefRE.FindAllStringSubmatch(value, -1) {
+		if m[1] != "" {
+			continue // cross-repo ref — handled by resolver, not by skip filter
+		}
+		if m[3] != "" {
+			continue // has :- default; resolver will fall back
+		}
+		if skipped[m[2]] {
+			return true
+		}
+	}
+	return false
 }
 
 func envSliceToMap(env []string) map[string]string {

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -100,11 +100,38 @@ func parseLinks(values []string) (map[string]string, error) {
 	return out, nil
 }
 
+// referencedServices returns the local sibling services that svc needs present
+// to start cleanly: its explicit depends_on, plus any local service whose port
+// or env var it interpolates from its own env without a default fallback.
+// Cross-repo (@repo.) refs and defaulted refs are excluded — those tolerate the
+// target's absence (the orchestrator resolver / the default covers them).
+func referencedServices(svc config.ServiceConfig) []string {
+	refs := append([]string(nil), svc.DependsOn...)
+	for _, entry := range svc.Env {
+		if entry.Ref != "" {
+			if entry.HasDefault() || envexpand.IsCrossRepoBareRef(entry.Ref) {
+				continue
+			}
+			// Local bare ref: svc.key or svc.env.VAR — name is up to first dot.
+			name := entry.Ref
+			if i := strings.IndexByte(name, '.'); i > 0 {
+				name = name[:i]
+			}
+			refs = append(refs, name)
+			continue
+		}
+		refs = append(refs, envexpand.LocalServiceRefs(entry.Value)...)
+	}
+	return refs
+}
+
 // resolveServiceSelection returns the set of service names to start, or nil to
 // mean "all services". Empty selection (after trimming) returns nil. Unknown
 // names return an error listing the valid names. The returned set is extended
-// with the transitive closure of each selected service's depends_on so the
-// existing dependency machinery has something to wait on.
+// with the transitive closure of each selected service's dependencies — both
+// depends_on and the local services it interpolates from env (see
+// referencedServices) — so port allocation and env expansion have every
+// service they reference, not just the ones declared in depends_on.
 func resolveServiceSelection(cfg *config.Config, selection []string) (map[string]bool, error) {
 	cleaned := make([]string, 0, len(selection))
 	for _, s := range selection {
@@ -134,35 +161,31 @@ func resolveServiceSelection(cfg *config.Config, selection []string) (map[string
 	}
 
 	selected := make(map[string]bool, len(cleaned))
-	explicit := make(map[string]bool, len(cleaned))
 	for _, name := range cleaned {
-		explicit[name] = true
 		selected[name] = true
 	}
 
+	var pulled []string
 	queue := append([]string(nil), cleaned...)
 	for len(queue) > 0 {
 		name := queue[0]
 		queue = queue[1:]
-		for _, dep := range cfg.Services[name].DependsOn {
-			if !selected[dep] {
-				if _, ok := cfg.Services[dep]; !ok {
-					// depends_on validation in config.Load already catches
-					// this, but guard anyway so we don't silently skip.
-					return nil, fmt.Errorf("service %q depends on unknown service %q", name, dep)
-				}
-				selected[dep] = true
-				queue = append(queue, dep)
+		for _, ref := range referencedServices(cfg.Services[name]) {
+			if selected[ref] {
+				continue
 			}
+			if _, ok := cfg.Services[ref]; !ok {
+				// depends_on is validated in config.Load; an env ref to a
+				// missing service would fail expansion at full startup too.
+				// Surface it here with the referencing service for context.
+				return nil, fmt.Errorf("service %q references unknown service %q", name, ref)
+			}
+			selected[ref] = true
+			pulled = append(pulled, ref)
+			queue = append(queue, ref)
 		}
 	}
 
-	var pulled []string
-	for name := range selected {
-		if !explicit[name] {
-			pulled = append(pulled, name)
-		}
-	}
 	if len(pulled) > 0 {
 		sort.Strings(pulled)
 		slog.Info("auto-included dependencies", "services", pulled)
@@ -190,7 +213,16 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 	if len(args) == 0 {
 		selection, _ := cmd.Flags().GetStringSlice("service")
-		if len(selection) == 0 {
+		// An explicit but empty flag (e.g. `--service ""`) must not shadow
+		// MDP_SERVICES — treat an all-blank selection as unset.
+		hasService := false
+		for _, s := range selection {
+			if strings.TrimSpace(s) != "" {
+				hasService = true
+				break
+			}
+		}
+		if !hasService {
 			if env := os.Getenv("MDP_SERVICES"); env != "" {
 				selection = strings.Split(env, ",")
 			}
@@ -858,12 +890,7 @@ func filterGlobalEnvForSkipped(globalEnv map[string]config.EnvValue, skipped map
 	out := make(map[string]config.EnvValue, len(globalEnv))
 	for k, entry := range globalEnv {
 		if entry.Ref != "" {
-			if entry.HasDefault() {
-				out[k] = entry
-				continue
-			}
-			if ref, ok := envexpand.ParseCrossRepoBareRef(entry.Ref); ok {
-				_ = ref
+			if entry.HasDefault() || envexpand.IsCrossRepoBareRef(entry.Ref) {
 				out[k] = entry
 				continue
 			}
@@ -880,10 +907,10 @@ func filterGlobalEnvForSkipped(globalEnv map[string]config.EnvValue, skipped map
 			out[k] = entry
 			continue
 		}
-		// Value form may embed ${svc.key} refs without defaults. Scan for any
-		// that point at skipped services.
-		if refsSkippedLocalSvcWithoutDefault(entry.Value, skipped) {
-			slog.Warn("omitting global env entry that references unselected service", "key", k, "value", entry.Value)
+		// Value form may embed ${svc.key} refs without defaults. Omit the entry
+		// if any such ref points at a skipped service.
+		if svc := firstSkippedRef(entry.Value, skipped); svc != "" {
+			slog.Warn("omitting global env entry that references unselected service", "key", k, "value", entry.Value, "service", svc)
 			continue
 		}
 		out[k] = entry
@@ -891,24 +918,16 @@ func filterGlobalEnvForSkipped(globalEnv map[string]config.EnvValue, skipped map
 	return out
 }
 
-// globalEnvRefRE matches embedded ${...} references inside an env value. It is
-// intentionally permissive (a subset of envexpand.refPattern) so we can
-// extract just the service name and detect a :- default.
-var globalEnvRefRE = regexp.MustCompile(`\$\{(@[A-Za-z0-9_-]+\.)?([A-Za-z0-9_-]+)\.(?:env\.)?[A-Za-z0-9_]+(:-[^}]*)?\}`)
-
-func refsSkippedLocalSvcWithoutDefault(value string, skipped map[string]bool) bool {
-	for _, m := range globalEnvRefRE.FindAllStringSubmatch(value, -1) {
-		if m[1] != "" {
-			continue // cross-repo ref — handled by resolver, not by skip filter
-		}
-		if m[3] != "" {
-			continue // has :- default; resolver will fall back
-		}
-		if skipped[m[2]] {
-			return true
+// firstSkippedRef returns the first local service referenced by value (without
+// a default) that is in the skipped set, or "" if none. Cross-repo and
+// defaulted refs are excluded by envexpand.LocalServiceRefs.
+func firstSkippedRef(value string, skipped map[string]bool) string {
+	for _, svc := range envexpand.LocalServiceRefs(value) {
+		if skipped[svc] {
+			return svc
 		}
 	}
-	return false
+	return ""
 }
 
 func envSliceToMap(env []string) map[string]string {

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -1113,6 +1113,7 @@ func TestParseLinks(t *testing.T) {
 }
 
 func TestResolveServiceSelection(t *testing.T) {
+	def := "9"
 	cfg := &config.Config{
 		Services: map[string]config.ServiceConfig{
 			"db":       {Command: "db"},
@@ -1121,6 +1122,27 @@ func TestResolveServiceSelection(t *testing.T) {
 			"worker":   {Command: "worker", DependsOn: []string{"db"}},
 			"frontend": {Command: "fe", DependsOn: []string{"api"}},
 			"solo":     {Command: "solo"},
+			// Env-ref services: depend on siblings via env, not depends_on.
+			"metrics": {Command: "m"},
+			"reporter": {Command: "r", Env: map[string]config.EnvValue{
+				"METRICS_URL": {Value: "http://localhost:${metrics.PORT}"},
+			}},
+			"queue": {Command: "q"},
+			"ingest": {Command: "i", Env: map[string]config.EnvValue{
+				"Q": {Ref: "queue.env.ADDR"},
+			}},
+			// Mirrors testbed web-main: depends_on api, env-refs db.
+			"web": {Command: "w", DependsOn: []string{"api"}, Env: map[string]config.EnvValue{
+				"DB_URL": {Value: "postgres://localhost:${db.DB_PORT}/app"},
+			}},
+			// Defaulted ref → tolerates absence, must not pull in (or error).
+			"opt": {Command: "o", Env: map[string]config.EnvValue{
+				"X": {Ref: "absent.PORT", Default: &def},
+			}},
+			// Cross-repo ref → resolved by orchestrator, must not pull in.
+			"xrepo": {Command: "x", Env: map[string]config.EnvValue{
+				"P": {Value: "${@backend.api.PORT}"},
+			}},
 		},
 	}
 
@@ -1201,6 +1223,64 @@ func TestResolveServiceSelection(t *testing.T) {
 		// "API" is not "api" — must error, not silently match.
 		if _, err := resolveServiceSelection(cfg, []string{"API"}); err == nil {
 			t.Error("expected case-sensitive mismatch to error")
+		}
+	})
+
+	t.Run("value-form env ref pulled in", func(t *testing.T) {
+		// reporter references ${metrics.PORT} but doesn't list it in depends_on.
+		got, err := resolveServiceSelection(cfg, []string{"reporter"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{"reporter": true, "metrics": true}
+		if !reflectEqualSet(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("bare-ref-form env ref pulled in", func(t *testing.T) {
+		got, err := resolveServiceSelection(cfg, []string{"ingest"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{"ingest": true, "queue": true}
+		if !reflectEqualSet(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("depends_on and env ref combine without double-count", func(t *testing.T) {
+		// Mirrors testbed `mdp run --service web-main`: web depends_on api and
+		// env-refs db. db arrives via both api's depends_on and web's env ref.
+		got, err := resolveServiceSelection(cfg, []string{"web"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{"web": true, "api": true, "db": true, "cache": true}
+		if !reflectEqualSet(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("defaulted ref does not pull in or error", func(t *testing.T) {
+		// opt's ref targets a nonexistent service but has a default, so it must
+		// neither pull anything in nor error on the missing target.
+		got, err := resolveServiceSelection(cfg, []string{"opt"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflectEqualSet(got, map[string]bool{"opt": true}) {
+			t.Errorf("got %v, want {opt}", got)
+		}
+	})
+
+	t.Run("cross-repo ref does not pull in", func(t *testing.T) {
+		got, err := resolveServiceSelection(cfg, []string{"xrepo"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflectEqualSet(got, map[string]bool{"xrepo": true}) {
+			t.Errorf("got %v, want {xrepo}", got)
 		}
 	})
 }

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -894,7 +894,7 @@ func TestExportBatchEnvFilesWritesGlobalAndPerService(t *testing.T) {
 		"web": {"port": 40101, "PORT": 40101},
 	}
 
-	if err := exportBatchEnvFiles(cfg, allocations, portMap, nil, nil); err != nil {
+	if err := exportBatchEnvFiles(cfg, allocations, portMap, nil, nil, nil); err != nil {
 		t.Fatalf("exportBatchEnvFiles: %v", err)
 	}
 
@@ -951,7 +951,7 @@ func TestExportBatchEnvFilesSkipsWhenNoEnvFile(t *testing.T) {
 			svc:          config.ServiceConfig{Env: map[string]config.EnvValue{"X": {Value: "y"}}},
 		},
 	}
-	if err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{}, nil, nil); err != nil {
+	if err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{}, nil, nil, nil); err != nil {
 		t.Fatalf("exportBatchEnvFiles: %v", err)
 	}
 	entries, _ := os.ReadDir(tmp)
@@ -979,7 +979,7 @@ func TestExportBatchEnvFilesPropagatesExpansionError(t *testing.T) {
 			svc:          config.ServiceConfig{Env: map[string]config.EnvValue{"A": {Value: "b"}}},
 		},
 	}
-	err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{"api": {"port": 40300, "PORT": 40300}}, nil, nil)
+	err := exportBatchEnvFiles(cfg, allocations, envexpand.PortMap{"api": {"port": 40300, "PORT": 40300}}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error from unresolved ref")
 	}
@@ -1032,7 +1032,7 @@ func TestExportBatchEnvFilesUsesPerAllocResolver(t *testing.T) {
 		},
 	}
 
-	if err := exportBatchEnvFiles(&config.Config{}, allocations, envexpand.PortMap{}, allocResolvers, nil); err != nil {
+	if err := exportBatchEnvFiles(&config.Config{}, allocations, envexpand.PortMap{}, allocResolvers, nil, nil); err != nil {
 		t.Fatalf("exportBatchEnvFiles: %v", err)
 	}
 
@@ -1092,4 +1092,170 @@ func TestParseLinks(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestResolveServiceSelection(t *testing.T) {
+	cfg := &config.Config{
+		Services: map[string]config.ServiceConfig{
+			"db":       {Command: "db"},
+			"cache":    {Command: "cache"},
+			"api":      {Command: "api", DependsOn: []string{"db", "cache"}},
+			"worker":   {Command: "worker", DependsOn: []string{"db"}},
+			"frontend": {Command: "fe", DependsOn: []string{"api"}},
+			"solo":     {Command: "solo"},
+		},
+	}
+
+	t.Run("empty selection returns nil", func(t *testing.T) {
+		for _, in := range [][]string{nil, {}, {"", "  "}} {
+			got, err := resolveServiceSelection(cfg, in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != nil {
+				t.Errorf("input %v: got %v, want nil", in, got)
+			}
+		}
+	})
+
+	t.Run("single service with no deps", func(t *testing.T) {
+		got, err := resolveServiceSelection(cfg, []string{"solo"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflectEqualSet(got, map[string]bool{"solo": true}) {
+			t.Errorf("got %v, want {solo}", got)
+		}
+	})
+
+	t.Run("transitive depends_on pulled in", func(t *testing.T) {
+		got, err := resolveServiceSelection(cfg, []string{"frontend"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{"frontend": true, "api": true, "db": true, "cache": true}
+		if !reflectEqualSet(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("diamond deps not double-counted", func(t *testing.T) {
+		// api and worker both pull in db; selecting both must not loop forever.
+		got, err := resolveServiceSelection(cfg, []string{"api", "worker"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{"api": true, "worker": true, "db": true, "cache": true}
+		if !reflectEqualSet(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("comma-separated and whitespace tolerated", func(t *testing.T) {
+		// Mirrors the env-var path which uses strings.Split on commas.
+		got, err := resolveServiceSelection(cfg, []string{"solo", "  db  "})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{"solo": true, "db": true}
+		if !reflectEqualSet(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unknown name errors with valid list", func(t *testing.T) {
+		_, err := resolveServiceSelection(cfg, []string{"nope"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "nope") {
+			t.Errorf("error %q should mention the bad name", msg)
+		}
+		for _, name := range []string{"api", "db", "frontend"} {
+			if !strings.Contains(msg, name) {
+				t.Errorf("error %q should list valid name %q", msg, name)
+			}
+		}
+	})
+
+	t.Run("case sensitive", func(t *testing.T) {
+		// "API" is not "api" — must error, not silently match.
+		if _, err := resolveServiceSelection(cfg, []string{"API"}); err == nil {
+			t.Error("expected case-sensitive mismatch to error")
+		}
+	})
+}
+
+func reflectEqualSet(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// TestExportBatchEnvFilesOmitsRefsToSkippedServices is the regression test for
+// `mdp run --service <subset>` runs aborting when global.env references a
+// service that was filtered out of the selection. Entries that reference a
+// skipped local service must be silently omitted (matching the cross-repo
+// unresolved-ref behavior); entries with defaults must use the default;
+// entries that reference selected services must pass through normally.
+func TestExportBatchEnvFilesOmitsRefsToSkippedServices(t *testing.T) {
+	tmp := t.TempDir()
+	globalPath := filepath.Join(tmp, "global.env")
+
+	defaultPort := "3000"
+	cfg := &config.Config{
+		Global: config.GlobalConfig{
+			EnvFile: globalPath,
+			Env: map[string]config.EnvValue{
+				"API_PORT":         {Ref: "api.PORT"},                                 // selected → kept
+				"WEB_PORT":         {Ref: "web.PORT"},                                 // skipped, no default → omit
+				"WEB_PORT_DEFAULT": {Ref: "web.PORT", Default: &defaultPort},          // skipped but default → kept via default
+				"COMBO_URL":        {Value: "http://api:${api.PORT}/x?w=${web.PORT}"}, // mixes selected + skipped, no default → omit
+				"COMBO_URL_DEF":    {Value: "http://${web.PORT:-3000}/"},              // skipped but inline default → kept
+			},
+		},
+	}
+
+	allocations := []batchAlloc{
+		{
+			name:         "api",
+			svcGroup:     "test",
+			assignedPort: 40100,
+			svc:          config.ServiceConfig{Env: map[string]config.EnvValue{"X": {Value: "y"}}},
+		},
+	}
+	portMap := envexpand.PortMap{"api": {"port": 40100, "PORT": 40100}}
+	skipped := map[string]bool{"web": true}
+
+	if err := exportBatchEnvFiles(cfg, allocations, portMap, nil, nil, skipped); err != nil {
+		t.Fatalf("exportBatchEnvFiles: %v", err)
+	}
+
+	raw, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("read global env: %v", err)
+	}
+	got := string(raw)
+
+	mustContain := []string{`API_PORT="40100"`, `WEB_PORT_DEFAULT="3000"`, `COMBO_URL_DEF="http://3000/"`}
+	for _, want := range mustContain {
+		if !strings.Contains(got, want) {
+			t.Errorf("global env file missing %q\n--- contents ---\n%s", want, got)
+		}
+	}
+
+	mustNotContain := []string{"WEB_PORT=", "COMBO_URL="}
+	for _, bad := range mustNotContain {
+		// Allow "WEB_PORT_DEFAULT=" / "COMBO_URL_DEF=" — match exact key boundary.
+		if strings.Contains(got, "\n"+bad) || strings.HasPrefix(got, bad) {
+			t.Errorf("global env file should have omitted entry starting with %q\n--- contents ---\n%s", bad, got)
+		}
+	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,12 @@ Without a command, reads `mdp.yaml` and batch-starts all configured services:
 ```sh
 mdp run                        # uses current git branch as group
 mdp run --group feature-auth   # override group name
+mdp run --service api          # start only `api` (and its depends_on)
+mdp run --service api,worker   # start a subset (also accepts repeated --service)
+MDP_SERVICES=api,worker mdp run  # same, via env var (flag wins if both are set)
 ```
+
+The `--service` selector restricts batch mode to a subset of the services declared in `mdp.yaml`. Names must match the service keys in the file; transitive `depends_on` entries are auto-included so dependency waits still work. Empty/unset = start everything (default).
 
 When a command is given, `mdp run` picks its mode in this order:
 
@@ -110,6 +115,7 @@ mdp --stop
 | Variable         | Description                                                                         |
 | ---------------- | ----------------------------------------------------------------------------------- |
 | `MDP_PROXY_PORT` | Default proxy port for `mdp run` and `mdp register` (overrides the default of 3000) |
+| `MDP_SERVICES`   | Comma-separated subset of services for `mdp run` batch mode (overridden by `--service`) |
 
 
 `**mdp` flags:**
@@ -141,6 +147,7 @@ mdp --stop
 | `--auto-tls`       | `false`       | Auto-detect TLS certs from mkcert                |
 | `--control-port`   | `13100`       | Orchestrator control port                        |
 | `--link`           |               | Override peer-lookup group: `repo=group` (repeatable). See [cross-repo refs](./mdp-yaml-reference.md#cross-group-lookups-via---link). |
+| `--service`        |               | Batch mode only: start only the listed services (repeatable or comma-separated). Transitive `depends_on` are auto-included. Falls back to `MDP_SERVICES`. |
 
 
 `**mdp register` flags:**

--- a/internal/envexpand/envexpand.go
+++ b/internal/envexpand/envexpand.go
@@ -188,6 +188,31 @@ func ScanCrossRepoRefs(value string) []CrossRepoRef {
 	return out
 }
 
+// LocalServiceRefs returns the distinct names of local services referenced by
+// value through ${svc.key} or ${svc.env.VAR}, in source order. Cross-repo
+// (@repo.) references and references carrying an inline :-default are excluded:
+// the former are resolved by a Resolver, and the latter tolerate the target's
+// absence. Returns nil when value has no qualifying references. Callers use
+// this to discover which sibling services a value depends on for expansion.
+func LocalServiceRefs(value string) []string {
+	var out []string
+	seen := make(map[string]bool)
+	for _, m := range refPattern.FindAllStringSubmatch(value, -1) {
+		if m[2] != "" {
+			continue // cross-repo ref
+		}
+		if m[6] != "" {
+			continue // has an inline :-default
+		}
+		svc := m[3]
+		if !seen[svc] {
+			seen[svc] = true
+			out = append(out, svc)
+		}
+	}
+	return out
+}
+
 // ParseCrossRepoBareRef parses a bare ref of the form @repo.svc[.env].key.
 // Returns (ref, true) if it is a cross-repo bare ref; (zero, false) otherwise.
 func ParseCrossRepoBareRef(ref string) (CrossRepoRef, bool) {

--- a/internal/envexpand/envexpand_test.go
+++ b/internal/envexpand/envexpand_test.go
@@ -477,3 +477,34 @@ func TestIsCrossRepoBareRef(t *testing.T) {
 		})
 	}
 }
+
+func TestLocalServiceRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"no refs", "plain string", nil},
+		{"port ref", "http://localhost:${api.PORT}", []string{"api"}},
+		{"env ref", "postgres://localhost:${db.env.DB_PORT}/app", []string{"db"}},
+		{"multiple distinct", "${api.PORT}/${db.DB_PORT}", []string{"api", "db"}},
+		{"dedupes repeats", "${api.PORT}-${api.ADMIN}", []string{"api"}},
+		{"excludes cross-repo", "${@backend.api.PORT}", nil},
+		{"excludes defaulted", "${db.DB_PORT:-5432}", nil},
+		{"mix: keeps local-no-default only", "${api.PORT}/${db.DB_PORT:-1}/${@x.svc.PORT}", []string{"api"}},
+		{"order preserved", "${web.PORT}-${api.PORT}", []string{"web", "api"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LocalServiceRefs(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("LocalServiceRefs(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("LocalServiceRefs(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds an opt-in subset selector to batch-mode `mdp run`: `--service api,worker` (repeatable, comma-separated) or `MDP_SERVICES=...` in the environment, flag wins on both. Transitive `depends_on` entries are auto-included so the existing dependency machinery has something to wait on, and unknown service names error out with the list of valid keys.

Both the fixed-port pre-reservation and the global env-file resolver respect the selection — entries that reference an unselected service (without a default fallback) are dropped from the global env file with a warning, mirroring the cross-repo unresolved-ref behavior. Defaults are unchanged: empty/unset = start everything. `docs/cli.md` updated with examples plus new rows in the env-vars and `mdp run` flag tables.