### PR TITLE
fix: drop deprecated goreleaser brews block, guard cask xattr hook for linux

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,25 +65,9 @@ homebrew_casks:
     hooks:
       post:
         install: |
-          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/mdp"]
-
-brews:
-  - name: mdp
-    ids:
-      - mdp
-    repository:
-      owner: drgould
-      name: homebrew-mdp
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
-    homepage: "https://github.com/drgould/multi-dev-proxy"
-    description: "Multi-dev proxy — run multiple dev servers behind one port"
-    license: "GPL-3.0"
-    skip_upload: auto
-    install: |
-      bin.install "mdp"
-    test: |
-      assert_match "mdp", shell_output("#{bin}/mdp --help")
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/mdp"]
+          end
 
 scoops:
   - name: mdp

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -744,12 +744,17 @@ func TestSuperviseProcessRestartsOnPeerChange(t *testing.T) {
 	// Stand up a fake control API that returns a port we can flip.
 	var port atomic.Int64
 	port.Store(9001)
+	// peerHits counts /__mdp/peers responses, incremented after encoding so a
+	// given count guarantees that many responses were sent with the port value
+	// current at send time. Used below to gate the flip on the supervisor's seed.
+	var peerHits atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/__mdp/peers" {
 			json.NewEncoder(w).Encode(map[string]any{
 				"port": port.Load(),
 				"env":  map[string]string{},
 			})
+			peerHits.Add(1)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -821,6 +826,19 @@ func TestSuperviseProcessRestartsOnPeerChange(t *testing.T) {
 	}
 	if !waitFor("9001", 2*time.Second) {
 		t.Fatalf("initial cmd never wrote 9001; log=%q", readFile(t, logPath))
+	}
+
+	// Wait for the supervisor to seed its peer baseline at 9001 before flipping.
+	// The 1st /__mdp/peers hit is buildBatchEnv's initial resolve (above); the
+	// 2nd is superviseProcess's seed. If the flip lands before the seed (e.g. a
+	// loaded CI runner delays the supervisor goroutine), the seed reads 9999 and
+	// the watcher never sees a change — the flaky "restart cmd never wrote 9999".
+	seedDeadline := time.Now().Add(2 * time.Second)
+	for peerHits.Load() < 2 && time.Now().Before(seedDeadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if peerHits.Load() < 2 {
+		t.Fatalf("supervisor never seeded peer baseline; /__mdp/peers hits=%d", peerHits.Load())
 	}
 
 	// Flip the peer port; the supervisor should kill the cmd and relaunch


### PR DESCRIPTION
GoReleaser turned the top-level `brews:` key into a hard error in v2.16, which failed the `GoReleaser check` CI job on every PR (both workflows install goreleaser with `version: "~> v2"`). This removes the deprecated `brews:` block and guards the cask's macOS-only `xattr` postflight hook with `if OS.mac?` so the single cask installs cleanly on both macOS and Linux. The Linux Homebrew support added in #53 is preserved via the now-Linux-capable cask (Homebrew #19121 enabled binary casks on Linux), so the separate formula is no longer needed. Verified locally: `goreleaser check` passes with no deprecation output and the rendered cask keeps both `on_macos`/`on_linux` URL blocks with the guarded postflight.

Resolves #56