### PR TITLE
feat: stable per-branch port allocation across mdp runs

### DIFF
--- a/cmd/mdp/pickport_test.go
+++ b/cmd/mdp/pickport_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/derekgould/multi-dev-proxy/internal/ports"
+)
+
+func TestPickPortReusesRememberedFreePort(t *testing.T) {
+	r := ports.PortRange{Start: 10000, End: 60000}
+	finderCalled := false
+	finder := func(ports.PortRange, []int) (int, error) {
+		finderCalled = true
+		return 99999, nil
+	}
+	isFree := func(int) bool { return true }
+
+	remembered := map[string]int{"api": 12345}
+	picked := map[string]int{}
+
+	got, err := pickPort(finder, isFree, remembered, picked, "api", r, nil)
+	if err != nil {
+		t.Fatalf("pickPort: %v", err)
+	}
+	if got != 12345 {
+		t.Errorf("got port %d, want remembered 12345", got)
+	}
+	if finderCalled {
+		t.Error("finder was called even though the remembered port was free")
+	}
+	if picked["api"] != 12345 {
+		t.Errorf("picked[api] = %d, want 12345", picked["api"])
+	}
+}
+
+func TestPickPortFallsBackWhenRememberedTaken(t *testing.T) {
+	r := ports.PortRange{Start: 10000, End: 60000}
+	finder := func(ports.PortRange, []int) (int, error) { return 23456, nil }
+	isFree := func(int) bool { return false } // remembered port is in use
+
+	remembered := map[string]int{"api": 12345}
+	picked := map[string]int{}
+
+	got, err := pickPort(finder, isFree, remembered, picked, "api", r, nil)
+	if err != nil {
+		t.Fatalf("pickPort: %v", err)
+	}
+	if got != 23456 {
+		t.Errorf("got port %d, want freshly allocated 23456", got)
+	}
+	if picked["api"] != 23456 {
+		t.Errorf("picked[api] = %d, want 23456", picked["api"])
+	}
+}
+
+func TestPickPortFallsBackWhenRememberedExcluded(t *testing.T) {
+	r := ports.PortRange{Start: 10000, End: 60000}
+	finder := func(ports.PortRange, []int) (int, error) { return 23456, nil }
+	isFree := func(int) bool { return true }
+
+	remembered := map[string]int{"api": 12345}
+	picked := map[string]int{}
+
+	// 12345 is free but already claimed by another service this run.
+	got, err := pickPort(finder, isFree, remembered, picked, "api", r, []int{12345})
+	if err != nil {
+		t.Fatalf("pickPort: %v", err)
+	}
+	if got != 23456 {
+		t.Errorf("got port %d, want freshly allocated 23456", got)
+	}
+}
+
+func TestPickPortFallsBackWhenRememberedOutOfRange(t *testing.T) {
+	// Range was narrowed since the port was remembered; the old port is free
+	// but no longer inside the configured range, so it must not be reused.
+	r := ports.PortRange{Start: 20000, End: 25000}
+	finderCalled := false
+	finder := func(ports.PortRange, []int) (int, error) {
+		finderCalled = true
+		return 21000, nil
+	}
+	isFree := func(int) bool { return true }
+
+	remembered := map[string]int{"api": 12345} // below r.Start
+	picked := map[string]int{}
+
+	got, err := pickPort(finder, isFree, remembered, picked, "api", r, nil)
+	if err != nil {
+		t.Fatalf("pickPort: %v", err)
+	}
+	if !finderCalled {
+		t.Error("finder was not called for an out-of-range remembered port")
+	}
+	if got != 21000 {
+		t.Errorf("got port %d, want freshly allocated 21000", got)
+	}
+}
+
+func TestPickPortNilMapsAllocateAndDontPanic(t *testing.T) {
+	r := ports.PortRange{Start: 10000, End: 60000}
+	finder := func(ports.PortRange, []int) (int, error) { return 34567, nil }
+	isFree := func(int) bool { return true }
+
+	// Stable ports disabled: both maps nil. Must not panic and must allocate.
+	got, err := pickPort(finder, isFree, nil, nil, "api", r, nil)
+	if err != nil {
+		t.Fatalf("pickPort: %v", err)
+	}
+	if got != 34567 {
+		t.Errorf("got port %d, want 34567", got)
+	}
+}

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -32,6 +32,7 @@ import (
 	"github.com/derekgould/multi-dev-proxy/internal/envexport"
 	"github.com/derekgould/multi-dev-proxy/internal/orchestrator"
 	"github.com/derekgould/multi-dev-proxy/internal/ports"
+	"github.com/derekgould/multi-dev-proxy/internal/portstore"
 	"github.com/derekgould/multi-dev-proxy/internal/process"
 	"github.com/derekgould/multi-dev-proxy/internal/registry"
 )
@@ -70,6 +71,7 @@ func init() {
 	runCmd.Flags().String("tls-key", "", "TLS key file (forwarded to proxy for HTTPS)")
 	runCmd.Flags().Bool("auto-tls", false, "Auto-detect TLS certs from mkcert")
 	runCmd.Flags().String("group", "", "Group name override (default: git branch)")
+	runCmd.Flags().Bool("no-stable-ports", false, "Disable stable per-branch port reuse (allocate fresh ports each run)")
 	runCmd.Flags().String("env", "PORT", "Environment variable name for the assigned port")
 	runCmd.Flags().Int("control-port", 13100, "Orchestrator control port")
 	runCmd.Flags().String("log-split", "", `Demultiplex combined-stream logs. Values: "compose" (docker-compose format) or "regex:<pattern>" with named captures 'name' and 'msg'.`)
@@ -97,6 +99,44 @@ func parseLinks(values []string) (map[string]string, error) {
 		out[repo] = group
 	}
 	return out, nil
+}
+
+// pickPort returns a port for key. When a previously-remembered port for key is
+// still free (per isFree) and not already taken this run (exclude), it is
+// reused; otherwise a fresh port is allocated via finder. The chosen port is
+// recorded in picked so callers can persist it. Passing a nil remembered/picked
+// map disables reuse/recording (used when stable ports are off).
+func pickPort(
+	finder func(ports.PortRange, []int) (int, error),
+	isFree func(int) bool,
+	remembered, picked map[string]int,
+	key string,
+	r ports.PortRange,
+	exclude []int,
+) (int, error) {
+	if p, ok := remembered[key]; ok && p >= r.Start && p <= r.End && isFree(p) && !intInSlice(p, exclude) {
+		if picked != nil {
+			picked[key] = p
+		}
+		return p, nil
+	}
+	p, err := finder(r, exclude)
+	if err != nil {
+		return 0, err
+	}
+	if picked != nil {
+		picked[key] = p
+	}
+	return p, nil
+}
+
+func intInSlice(v int, s []int) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
@@ -175,6 +215,20 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 		return fmt.Errorf("invalid port range in config: %w", err)
 	}
 
+	repo := detect.DetectRepo(filepath.Dir(configPath))
+
+	// Stable ports: reuse this branch's previously-assigned ports (when still
+	// free) so certs/trust keyed to a port survive restarts. Best-effort —
+	// remembered and picked stay nil when disabled, which makes pickPort fall
+	// straight through to fresh allocation.
+	noStable, _ := cmd.Flags().GetBool("no-stable-ports")
+	stable := cfg.StablePortsEnabled() && !noStable
+	var remembered, picked map[string]int
+	if stable {
+		remembered = portstore.Load(repo, group)
+		picked = map[string]int{}
+	}
+
 	bt := &batchTracker{}
 
 	var allocations []batchAlloc
@@ -201,10 +255,12 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 			for envName, value := range svc.Env {
 				if value.Ref == "" && value.Value == "auto" {
 					finder := ports.FindFreePort
+					isFree := ports.IsPortFree
 					if envProtocols[envName] == "udp" {
 						finder = ports.FindFreeUDPPort
+						isFree = ports.IsUDPPortFree
 					}
-					port, err := finder(portRange, assignedPorts)
+					port, err := pickPort(finder, isFree, remembered, picked, name+"."+envName, portRange, assignedPorts)
 					if err != nil {
 						return fmt.Errorf("find free port for %q.%s: %w", name, envName, err)
 					}
@@ -223,7 +279,7 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 
 		assignedPort := svc.Port
 		if assignedPort == 0 {
-			assignedPort, err = ports.FindFreePort(portRange, assignedPorts)
+			assignedPort, err = pickPort(ports.FindFreePort, ports.IsPortFree, remembered, picked, name, portRange, assignedPorts)
 			if err != nil {
 				return fmt.Errorf("find free port for %q: %w", name, err)
 			}
@@ -233,7 +289,17 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 		allocations = append(allocations, batchAlloc{name: name, svc: svc, svcGroup: svcGroup, assignedPort: assignedPort})
 	}
 
-	repo := detect.DetectRepo(filepath.Dir(configPath))
+	if stable {
+		// Merge this run's picks over what was remembered so a service started
+		// via a different mode (single vs batch shares the same repo/group file)
+		// keeps its entry instead of being wiped.
+		for k, v := range picked {
+			remembered[k] = v
+		}
+		if err := portstore.Save(repo, group, remembered); err != nil {
+			slog.Warn("failed to persist stable ports", "err", err)
+		}
+	}
 
 	// Build a resolver per allocation so that services with a `group:` override
 	// query the orchestrator under their own group, not the workspace's
@@ -1111,14 +1177,13 @@ func runSingleMode(cmd *cobra.Command, args []string, controlPort int, groupFlag
 		}
 		tlsKey = abs
 	}
+	repo := repoOverride
+	if repo == "" {
+		repo = detect.DetectRepo(cwd)
+	}
 	serverName := nameOverride
 	if serverName == "" {
-		repo := repoOverride
-		if repo == "" {
-			repo = detect.DetectRepo(cwd)
-		}
-		branch := detect.DetectBranch(cwd)
-		serverName = detect.ServerName(repo, branch)
+		serverName = detect.ServerName(repo, detect.DetectBranch(cwd))
 	}
 
 	group := groupFlag
@@ -1126,9 +1191,28 @@ func runSingleMode(cmd *cobra.Command, args []string, controlPort int, groupFlag
 		group = detect.DetectBranch(cwd)
 	}
 
-	assignedPort, err := ports.FindFreePort(portRange, nil)
+	// Stable ports: reuse this branch's previously-assigned port when still free
+	// (see runBatchMode). On by default; --no-stable-ports opts out.
+	noStable, _ := cmd.Flags().GetBool("no-stable-ports")
+	stable := !noStable
+	var remembered, picked map[string]int
+	if stable {
+		remembered = portstore.Load(repo, group)
+		picked = map[string]int{}
+	}
+	assignedPort, err := pickPort(ports.FindFreePort, ports.IsPortFree, remembered, picked, serverName, portRange, nil)
 	if err != nil {
 		return fmt.Errorf("find free port: %w", err)
+	}
+	if stable {
+		// Merge over remembered so batch-mode services sharing this repo/group
+		// file aren't wiped by an ad-hoc single-command run.
+		for k, v := range picked {
+			remembered[k] = v
+		}
+		if err := portstore.Save(repo, group, remembered); err != nil {
+			slog.Warn("failed to persist stable ports", "err", err)
+		}
 	}
 
 	scheme := "http"

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -115,7 +116,7 @@ func pickPort(
 	r ports.PortRange,
 	exclude []int,
 ) (int, error) {
-	if p, ok := remembered[key]; ok && p >= r.Start && p <= r.End && isFree(p) && !intInSlice(p, exclude) {
+	if p, ok := remembered[key]; ok && p >= r.Start && p <= r.End && isFree(p) && !slices.Contains(exclude, p) {
 		if picked != nil {
 			picked[key] = p
 		}
@@ -129,15 +130,6 @@ func pickPort(
 		picked[key] = p
 	}
 	return p, nil
-}
-
-func intInSlice(v int, s []int) bool {
-	for _, x := range s {
-		if x == v {
-			return true
-		}
-	}
-	return false
 }
 
 // referencedServices returns the local sibling services that svc needs present
@@ -411,13 +403,10 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 	}
 
 	if stable {
-		// Merge this run's picks over what was remembered so a service started
-		// via a different mode (single vs batch shares the same repo/group file)
-		// keeps its entry instead of being wiped.
-		for k, v := range picked {
-			remembered[k] = v
-		}
-		if err := portstore.Save(repo, group, remembered); err != nil {
+		// Save merges picked into the on-disk file under a lock, so other
+		// services' entries (and concurrent runs sharing this repo/group file)
+		// survive.
+		if err := portstore.Save(repo, group, picked); err != nil {
 			slog.Warn("failed to persist stable ports", "err", err)
 		}
 	}
@@ -1394,12 +1383,9 @@ func runSingleMode(cmd *cobra.Command, args []string, controlPort int, groupFlag
 		return fmt.Errorf("find free port: %w", err)
 	}
 	if stable {
-		// Merge over remembered so batch-mode services sharing this repo/group
-		// file aren't wiped by an ad-hoc single-command run.
-		for k, v := range picked {
-			remembered[k] = v
-		}
-		if err := portstore.Save(repo, group, remembered); err != nil {
+		// Save merges under a lock, so batch-mode services sharing this
+		// repo/group file aren't wiped by an ad-hoc single-command run.
+		if err := portstore.Save(repo, group, picked); err != nil {
 			slog.Warn("failed to persist stable ports", "err", err)
 		}
 	}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,6 +136,7 @@ mdp --stop
 | `--group`          |               | Group name override (default: git branch)        |
 | `--env`            | `PORT`        | Env var name for the assigned port               |
 | `--port-range`     | `10000-60000` | Port range for spawned services                  |
+| `--no-stable-ports`| `false`       | Allocate fresh ports each run instead of reusing this branch's previous ports. See [stable ports](./recipes.md#stable-ports). |
 | `--tls-cert`       |               | TLS certificate file (serves this service over HTTPS; see [recipes](./recipes.md)) |
 | `--tls-key`        |               | TLS key file (paired with `--tls-cert`)          |
 | `--auto-tls`       | `false`       | Auto-detect TLS certs from mkcert                |

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -39,6 +39,7 @@ services:
 |---|---|---|---|
 | `services` | map of name → [service](#service) | `{}` | Each key is a service name. Shown in the TUI and referenced by `depends_on`. |
 | `port_range` | `"MIN-MAX"` string | `"10000-60000"` | Range for auto-allocating service ports (when `port` is `0` / unset). |
+| `stable_ports` | bool | `true` | Reuse each branch's previously-assigned ports across restarts (when still free), stored under `~/.mdp/ports/`. Set `false` to allocate fresh ports every run. See [Stable ports](./recipes.md#stable-ports). |
 | `global` | [global](#global) | `{}` | Project-wide env export block. |
 
 ```yaml

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -103,6 +103,20 @@ mkcert localhost
 mdp run --tls-cert localhost.pem --tls-key localhost-key.pem -- npm run dev
 ```
 
+## Stable ports
+
+By default mdp remembers each branch's assigned ports and reuses them on the next `mdp run`, as long as the port is still free. Assignments are stored per repo + branch under `~/.mdp/ports/`. This keeps ports steady across restarts — handy when a service binds a TLS cert (or a trust-store entry) to a specific port, so the one-time setup survives a restart instead of repeating every run.
+
+The first run still picks ports at random, so different branches naturally get distinct ports. If a remembered port is taken by something else at startup, mdp transparently allocates a fresh one.
+
+To turn it off, use `--no-stable-ports` — the universal off switch, valid for both `mdp run` (batch) and `mdp run -- <command>` (single-command) runs:
+
+```sh
+mdp run --no-stable-ports
+```
+
+For batch runs you can also disable it by default in `mdp.yaml` with `stable_ports: false`. (The config file isn't read for single-command runs, so use the flag there.)
+
 ---
 
 [← Back to docs index](./index.md)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/spf13/cobra v1.8.0
+	golang.org/x/sys v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -28,6 +29,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,16 @@ import (
 type Config struct {
 	Services  map[string]ServiceConfig `yaml:"services"`
 	PortRange string                   `yaml:"port_range"`
-	Global    GlobalConfig             `yaml:"global"`
+	// StablePorts toggles per-branch stable port reuse. Nil (absent) means on;
+	// set `stable_ports: false` to disable. See StablePortsEnabled.
+	StablePorts *bool        `yaml:"stable_ports"`
+	Global      GlobalConfig `yaml:"global"`
+}
+
+// StablePortsEnabled reports whether per-branch stable port reuse is active.
+// It defaults to on; set `stable_ports: false` in mdp.yaml to disable.
+func (c *Config) StablePortsEnabled() bool {
+	return c.StablePorts == nil || *c.StablePorts
 }
 
 // GlobalConfig holds project-wide settings that aren't tied to a single service.

--- a/internal/portstore/lock_unix.go
+++ b/internal/portstore/lock_unix.go
@@ -1,0 +1,26 @@
+//go:build unix
+
+package portstore
+
+import (
+	"os"
+	"syscall"
+)
+
+// withLock runs fn while holding an exclusive advisory lock on lockPath,
+// releasing it when fn returns. flock is tied to the open file description and
+// released by the kernel if the process dies, so a crash can't leave a stale
+// lock behind. The lock file itself is intentionally left in place (unlinking a
+// flock'd file is racy).
+func withLock(lockPath string, fn func() error) error {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return fn()
+}

--- a/internal/portstore/lock_windows.go
+++ b/internal/portstore/lock_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package portstore
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// withLock runs fn while holding an exclusive lock on lockPath via LockFileEx,
+// releasing it when fn returns. Windows releases the lock when the handle is
+// closed (including on process exit), so a crash can't leave a stale lock.
+func withLock(lockPath string, fn func() error) error {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := windows.Handle(f.Fd())
+	ol := new(windows.Overlapped)
+	if err := windows.LockFileEx(h, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, ol); err != nil {
+		return err
+	}
+	defer windows.UnlockFileEx(h, 0, 1, 0, ol)
+	return fn()
+}

--- a/internal/portstore/portstore.go
+++ b/internal/portstore/portstore.go
@@ -13,10 +13,16 @@ import (
 	"regexp"
 )
 
-// dir returns the directory where port-assignment files live. Declared as a
-// var so tests can redirect it without touching $HOME.
+// dir returns the directory where port-assignment files live, or "" when the
+// home directory can't be determined (e.g. $HOME unset in some containers/CI).
+// Returning "" rather than a relative path keeps Save from leaking a `.mdp/`
+// directory into the current working directory. Declared as a var so tests can
+// redirect it without touching $HOME.
 var dir = func() string {
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
 	return filepath.Join(home, ".mdp", "ports")
 }
 
@@ -39,11 +45,10 @@ func sanitize(s string) string {
 	return s
 }
 
-// Load returns the remembered port assignments for (repo, group). Any error
-// (missing file, unreadable, malformed) yields an empty map so callers can
-// treat persistence as advisory.
-func Load(repo, group string) map[string]int {
-	data, err := os.ReadFile(filepath.Join(dir(), fileName(repo, group)))
+// readFile loads the assignment map at path, returning an empty map on any
+// error (missing, unreadable, malformed) so persistence stays best-effort.
+func readFile(path string) map[string]int {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return map[string]int{}
 	}
@@ -54,21 +59,60 @@ func Load(repo, group string) map[string]int {
 	return m
 }
 
-// Save writes the port assignments for (repo, group) atomically (temp file +
-// rename). encoding/json emits map keys in sorted order, so output is stable.
+// Load returns the remembered port assignments for (repo, group). Reads are
+// lock-free: Save replaces the file via atomic rename, so a reader always sees
+// a complete file (the old or the new one), never a torn write.
+func Load(repo, group string) map[string]int {
+	d := dir()
+	if d == "" {
+		return map[string]int{}
+	}
+	return readFile(filepath.Join(d, fileName(repo, group)))
+}
+
+// Save merges m into the persisted assignments for (repo, group) and writes the
+// result atomically (temp file + rename). The read-merge-write runs under an
+// exclusive file lock so concurrent mdp runs sharing the (repo, group) file —
+// e.g. two `mdp run --service ...` invocations for disjoint subsets — don't drop
+// each other's entries to a last-writer-wins overwrite.
 func Save(repo, group string, m map[string]int) error {
 	d := dir()
+	if d == "" {
+		return nil // no home dir — degrade to non-persistent (best-effort)
+	}
 	if err := os.MkdirAll(d, 0o755); err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return err
-	}
 	path := filepath.Join(d, fileName(repo, group))
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return withLock(path+".lock", func() error {
+		merged := readFile(path)
+		for k, v := range m {
+			merged[k] = v
+		}
+		data, err := json.MarshalIndent(merged, "", "  ")
+		if err != nil {
+			return err
+		}
+		// Unique temp file + atomic rename. The lock already serializes writers;
+		// CreateTemp guarantees the in-flight temp is never shared even so.
+		tmp, err := os.CreateTemp(d, "ports-*.tmp")
+		if err != nil {
+			return err
+		}
+		tmpName := tmp.Name()
+		if _, err := tmp.Write(data); err != nil {
+			tmp.Close()
+			os.Remove(tmpName)
+			return err
+		}
+		if err := tmp.Close(); err != nil {
+			os.Remove(tmpName)
+			return err
+		}
+		if err := os.Rename(tmpName, path); err != nil {
+			os.Remove(tmpName)
+			return err
+		}
+		return nil
+	})
 }

--- a/internal/portstore/portstore.go
+++ b/internal/portstore/portstore.go
@@ -1,0 +1,74 @@
+// Package portstore persists per-(repo, group) port assignments under ~/.mdp
+// so a branch's services keep the same ports across mdp restarts. Reuse is
+// best-effort — callers only reuse a remembered port when it is still free, so
+// a missing or stale file never blocks a run.
+package portstore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// dir returns the directory where port-assignment files live. Declared as a
+// var so tests can redirect it without touching $HOME.
+var dir = func() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".mdp", "ports")
+}
+
+var unsafeChars = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// fileName builds the JSON filename for a (repo, group) pair. The human-readable
+// parts are sanitized for the filesystem and suffixed with a short hash of the
+// raw inputs so distinct pairs that sanitize to the same string don't collide.
+func fileName(repo, group string) string {
+	sum := sha256.Sum256([]byte(repo + "\x00" + group))
+	h := hex.EncodeToString(sum[:])[:8]
+	return sanitize(repo) + "__" + sanitize(group) + "__" + h + ".json"
+}
+
+func sanitize(s string) string {
+	s = unsafeChars.ReplaceAllString(s, "-")
+	if s == "" {
+		return "_"
+	}
+	return s
+}
+
+// Load returns the remembered port assignments for (repo, group). Any error
+// (missing file, unreadable, malformed) yields an empty map so callers can
+// treat persistence as advisory.
+func Load(repo, group string) map[string]int {
+	data, err := os.ReadFile(filepath.Join(dir(), fileName(repo, group)))
+	if err != nil {
+		return map[string]int{}
+	}
+	m := map[string]int{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return map[string]int{}
+	}
+	return m
+}
+
+// Save writes the port assignments for (repo, group) atomically (temp file +
+// rename). encoding/json emits map keys in sorted order, so output is stable.
+func Save(repo, group string, m map[string]int) error {
+	d := dir()
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(d, fileName(repo, group))
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/portstore/portstore_test.go
+++ b/internal/portstore/portstore_test.go
@@ -3,6 +3,8 @@ package portstore
 import (
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 )
 
@@ -34,21 +36,16 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
-func TestLoadMergeSavePreservesOtherKeys(t *testing.T) {
+func TestSaveMergesWithExistingFile(t *testing.T) {
 	withTempDir(t)
 
 	// A batch run records two services.
 	if err := Save("repo", "main", map[string]int{"api": 100, "web": 200}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-
-	// A later (e.g. single-command) run reuses Load → merge → Save with a
-	// disjoint key. The original entries must survive.
-	remembered := Load("repo", "main")
-	for k, v := range map[string]int{"adhoc": 300} {
-		remembered[k] = v
-	}
-	if err := Save("repo", "main", remembered); err != nil {
+	// A later run (e.g. a disjoint `--service` subset, or single-command mode)
+	// saves only its own key. Save merges, so the originals survive.
+	if err := Save("repo", "main", map[string]int{"adhoc": 300}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -61,6 +58,53 @@ func TestLoadMergeSavePreservesOtherKeys(t *testing.T) {
 		if got[k] != v {
 			t.Errorf("key %q: got %d, want %d", k, got[k], v)
 		}
+	}
+}
+
+func TestConcurrentSavesDoNotDropEntries(t *testing.T) {
+	withTempDir(t)
+
+	// Many processes/goroutines saving disjoint keys to the same (repo, group)
+	// file concurrently must not drop each other's entries. The locked
+	// read-merge-write in Save serializes them; without it this loses entries.
+	const n = 20
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := "svc" + strconv.Itoa(i)
+			if err := Save("repo", "main", map[string]int{key: 10000 + i}); err != nil {
+				t.Errorf("Save: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	got := Load("repo", "main")
+	if len(got) != n {
+		t.Fatalf("got %d entries, want %d — concurrent saves dropped entries: %v", len(got), n, got)
+	}
+	for i := 0; i < n; i++ {
+		key := "svc" + strconv.Itoa(i)
+		if got[key] != 10000+i {
+			t.Errorf("key %q: got %d, want %d", key, got[key], 10000+i)
+		}
+	}
+}
+
+func TestSaveSkipsWhenNoHomeDir(t *testing.T) {
+	// dir() returns "" when the home directory is unknown; Save must be a no-op
+	// rather than writing a relative ".mdp/" into the cwd.
+	orig := dir
+	dir = func() string { return "" }
+	t.Cleanup(func() { dir = orig })
+
+	if err := Save("repo", "main", map[string]int{"api": 1}); err != nil {
+		t.Errorf("Save with no home dir should be a no-op, got: %v", err)
+	}
+	if got := Load("repo", "main"); len(got) != 0 {
+		t.Errorf("Load with no home dir should be empty, got %v", got)
 	}
 }
 

--- a/internal/portstore/portstore_test.go
+++ b/internal/portstore/portstore_test.go
@@ -1,0 +1,114 @@
+package portstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempDir redirects the store directory to a fresh temp dir for the test.
+func withTempDir(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	orig := dir
+	dir = func() string { return tmp }
+	t.Cleanup(func() { dir = orig })
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	withTempDir(t)
+
+	want := map[string]int{"api": 12345, "web.PORT": 23456}
+	if err := Save("myrepo", "feature/x", want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got := Load("myrepo", "feature/x")
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %q: got %d, want %d", k, got[k], v)
+		}
+	}
+}
+
+func TestLoadMergeSavePreservesOtherKeys(t *testing.T) {
+	withTempDir(t)
+
+	// A batch run records two services.
+	if err := Save("repo", "main", map[string]int{"api": 100, "web": 200}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// A later (e.g. single-command) run reuses Load → merge → Save with a
+	// disjoint key. The original entries must survive.
+	remembered := Load("repo", "main")
+	for k, v := range map[string]int{"adhoc": 300} {
+		remembered[k] = v
+	}
+	if err := Save("repo", "main", remembered); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got := Load("repo", "main")
+	want := map[string]int{"api": 100, "web": 200, "adhoc": 300}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %q: got %d, want %d", k, got[k], v)
+		}
+	}
+}
+
+func TestLoadMissingReturnsEmpty(t *testing.T) {
+	withTempDir(t)
+
+	got := Load("norepo", "nobranch")
+	if got == nil {
+		t.Fatal("Load returned nil; want empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d entries, want 0", len(got))
+	}
+}
+
+func TestLoadMalformedReturnsEmpty(t *testing.T) {
+	withTempDir(t)
+
+	path := filepath.Join(dir(), fileName("repo", "branch"))
+	if err := os.MkdirAll(dir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := Load("repo", "branch"); len(got) != 0 {
+		t.Errorf("got %v, want empty map", got)
+	}
+}
+
+func TestFileNameSanitizesAndDisambiguates(t *testing.T) {
+	// Branch names with slashes must not produce nested paths.
+	name := fileName("myrepo", "feature/login")
+	if filepath.Base(name) != name {
+		t.Errorf("fileName produced a path separator: %q", name)
+	}
+
+	// Distinct pairs that sanitize to the same readable string must differ
+	// thanks to the hash suffix.
+	a := fileName("repo", "a/b")
+	b := fileName("repo", "a-b")
+	if a == b {
+		t.Errorf("distinct pairs collided: %q == %q", a, b)
+	}
+
+	// Same inputs are stable across calls.
+	if fileName("repo", "a/b") != a {
+		t.Error("fileName not deterministic for the same inputs")
+	}
+}


### PR DESCRIPTION
mdp now remembers each branch's assigned ports under `~/.mdp/ports/` (per repo + group) and reuses them on the next run when the port is still free and in range, so setup pinned to a port — e.g. trusting a TLS cert bound to a floci port — survives restarts instead of repeating every run. A new `internal/portstore` package persists the mapping, and both `runBatchMode` and `runSingleMode` allocate via a new `pickPort` helper that reuses a remembered port or falls back to fresh allocation, merging picks back into the file so batch and single modes don't wipe each other's entries. The first run still allocates randomly (so branches diverge) and a taken remembered port transparently reallocates. It's on by default; opt out with `stable_ports: false` in `mdp.yaml` (batch runs) or `--no-stable-ports` (both modes). Includes docs updates (`recipes.md`, `cli.md`, `mdp-yaml-reference.md`) and unit tests for `portstore` and `pickPort`.