### PR TITLE
feat: interactive inputs and cross-repo links for mdp run

### DIFF
--- a/cmd/mdp/inputs.go
+++ b/cmd/mdp/inputs.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/derekgould/multi-dev-proxy/internal/config"
+	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
+)
+
+// fetchActiveGroups returns the sorted list of groups currently registered with
+// the orchestrator, used to populate `choices: groups` pick-lists. Returns nil
+// on any error — prompting then degrades to free-text entry.
+func fetchActiveGroups(client *http.Client, controlURL string) []string {
+	resp, err := client.Get(controlURL + "/__mdp/groups")
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	var groups map[string][]string
+	if err := json.NewDecoder(resp.Body).Decode(&groups); err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(groups))
+	for g := range groups {
+		names = append(names, g)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// resolveInputs produces the {name -> value} map for the config's declared
+// inputs. When interactive, each input is prompted for (groupsFor populates
+// `choices: groups` lists, fetched at most once) reading from in; otherwise
+// every input resolves to its Default, and an input with no default is an
+// error. in/out are injectable for testing.
+func resolveInputs(cfg *config.Config, interactive bool, groupsFor func() []string, in io.Reader, out io.Writer) (map[string]string, error) {
+	if len(cfg.Inputs) == 0 {
+		return nil, nil
+	}
+	values := make(map[string]string, len(cfg.Inputs))
+	reader := bufio.NewReader(in)
+	var groups []string
+	var groupsLoaded bool
+	for _, spec := range cfg.Inputs {
+		if !interactive {
+			if !spec.HasDefault {
+				return nil, fmt.Errorf("input %q has no default; rerun with -i to provide a value", spec.Name)
+			}
+			values[spec.Name] = spec.Default
+			continue
+		}
+		if spec.Choices == "groups" && !groupsLoaded {
+			groups = groupsFor()
+			groupsLoaded = true
+		}
+		val, err := promptInput(spec, groups, reader, out)
+		if err != nil {
+			return nil, err
+		}
+		values[spec.Name] = val
+	}
+	return values, nil
+}
+
+// promptInput asks for one input on out, reading the answer from r, and returns
+// the resolved value. For `choices: groups` it prints a numbered list of active
+// groups (marking the default) and accepts a list number or a typed value; an
+// answer matching a group name is taken literally (so a numerically-named group
+// stays selectable), and an out-of-range number is taken as a literal value (so
+// a not-yet-running branch named "3" can still be entered). An empty answer
+// uses the default when one is declared, else re-prompts. EOF (Ctrl-D / end of
+// input) aborts. The resolved value — typed or picked — is rejected if it
+// contains ${...}, so inputs stay plain literals (no smuggled port/peer refs).
+func promptInput(spec config.InputSpec, groups []string, r *bufio.Reader, out io.Writer) (string, error) {
+	label := spec.Prompt
+	if label == "" {
+		label = spec.Name
+	}
+	pickList := spec.Choices == "groups" && len(groups) > 0
+	if pickList {
+		fmt.Fprintf(out, "%s\n", label)
+		for i, g := range groups {
+			marker := ""
+			if g == spec.Default {
+				marker = " (default)"
+			}
+			fmt.Fprintf(out, "  %d) %s%s\n", i+1, g, marker)
+		}
+	}
+	for {
+		switch {
+		case pickList && spec.HasDefault:
+			fmt.Fprintf(out, "Select a number, type a branch, or press enter for default [%s]: ", spec.Default)
+		case pickList:
+			fmt.Fprintf(out, "Select a number or type a branch: ")
+		case spec.HasDefault:
+			fmt.Fprintf(out, "%s [%s]: ", label, spec.Default)
+		default:
+			fmt.Fprintf(out, "%s: ", label)
+		}
+
+		line, err := r.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return "", fmt.Errorf("read input %q: %w", spec.Name, err)
+		}
+		answer := strings.TrimSpace(line)
+		if answer == "" {
+			if err == io.EOF {
+				return "", fmt.Errorf("input %q cancelled (end of input)", spec.Name)
+			}
+			if spec.HasDefault {
+				return spec.Default, nil
+			}
+			fmt.Fprintln(out, "  a value is required")
+			continue
+		}
+
+		value := answer
+		// In a pick-list, a bare number selects by 1-based index. An exact
+		// group-name match wins first (so a group literally named "456" stays
+		// selectable), and an out-of-range number is taken as a literal value
+		// (so a not-yet-running branch named "3" can still be entered).
+		if pickList && !slices.Contains(groups, answer) {
+			if n, convErr := strconv.Atoi(answer); convErr == nil && n >= 1 && n <= len(groups) {
+				value = groups[n-1]
+			}
+		}
+		// Guard the resolved value — covers both the typed and pick-list paths.
+		if strings.Contains(value, "${") {
+			return "", fmt.Errorf("input %q: value must be a plain literal (it cannot contain ${...} references)", spec.Name)
+		}
+		return value, nil
+	}
+}
+
+// applyInputs rewrites every ${inputs.X} reference in the loaded config to its
+// resolved value, in place, so the downstream pipeline never sees an input
+// reference. It drives config.VisitInputRefFields — the single source of truth
+// for which fields support inputs — so the substituted set always matches what
+// validation checked.
+func applyInputs(cfg *config.Config, inputs map[string]string) error {
+	var firstErr error
+	cfg.VisitInputRefFields(func(where, value string) (string, bool) {
+		if firstErr != nil {
+			return value, false
+		}
+		out, err := envexpand.SubstituteInputs(value, inputs)
+		if err != nil {
+			firstErr = fmt.Errorf("%s: %w", where, err)
+			return value, false
+		}
+		// A `ref:` that substitutes to empty would be silently downgraded to a
+		// scalar empty value (KEY=) by env building — reject it instead.
+		if out == "" && value != "" && strings.HasSuffix(where, " ref") {
+			firstErr = fmt.Errorf("%s resolved to an empty ref", where)
+			return value, false
+		}
+		return out, true
+	})
+	return firstErr
+}
+
+// checkLinkGroups rejects any link whose group resolved to empty — a declared
+// link pointing at nothing would silently fall back to the caller's own group.
+// Run after merging config links with CLI --link overrides, so an override can
+// rescue a config link that resolved empty.
+func checkLinkGroups(links map[string]string) error {
+	repos := make([]string, 0, len(links))
+	for repo := range links {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+	for _, repo := range repos {
+		if strings.TrimSpace(links[repo]) == "" {
+			return fmt.Errorf("link %q resolves to an empty group", repo)
+		}
+	}
+	return nil
+}

--- a/cmd/mdp/inputs_test.go
+++ b/cmd/mdp/inputs_test.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/derekgould/multi-dev-proxy/internal/config"
+)
+
+func TestPromptInput(t *testing.T) {
+	groups := []string{"main", "derek/foo"}
+	tests := []struct {
+		name    string
+		spec    config.InputSpec
+		groups  []string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{"pick by number", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "2\n", "derek/foo", ""},
+		{"empty uses default", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "\n", "main", ""},
+		{"custom typed branch", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "other/branch\n", "other/branch", ""},
+		{"out-of-range number is literal", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "9\n", "9", ""},
+		{"numeric-named group selectable", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, []string{"main", "456"}, "456\n", "456", ""},
+		{"picked group with ${} rejected", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, []string{"main", "dev${x.port}"}, "2\n", "", "plain literal"},
+		{"free text", config.InputSpec{Name: "r", Default: "us", HasDefault: true}, nil, "eu\n", "eu", ""},
+		{"free text empty uses default", config.InputSpec{Name: "r", Default: "us", HasDefault: true}, nil, "\n", "us", ""},
+		{"no active groups falls to free text", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, nil, "1\n", "1", ""},
+		{"EOF aborts", config.InputSpec{Name: "b", Default: "main", HasDefault: true}, nil, "", "", "cancelled"},
+		{"re-prompts then accepts value when no default", config.InputSpec{Name: "b"}, nil, "\nfeature\n", "feature", ""},
+		{"value with ${} rejected", config.InputSpec{Name: "b", Default: "main", HasDefault: true}, nil, "${web.port}\n", "", "plain literal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bufio.NewReader(strings.NewReader(tt.input))
+			var out bytes.Buffer
+			got, err := promptInput(tt.spec, tt.groups, r, &out)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveInputsDefaults(t *testing.T) {
+	cfg := &config.Config{Inputs: config.Inputs{
+		{Name: "a", Default: "x", HasDefault: true},
+		{Name: "b", Default: "y", HasDefault: true},
+	}}
+	vals, err := resolveInputs(cfg, false, nil, strings.NewReader(""), io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["a"] != "x" || vals["b"] != "y" {
+		t.Fatalf("got %v", vals)
+	}
+}
+
+func TestResolveInputsMissingDefault(t *testing.T) {
+	cfg := &config.Config{Inputs: config.Inputs{{Name: "a"}}}
+	_, err := resolveInputs(cfg, false, nil, strings.NewReader(""), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "has no default") {
+		t.Fatalf("want missing-default error, got %v", err)
+	}
+}
+
+// An explicit `default: ""` is a valid optional value, distinct from an absent
+// default, so the non-interactive path resolves it to "" without erroring.
+func TestResolveInputsEmptyDefault(t *testing.T) {
+	cfg := &config.Config{Inputs: config.Inputs{{Name: "a", Default: "", HasDefault: true}}}
+	vals, err := resolveInputs(cfg, false, nil, strings.NewReader(""), io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, ok := vals["a"]; !ok || v != "" {
+		t.Fatalf("got %q (ok=%v), want empty string", v, ok)
+	}
+}
+
+// Without -i (interactive=false), defaults are used and the groups fetcher is
+// never invoked.
+func TestResolveInputsPromptDisabled(t *testing.T) {
+	cfg := &config.Config{Inputs: config.Inputs{{Name: "a", Default: "x", HasDefault: true, Choices: "groups"}}}
+	vals, err := resolveInputs(cfg, false, func() []string {
+		t.Fatal("groups fetcher must not be called when prompting is disabled")
+		return nil
+	}, strings.NewReader("ignored\n"), io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["a"] != "x" {
+		t.Fatalf("got %v", vals)
+	}
+}
+
+// When prompting, a `choices: groups` input fetches the active groups once and
+// accepts a numbered selection; a plain input reads free text; and an empty
+// answer falls back to the declared default.
+func TestResolveInputsPrompting(t *testing.T) {
+	cfg := &config.Config{Inputs: config.Inputs{
+		{Name: "branch", Default: "main", HasDefault: true, Choices: "groups"},
+		{Name: "region", Default: "us", HasDefault: true},
+		{Name: "tier", Default: "free", HasDefault: true},
+	}}
+	fetches := 0
+	groupsFor := func() []string {
+		fetches++
+		return []string{"main", "derek/foo"}
+	}
+	// branch: pick #2; region: typed; tier: empty => default.
+	vals, err := resolveInputs(cfg, true, groupsFor, strings.NewReader("2\neu\n\n"), io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["branch"] != "derek/foo" || vals["region"] != "eu" || vals["tier"] != "free" {
+		t.Fatalf("got %v", vals)
+	}
+	if fetches != 1 {
+		t.Fatalf("groups fetched %d times, want 1", fetches)
+	}
+}
+
+func TestApplyInputs(t *testing.T) {
+	def := "${inputs.x}"
+	cfg := &config.Config{
+		Services: map[string]config.ServiceConfig{
+			"web": {
+				Command:  "run --branch ${inputs.x}",
+				Dir:      "/repo/worktrees/${inputs.x}",
+				EnvFile:  "/repo/worktrees/${inputs.x}/.env",
+				Setup:    []string{"setup ${inputs.x}"},
+				Shutdown: []string{"teardown ${inputs.x}"},
+				Env: map[string]config.EnvValue{
+					"A": {Value: "v-${inputs.x}"},
+					"B": {Ref: "api.port", Default: &def},
+					"C": {Ref: "@${inputs.x}.server.port"},
+				},
+			},
+		},
+		Global: config.GlobalConfig{Env: map[string]config.EnvValue{
+			"G": {Value: "${inputs.x}"},
+		}},
+		Links: map[string]string{"api": "${inputs.x}", "auth": "stable"},
+	}
+	if err := applyInputs(cfg, map[string]string{"x": "main"}); err != nil {
+		t.Fatalf("applyInputs: %v", err)
+	}
+	web := cfg.Services["web"]
+	if web.Command != "run --branch main" {
+		t.Fatalf("command = %q", web.Command)
+	}
+	if web.Dir != "/repo/worktrees/main" {
+		t.Fatalf("dir = %q", web.Dir)
+	}
+	if web.EnvFile != "/repo/worktrees/main/.env" {
+		t.Fatalf("env_file = %q", web.EnvFile)
+	}
+	if web.Setup[0] != "setup main" || web.Shutdown[0] != "teardown main" {
+		t.Fatalf("setup/shutdown = %v / %v", web.Setup, web.Shutdown)
+	}
+	if got := web.Env["A"].Value; got != "v-main" {
+		t.Fatalf("env A = %q", got)
+	}
+	if got := web.Env["B"].DefaultValue(); got != "main" {
+		t.Fatalf("env B default = %q", got)
+	}
+	if got := web.Env["C"].Ref; got != "@main.server.port" {
+		t.Fatalf("env C ref = %q", got)
+	}
+	if got := cfg.Global.Env["G"].Value; got != "main" {
+		t.Fatalf("global G = %q", got)
+	}
+	if cfg.Links["api"] != "main" || cfg.Links["auth"] != "stable" {
+		t.Fatalf("links = %v", cfg.Links)
+	}
+}
+
+// A relative env_file resolved against a dir containing ${inputs...} must be
+// fixed up alongside dir, not left pointing at the literal placeholder path.
+func TestApplyInputsResolvesRelativeEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+inputs:
+  branch:
+    default: main
+services:
+  web:
+    command: run
+    dir: ./services/${inputs.branch}
+    env_file: .env
+    proxy: 3000
+`), 0644)
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if err := applyInputs(cfg, map[string]string{"branch": "feature"}); err != nil {
+		t.Fatalf("applyInputs: %v", err)
+	}
+	cfg.FinalizePaths(dir) // mirrors runBatchMode: resolve paths after substitution
+	web := cfg.Services["web"]
+	wantDir := filepath.Join(dir, "services", "feature")
+	if web.Dir != wantDir {
+		t.Fatalf("dir = %q, want %q", web.Dir, wantDir)
+	}
+	if want := filepath.Join(wantDir, ".env"); web.EnvFile != want {
+		t.Fatalf("env_file = %q, want %q", web.EnvFile, want)
+	}
+}
+
+// An input resolving to an absolute path must be honored as-is, not joined to
+// the config dir — the case that breaks if resolution runs before substitution.
+func TestApplyInputsAbsoluteDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+inputs:
+  wt:
+    default: /tmp/placeholder
+services:
+  web:
+    command: run
+    dir: ${inputs.wt}
+    proxy: 3000
+`), 0644)
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if err := applyInputs(cfg, map[string]string{"wt": "/home/u/work"}); err != nil {
+		t.Fatalf("applyInputs: %v", err)
+	}
+	cfg.FinalizePaths(dir)
+	if got := cfg.Services["web"].Dir; got != "/home/u/work" {
+		t.Fatalf("dir = %q, want /home/u/work (must not be joined to the config dir)", got)
+	}
+}
+
+// An env ref: that resolves to empty must be rejected, not silently downgraded
+// to a scalar KEY= value.
+func TestApplyInputsEmptyRef(t *testing.T) {
+	cfg := &config.Config{Services: map[string]config.ServiceConfig{
+		"web": {Env: map[string]config.EnvValue{"K": {Ref: "${inputs.target}"}}},
+	}}
+	err := applyInputs(cfg, map[string]string{"target": ""})
+	if err == nil || !strings.Contains(err.Error(), "empty ref") {
+		t.Fatalf("want empty-ref error, got %v", err)
+	}
+}
+
+// A link that resolves to an empty group is an error (not a silent fall-through
+// to the caller's own group), but only after CLI --link overrides are merged in
+// — an override can rescue a config link that resolved empty.
+func TestCheckLinkGroups(t *testing.T) {
+	if err := checkLinkGroups(map[string]string{"api": "main"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := checkLinkGroups(map[string]string{"api": ""}); err == nil || !strings.Contains(err.Error(), "empty group") {
+		t.Fatalf("want empty-group error, got %v", err)
+	}
+	// An input that resolves to empty leaves an empty config link; a --link
+	// override for that repo rescues it, so the merged result is valid.
+	cfg := &config.Config{Links: map[string]string{"api": "${inputs.x}"}}
+	if err := applyInputs(cfg, map[string]string{"x": ""}); err != nil {
+		t.Fatalf("applyInputs: %v", err)
+	}
+	merged := mergeLinks(cfg.Links, map[string]string{"api": "main"})
+	if err := checkLinkGroups(merged); err != nil {
+		t.Fatalf("override should rescue empty link, got %v", err)
+	}
+	// Without the override the empty link is rejected.
+	if err := checkLinkGroups(mergeLinks(cfg.Links, nil)); err == nil {
+		t.Fatalf("want empty-group error for un-overridden empty link")
+	}
+}
+
+func TestFetchActiveGroups(t *testing.T) {
+	client := &http.Client{}
+
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"main":["a"],"derek/foo":["b"]}`))
+	}))
+	defer ok.Close()
+	if got := fetchActiveGroups(client, ok.URL); !reflect.DeepEqual(got, []string{"derek/foo", "main"}) {
+		t.Fatalf("success: got %v, want sorted [derek/foo main]", got)
+	}
+
+	// Each degradation path returns nil so prompting falls back to free text.
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	if got := fetchActiveGroups(client, bad.URL); got != nil {
+		t.Fatalf("non-200: got %v, want nil", got)
+	}
+
+	junk := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer junk.Close()
+	if got := fetchActiveGroups(client, junk.URL); got != nil {
+		t.Fatalf("bad json: got %v, want nil", got)
+	}
+
+	if got := fetchActiveGroups(client, "http://127.0.0.1:1"); got != nil {
+		t.Fatalf("connection error: got %v, want nil", got)
+	}
+}
+
+func TestMergeLinks(t *testing.T) {
+	// CLI wins per repo; config-only repos are retained.
+	got := mergeLinks(
+		map[string]string{"api": "main", "auth": "stable"},
+		map[string]string{"api": "cli-override"},
+	)
+	want := map[string]string{"api": "cli-override", "auth": "stable"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	// No config links: returns the CLI map unchanged.
+	cli := map[string]string{"x": "y"}
+	if got := mergeLinks(nil, cli); !reflect.DeepEqual(got, cli) {
+		t.Fatalf("got %v, want %v", got, cli)
+	}
+	// No CLI links: returns the config map unchanged (no allocation).
+	conf := map[string]string{"api": "main"}
+	if got := mergeLinks(conf, nil); !reflect.DeepEqual(got, conf) {
+		t.Fatalf("got %v, want %v", got, conf)
+	}
+}

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -74,6 +74,7 @@ func init() {
 	runCmd.Flags().Int("control-port", 13100, "Orchestrator control port")
 	runCmd.Flags().String("log-split", "", `Demultiplex combined-stream logs. Values: "compose" (docker-compose format) or "regex:<pattern>" with named captures 'name' and 'msg'.`)
 	runCmd.Flags().StringArray("link", nil, "Override the lookup group for cross-repo @<repo>.* env refs: repo=group (repeatable, last-wins per repo). Used when a peer service runs in a different group than the caller (e.g. backend on main, frontend on a feature branch).")
+	runCmd.Flags().BoolP("interactive", "i", false, "Prompt for the inputs declared in mdp.yaml (see the `inputs:` section); without it, inputs use their defaults.")
 }
 
 // parseLinks converts repeated `--link repo=group` values into a map. Empty
@@ -99,6 +100,27 @@ func parseLinks(values []string) (map[string]string, error) {
 	return out, nil
 }
 
+// mergeLinks combines config `links:` with CLI --link overrides. CLI wins per
+// repo. Returns the CLI map unchanged when there are no config links. Empty
+// groups are not filtered here — checkLinkGroups rejects them after the merge,
+// so a CLI override can still rescue a config link that resolved empty.
+func mergeLinks(configLinks, cliLinks map[string]string) map[string]string {
+	if len(configLinks) == 0 {
+		return cliLinks
+	}
+	if len(cliLinks) == 0 {
+		return configLinks
+	}
+	merged := make(map[string]string, len(configLinks)+len(cliLinks))
+	for repo, group := range configLinks {
+		merged[repo] = group
+	}
+	for repo, group := range cliLinks {
+		merged[repo] = group
+	}
+	return merged
+}
+
 func runRun(cmd *cobra.Command, args []string) error {
 	controlPort, _ := cmd.Flags().GetInt("control-port")
 	groupFlag, _ := cmd.Flags().GetString("group")
@@ -116,8 +138,12 @@ func runRun(cmd *cobra.Command, args []string) error {
 		slog.Info("link flags parsed", "links", pairs)
 	}
 
+	interactive, _ := cmd.Flags().GetBool("interactive")
 	if len(args) == 0 {
-		return runBatchMode(cmd, controlPort, groupFlag, linkMap)
+		return runBatchMode(cmd, controlPort, groupFlag, linkMap, interactive)
+	}
+	if interactive {
+		return fmt.Errorf("-i/--interactive applies only to mdp.yaml batch mode, not `mdp run -- <command>`")
 	}
 
 	tlsCert, _ := cmd.Flags().GetString("tls-cert")
@@ -142,7 +168,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	return runSingleMode(cmd, args, controlPort, groupFlag, tlsCert, tlsKey, logSplit)
 }
 
-func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap map[string]string) error {
+func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap map[string]string, interactive bool) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cannot determine working directory: %w", err)
@@ -169,6 +195,36 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 	client := &http.Client{Timeout: 5 * time.Second}
 	controlURL := fmt.Sprintf("http://127.0.0.1:%d", controlPort)
 	clientID := generateClientID()
+
+	// Resolve declared inputs (prompting when -i, else defaults), then
+	// substitute ${inputs.X} refs throughout the config so the env/link
+	// pipeline below never sees an input reference.
+	inputs, err := resolveInputs(cfg, interactive, func() []string { return fetchActiveGroups(client, controlURL) }, os.Stdin, os.Stderr)
+	if err != nil {
+		return err
+	}
+	if err := applyInputs(cfg, inputs); err != nil {
+		return err
+	}
+	// Resolve dir/env_file paths now that input placeholders are gone — Load
+	// deferred any that contained ${inputs.X} so absolute/~ input values
+	// resolve correctly.
+	cfg.FinalizePaths(filepath.Dir(configPath))
+	// Merge config `links:` (now input-substituted) under the CLI --link
+	// overrides (CLI wins per repo), then reject empties — checked after the
+	// merge so a --link override can rescue a config link that resolved empty.
+	linkMap = mergeLinks(cfg.Links, linkMap)
+	if err := checkLinkGroups(linkMap); err != nil {
+		return err
+	}
+	if len(linkMap) > 0 {
+		pairs := make([]string, 0, len(linkMap))
+		for repo, group := range linkMap {
+			pairs = append(pairs, repo+"="+group)
+		}
+		sort.Strings(pairs)
+		slog.Info("cross-repo links resolved", "links", pairs)
+	}
 
 	portRange, err := ports.ParseRange(cfg.PortRange)
 	if err != nil {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,10 @@ Without a command, reads `mdp.yaml` and batch-starts all configured services:
 ```sh
 mdp run                        # uses current git branch as group
 mdp run --group feature-auth   # override group name
+mdp run -i                     # prompt for declared inputs (e.g. cross-repo branch names)
 ```
+
+Add `-i` to prompt for the [`inputs:`](./mdp-yaml-reference.md#inputs) declared in `mdp.yaml` — handy for choosing a peer's branch interactively instead of typing `--link repo=branch`. Without `-i`, inputs use their defaults (an input with no default errors). With `-i`, answers are read from stdin, so they can also be piped (`mdp run -i < answers.txt`).
 
 When a command is given, `mdp run` picks its mode in this order:
 
@@ -141,6 +144,7 @@ mdp --stop
 | `--auto-tls`       | `false`       | Auto-detect TLS certs from mkcert                |
 | `--control-port`   | `13100`       | Orchestrator control port                        |
 | `--link`           |               | Override peer-lookup group: `repo=group` (repeatable). See [cross-repo refs](./mdp-yaml-reference.md#cross-group-lookups-via---link). |
+| `-i, --interactive`| `false`       | Prompt for the [`inputs:`](./mdp-yaml-reference.md#inputs) declared in `mdp.yaml`; without it, inputs use their defaults. |
 
 
 `**mdp register` flags:**

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -40,6 +40,8 @@ services:
 | `services` | map of name → [service](#service) | `{}` | Each key is a service name. Shown in the TUI and referenced by `depends_on`. |
 | `port_range` | `"MIN-MAX"` string | `"10000-60000"` | Range for auto-allocating service ports (when `port` is `0` / unset). |
 | `global` | [global](#global) | `{}` | Project-wide env export block. |
+| `inputs` | map of name → [input](#inputs) | `{}` | Values prompted for by `mdp run -i`, referenced elsewhere as `${inputs.<name>}`. Declaration order is the prompt order. |
+| `links` | map of `repo` → `group` | `{}` | Cross-repo peer-lookup groups, equivalent to the `--link repo=group` CLI flag. Values may reference an input (e.g. `${inputs.api_branch}`). See [`links`](#links). |
 
 ```yaml
 port_range: "20000-25000"   # narrow range if you want predictable ports for firewall rules
@@ -90,6 +92,57 @@ DB_URL="postgres://app:app@localhost:20045/app"
 Keys are sorted alphabetically and values are double-quoted so the file is safe to `source` from a shell or load with standard `.env` parsers.
 
 The file is written after all ports are allocated and before any service `command` runs. Point your editor's run config or shell tooling at it when you need the same values outside `mdp`.
+
+## `inputs`
+
+`inputs` declares values that `mdp run -i` prompts for at startup. Each resolved value is referenced elsewhere as `${inputs.<name>}`. The motivating case is supplying a cross-repo branch name interactively instead of typing `--link repo=branch` on the command line.
+
+`${inputs.<name>}` is supported in these fields: a service's `command`, `dir`, `setup`, `shutdown`, `env` (scalar value, `ref:`, and `default:`), and `env_file`; the `global.env` block and `global.env_file`; and [`links`](#links) values. Using it in `group`, `tls_cert`, or `tls_key` is a load-time error (use [`links`](#links) for cross-repo groups); it is not expanded in other fields such as `port_range` or `health_check`.
+
+Input names may contain only letters, digits, and underscore (so they are always referenceable as `${inputs.<name>}`).
+
+Keys under `inputs.<name>`:
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `prompt` | string | the input name | Question shown when prompting. |
+| `default` | string | none | Fallback used when not prompting, or when the answer is empty. Omitting the key (or writing a bare `default:` with no value) means **no default** — such an input errors under plain `mdp run` and must be prompted with `-i`. Use `default: ""` for an explicit empty default. Must be a plain literal — it cannot contain `${...}` references. |
+| `choices` | string | `""` | Set to `groups` to offer a numbered pick-list of the orchestrator's currently active groups (you may still type a custom value). Any other value is rejected at load. |
+
+```yaml
+inputs:
+  api_branch:
+    prompt: "Which branch is the API running on?"
+    default: main
+    choices: groups
+
+links:
+  api: ${inputs.api_branch}
+
+services:
+  web:
+    command: npm run dev
+    env:
+      VITE_API_URL: "http://localhost:${@api.server.port}"
+      VITE_TARGET_BRANCH: "${inputs.api_branch}"
+```
+
+Resolution:
+
+- **`mdp run -i`**: each input is prompted in declaration order, reading from stdin (a terminal, or piped answers such as `mdp run -i < answers.txt`). A `choices: groups` input prints the active groups (marking the `default`); enter a number, type a custom value, or press enter to accept the `default`. Pressing enter on an input that has no `default` re-prompts; `Ctrl-D` / end-of-input aborts the run.
+- **`mdp run`** (no `-i`): every input resolves to its `default`. An input with no `default` is an error — provide a `default` or run with `-i`.
+
+Input values are plain literals: an answer (or `default`) containing `${...}` is rejected, so an input can never smuggle in a port or peer reference. An undeclared `${inputs.X}` reference in a supported field is a load-time error, and the service name `inputs` is reserved.
+
+## `links`
+
+`links` maps a peer repo name to the group its services run in — the config-file equivalent of the repeatable `--link repo=group` CLI flag. A value may be a literal group or an `${inputs.<name>}` reference. The CLI `--link` flag overrides config `links` per repo. See [Cross-group lookups](#cross-group-lookups-via---link).
+
+```yaml
+links:
+  api: ${inputs.api_branch}   # group chosen interactively
+  auth: stable                # fixed group
+```
 
 ## Service
 
@@ -553,6 +606,20 @@ services:
 ```
 
 The override applies to all `@<repo>.*` references resolved during this `mdp run` invocation, both at startup and during peer-change watching.
+
+To avoid typing the group on every run, declare it in the [`links`](#links) section instead — and combine it with an [input](#inputs) to choose the branch interactively:
+
+```yaml
+inputs:
+  api_branch:
+    prompt: "Which branch is the API on?"
+    default: main
+    choices: groups
+links:
+  api: ${inputs.api_branch}
+```
+
+`mdp run -i` then prompts for `api_branch` (offering the active groups), and `mdp run` without `-i` uses the `main` default. A `--link api=<group>` on the command line still overrides the config value.
 
 ## Path resolution
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,6 +17,15 @@ type Config struct {
 	Services  map[string]ServiceConfig `yaml:"services"`
 	PortRange string                   `yaml:"port_range"`
 	Global    GlobalConfig             `yaml:"global"`
+	// Inputs declares values prompted for by `mdp run -i` and referenced
+	// elsewhere as ${inputs.<name>}. Declaration order is preserved so prompts
+	// appear in a stable order.
+	Inputs Inputs `yaml:"inputs"`
+	// Links maps a peer repo name to the group its services run in, mirroring
+	// the repeatable `--link repo=group` CLI flag. A value may reference an
+	// input (e.g. ${inputs.api_branch}). CLI `--link` overrides config links
+	// per repo.
+	Links map[string]string `yaml:"links"`
 }
 
 // GlobalConfig holds project-wide settings that aren't tied to a single service.
@@ -94,6 +104,71 @@ func (g EnvValue) DefaultValue() string {
 		return ""
 	}
 	return *g.Default
+}
+
+// InputSpec is one declared input under the top-level `inputs:` mapping. Its
+// resolved value (prompted via `mdp run -i`, or the Default otherwise) is
+// referenced elsewhere as ${inputs.<Name>}.
+type InputSpec struct {
+	Name       string // the mapping key
+	Prompt     string // question shown when prompting; defaults to Name
+	Default    string // fallback when not prompting or the answer is empty
+	HasDefault bool   // whether `default:` was present (distinguishes `default: ""` from absent)
+	Choices    string // optional; "groups" => live orchestrator group pick-list
+}
+
+// Inputs is an ordered list of declared inputs. YAML mappings lose key order,
+// so UnmarshalYAML walks the mapping node directly to preserve the declaration
+// order used when prompting.
+type Inputs []InputSpec
+
+// UnmarshalYAML decodes the `inputs:` mapping, preserving declaration order and
+// rejecting unknown spec keys so typos surface at load.
+func (in *Inputs) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("line %d: inputs must be a mapping of name -> spec", node.Line)
+	}
+	specs := make(Inputs, 0, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+		if keyNode.Value == "" {
+			return fmt.Errorf("line %d: input name must not be empty", keyNode.Line)
+		}
+		if valNode.Kind != yaml.MappingNode {
+			return fmt.Errorf("line %d: input %q must be a mapping with prompt/default/choices keys", valNode.Line, keyNode.Value)
+		}
+		spec := InputSpec{Name: keyNode.Value}
+		for j := 0; j+1 < len(valNode.Content); j += 2 {
+			k := valNode.Content[j]
+			v := valNode.Content[j+1]
+			// A bare `default:` (null node) means "no default"; only an explicit
+			// scalar (including `default: ""`) sets one. This keeps null distinct
+			// from the empty string so the non-interactive "no default" error
+			// still fires for `default:` written with no value.
+			if k.Value == "default" && v.Tag == "!!null" {
+				continue
+			}
+			var dst *string
+			switch k.Value {
+			case "prompt":
+				dst = &spec.Prompt
+			case "default":
+				dst = &spec.Default
+				spec.HasDefault = true
+			case "choices":
+				dst = &spec.Choices
+			default:
+				return fmt.Errorf("line %d: unknown key %q in input %q (only `prompt`, `default`, and `choices` are supported)", k.Line, k.Value, keyNode.Value)
+			}
+			if err := v.Decode(dst); err != nil {
+				return fmt.Errorf("line %d: input %q %s: %w", v.Line, keyNode.Value, k.Value, err)
+			}
+		}
+		specs = append(specs, spec)
+	}
+	*in = specs
+	return nil
 }
 
 // ServiceConfig defines a single service in the config file.
@@ -229,16 +304,25 @@ func Load(path string) (*Config, error) {
 	}
 	dir := filepath.Dir(path)
 	for name, svc := range cfg.Services {
-		svc.Dir = resolvePath(svc.Dir, dir)
+		// Paths containing ${inputs.X} are resolved later by FinalizePaths,
+		// after inputs are substituted — resolving a placeholder now would join
+		// a relative literal to the config dir (or miss ~-expansion) for input
+		// values that are themselves absolute or ~-prefixed.
+		if !containsInputRef(svc.Dir) {
+			svc.Dir = resolvePath(svc.Dir, dir)
+		}
 		svc.TLSCert = resolvePath(svc.TLSCert, dir)
 		svc.TLSKey = resolvePath(svc.TLSKey, dir)
 		// Per-service env_file is resolved against the service's (already
-		// absolute) dir; fall back to the config dir when dir is empty.
-		envFileBase := svc.Dir
-		if envFileBase == "" {
-			envFileBase = dir
+		// absolute) dir; fall back to the config dir when dir is empty. Defer
+		// when env_file or its base dir still carries an input ref.
+		if !containsInputRef(svc.EnvFile) && !containsInputRef(svc.Dir) {
+			envFileBase := svc.Dir
+			if envFileBase == "" {
+				envFileBase = dir
+			}
+			svc.EnvFile = resolvePath(svc.EnvFile, envFileBase)
 		}
-		svc.EnvFile = resolvePath(svc.EnvFile, envFileBase)
 		// Infer scheme from cert presence.
 		if svc.Scheme == "" && svc.TLSCert != "" {
 			svc.Scheme = "https"
@@ -282,11 +366,188 @@ func Load(path string) (*Config, error) {
 		}
 		cfg.Services[name] = svc
 	}
-	cfg.Global.EnvFile = resolvePath(cfg.Global.EnvFile, dir)
+	if !containsInputRef(cfg.Global.EnvFile) {
+		cfg.Global.EnvFile = resolvePath(cfg.Global.EnvFile, dir)
+	}
 	if err := validateDependencies(cfg.Services); err != nil {
 		return nil, err
 	}
+	if err := validateInputs(&cfg); err != nil {
+		return nil, err
+	}
 	return &cfg, nil
+}
+
+// containsInputRef reports whether s carries a ${inputs.X} placeholder, whose
+// resolution is deferred until inputs are substituted.
+func containsInputRef(s string) bool {
+	return strings.Contains(s, "${inputs.")
+}
+
+// FinalizePaths resolves the service Dir/EnvFile and global EnvFile that Load
+// left raw because they contained ${inputs.X}. Call it after inputs are
+// substituted (see VisitInputRefFields). resolvePath is idempotent on already
+// absolute paths, so paths Load already resolved are unchanged — meaning this
+// is a no-op for configs that use no inputs in path fields. configDir is the
+// directory containing the mdp.yaml.
+func (cfg *Config) FinalizePaths(configDir string) {
+	for name, svc := range cfg.Services {
+		svc.Dir = resolvePath(svc.Dir, configDir)
+		base := svc.Dir
+		if base == "" {
+			base = configDir
+		}
+		svc.EnvFile = resolvePath(svc.EnvFile, base)
+		cfg.Services[name] = svc
+	}
+	cfg.Global.EnvFile = resolvePath(cfg.Global.EnvFile, configDir)
+}
+
+// inputNamePattern is the accepted syntax for input names. It must match the
+// key syntax that envexpand's ${inputs.NAME} reference regex supports, so a
+// declared input is always referenceable (and any ${inputs.X} typo is caught
+// as an undeclared reference rather than silently surviving substitution).
+var inputNamePattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// validateInputs checks the `inputs:` and `links:` sections: input names are
+// valid and unique, `choices` is empty or "groups", defaults are plain
+// literals, the reserved service name "inputs" is unused, and every
+// ${inputs.X} reference names a declared input. The reference scan drives
+// VisitInputRefFields, so it covers exactly the fields where substitution
+// applies — the two cannot drift apart — and in a deterministic order, so the
+// reported error is stable when several refs are undeclared.
+func validateInputs(cfg *Config) error {
+	declared := make(map[string]bool, len(cfg.Inputs))
+	for _, in := range cfg.Inputs {
+		if in.Name == "" {
+			return fmt.Errorf("input name must not be empty")
+		}
+		if !inputNamePattern.MatchString(in.Name) {
+			return fmt.Errorf("input name %q is invalid: only letters, digits, and underscore are allowed", in.Name)
+		}
+		if declared[in.Name] {
+			return fmt.Errorf("input %q declared more than once", in.Name)
+		}
+		declared[in.Name] = true
+		switch in.Choices {
+		case "", "groups":
+		default:
+			return fmt.Errorf("input %q: unknown choices %q (only \"groups\" is supported)", in.Name, in.Choices)
+		}
+		if in.HasDefault && strings.Contains(in.Default, "${") {
+			return fmt.Errorf("input %q: default must be a plain literal (it cannot contain ${...} references)", in.Name)
+		}
+	}
+	if _, ok := cfg.Services["inputs"]; ok {
+		return fmt.Errorf("service name \"inputs\" is reserved (it collides with ${inputs.*} references)")
+	}
+
+	var firstErr error
+	cfg.VisitInputRefFields(func(where, value string) (string, bool) {
+		if firstErr != nil {
+			return value, false
+		}
+		if bad := envexpand.InvalidInputRefs(value); len(bad) > 0 {
+			firstErr = fmt.Errorf("%s has malformed input reference %s (input names allow only letters, digits, and underscore; a :-fallback cannot contain a nested ${...})", where, bad[0])
+			return value, false
+		}
+		for _, name := range envexpand.ScanInputRefs(value) {
+			if !declared[name] {
+				firstErr = fmt.Errorf("%s references undeclared input ${inputs.%s}", where, name)
+				break
+			}
+		}
+		return value, false // validation never rewrites
+	})
+	if firstErr != nil {
+		return firstErr
+	}
+
+	// Reject ${inputs.X} in fields that don't support substitution, so a natural
+	// mistake (e.g. `group: ${inputs.branch}`) fails clearly at load instead of
+	// surviving as a literal. These are the plausible branch/group/path-shaped
+	// fields outside VisitInputRefFields' supported set.
+	svcNames := make([]string, 0, len(cfg.Services))
+	for name := range cfg.Services {
+		svcNames = append(svcNames, name)
+	}
+	sort.Strings(svcNames)
+	for _, name := range svcNames {
+		svc := cfg.Services[name]
+		for _, f := range []struct{ label, val string }{
+			{"group", svc.Group},
+			{"tls_cert", svc.TLSCert},
+			{"tls_key", svc.TLSKey},
+		} {
+			if strings.Contains(f.val, "${inputs.") {
+				return fmt.Errorf("service %q %s does not support ${inputs.X} references", name, f.label)
+			}
+		}
+	}
+	return nil
+}
+
+// VisitInputRefFields walks, in deterministic order, every config field where
+// ${inputs.X} references are supported — a service's command, dir, setup,
+// shutdown, env (value/ref/default), and env_file; the global env block and
+// env_file; and links values — calling visit(where, value). When visit returns
+// (newValue, true), the field is rewritten in place. Load-time validation and
+// run-time substitution both drive this single walk, so the supported-field set
+// cannot drift between them.
+func (cfg *Config) VisitInputRefFields(visit func(where, value string) (string, bool)) {
+	apply := func(where, value string, set func(string)) {
+		if nv, changed := visit(where, value); changed {
+			set(nv)
+		}
+	}
+	visitEnv := func(where string, env map[string]EnvValue) {
+		keys := make([]string, 0, len(env))
+		for k := range env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			e := env[k]
+			apply(fmt.Sprintf("%s env %q", where, k), e.Value, func(v string) { e.Value = v })
+			apply(fmt.Sprintf("%s env %q ref", where, k), e.Ref, func(v string) { e.Ref = v })
+			if e.Default != nil {
+				apply(fmt.Sprintf("%s env %q default", where, k), *e.Default, func(v string) { e.Default = &v })
+			}
+			env[k] = e
+		}
+	}
+
+	names := make([]string, 0, len(cfg.Services))
+	for name := range cfg.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		svc := cfg.Services[name]
+		where := fmt.Sprintf("service %q", name)
+		apply(where+" command", svc.Command, func(v string) { svc.Command = v })
+		apply(where+" dir", svc.Dir, func(v string) { svc.Dir = v })
+		for i := range svc.Setup {
+			apply(fmt.Sprintf("%s setup[%d]", where, i), svc.Setup[i], func(v string) { svc.Setup[i] = v })
+		}
+		for i := range svc.Shutdown {
+			apply(fmt.Sprintf("%s shutdown[%d]", where, i), svc.Shutdown[i], func(v string) { svc.Shutdown[i] = v })
+		}
+		visitEnv(where, svc.Env)
+		apply(where+" env_file", svc.EnvFile, func(v string) { svc.EnvFile = v })
+		cfg.Services[name] = svc
+	}
+	visitEnv("global", cfg.Global.Env)
+	apply("global env_file", cfg.Global.EnvFile, func(v string) { cfg.Global.EnvFile = v })
+
+	repos := make([]string, 0, len(cfg.Links))
+	for repo := range cfg.Links {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+	for _, repo := range repos {
+		apply(fmt.Sprintf("link %q", repo), cfg.Links[repo], func(v string) { cfg.Links[repo] = v })
+	}
 }
 
 // resolvePath expands a leading "~" and joins relative paths against base.

--- a/internal/config/inputs_test.go
+++ b/internal/config/inputs_test.go
@@ -1,0 +1,273 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadInputsAndLinks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+inputs:
+  api_branch:
+    prompt: "Which branch?"
+    default: main
+    choices: groups
+  region:
+    default: us
+links:
+  api: ${inputs.api_branch}
+  auth: stable
+services:
+  web:
+    command: npm run dev
+    proxy: 3000
+    env:
+      TARGET: ${inputs.api_branch}
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.Inputs) != 2 {
+		t.Fatalf("expected 2 inputs, got %d", len(cfg.Inputs))
+	}
+	// Declaration order is preserved.
+	if cfg.Inputs[0].Name != "api_branch" || cfg.Inputs[1].Name != "region" {
+		t.Fatalf("input order not preserved: %+v", cfg.Inputs)
+	}
+	got := cfg.Inputs[0]
+	if got.Prompt != "Which branch?" || got.Default != "main" || got.Choices != "groups" {
+		t.Fatalf("api_branch spec wrong: %+v", got)
+	}
+	if cfg.Links["api"] != "${inputs.api_branch}" || cfg.Links["auth"] != "stable" {
+		t.Fatalf("links wrong: %+v", cfg.Links)
+	}
+}
+
+func TestLoadInputDefaultPresence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+inputs:
+  region:
+    default: ""
+  other:
+    prompt: pick
+  bare:
+    default:
+services:
+  web: {command: x, proxy: 3000}
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	// region: an explicit empty default is present and distinct from absent.
+	if cfg.Inputs[0].Name != "region" || !cfg.Inputs[0].HasDefault || cfg.Inputs[0].Default != "" {
+		t.Fatalf("region spec wrong: %+v", cfg.Inputs[0])
+	}
+	// other: no `default:` key => HasDefault false.
+	if cfg.Inputs[1].Name != "other" || cfg.Inputs[1].HasDefault {
+		t.Fatalf("other spec wrong: %+v", cfg.Inputs[1])
+	}
+	// bare: `default:` with no value (null) is treated as "no default".
+	if cfg.Inputs[2].Name != "bare" || cfg.Inputs[2].HasDefault {
+		t.Fatalf("bare spec wrong: %+v", cfg.Inputs[2])
+	}
+}
+
+// Load defers resolving dir/env_file when they carry ${inputs.X}, and
+// FinalizePaths resolves them once substitution has happened.
+func TestLoadDefersInputPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+inputs:
+  branch:
+    default: main
+services:
+  web:
+    command: run
+    dir: ./services/${inputs.branch}
+    env_file: .env
+    proxy: 3000
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	// Deferred: still raw (not joined to the config dir) after Load.
+	if got := cfg.Services["web"].Dir; got != "./services/${inputs.branch}" {
+		t.Fatalf("dir resolved too early: %q", got)
+	}
+	if got := cfg.Services["web"].EnvFile; got != ".env" {
+		t.Fatalf("env_file resolved too early: %q", got)
+	}
+
+	// After substitution + FinalizePaths an absolute dir is honored as-is and a
+	// relative env_file resolves against it.
+	svc := cfg.Services["web"]
+	svc.Dir = "/abs/work/feature"
+	cfg.Services["web"] = svc
+	cfg.FinalizePaths(dir)
+	if got := cfg.Services["web"].Dir; got != "/abs/work/feature" {
+		t.Fatalf("absolute dir = %q", got)
+	}
+	if got := cfg.Services["web"].EnvFile; got != filepath.Join("/abs/work/feature", ".env") {
+		t.Fatalf("env_file = %q", got)
+	}
+}
+
+func TestLoadInputsValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			"unknown choices",
+			`
+inputs:
+  x:
+    choices: branches
+services:
+  web: {command: x, proxy: 3000}
+`,
+			`unknown choices "branches"`,
+		},
+		{
+			"undeclared input ref in env",
+			`
+services:
+  web:
+    command: x
+    proxy: 3000
+    env:
+      A: ${inputs.nope}
+`,
+			"undeclared input ${inputs.nope}",
+		},
+		{
+			"undeclared input ref in link",
+			`
+links:
+  api: ${inputs.nope}
+services:
+  web: {command: x, proxy: 3000}
+`,
+			"undeclared input ${inputs.nope}",
+		},
+		{
+			"reserved service name",
+			`
+services:
+  inputs: {command: x, proxy: 3000}
+`,
+			`service name "inputs" is reserved`,
+		},
+		{
+			"invalid input name",
+			`
+inputs:
+  api-branch:
+    default: main
+services:
+  web: {command: x, proxy: 3000}
+`,
+			`input name "api-branch" is invalid`,
+		},
+		{
+			"default is not a plain literal",
+			`
+inputs:
+  a:
+    default: main
+  b:
+    default: "${inputs.a}"
+services:
+  web: {command: x, proxy: 3000}
+`,
+			`input "b": default must be a plain literal`,
+		},
+		{
+			"undeclared input ref in command",
+			`
+services:
+  web:
+    command: "run --branch ${inputs.nope}"
+    proxy: 3000
+`,
+			"undeclared input ${inputs.nope}",
+		},
+		{
+			"malformed input ref (bad name)",
+			`
+inputs:
+  api_branch:
+    default: main
+services:
+  web:
+    command: x
+    proxy: 3000
+    env:
+      A: ${inputs.api-branch}
+`,
+			"malformed input reference",
+		},
+		{
+			"nested ref in input fallback",
+			`
+services:
+  web:
+    command: x
+    proxy: 3000
+    env:
+      A: "${inputs.host:-${api.port}}"
+`,
+			"malformed input reference",
+		},
+		{
+			"input ref in unsupported field (group)",
+			`
+inputs:
+  branch:
+    default: main
+services:
+  web:
+    command: x
+    proxy: 3000
+    group: ${inputs.branch}
+`,
+			"group does not support ${inputs.X}",
+		},
+		{
+			"unknown spec key",
+			`
+inputs:
+  x:
+    bogus: 1
+services:
+  web: {command: x, proxy: 3000}
+`,
+			`unknown key "bogus"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "mdp.yaml")
+			os.WriteFile(path, []byte(tc.yaml), 0644)
+			_, err := Load(path)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/envexpand/envexpand.go
+++ b/internal/envexpand/envexpand.go
@@ -216,3 +216,85 @@ func lookup(pm PortMap, svc, key string) (int, bool) {
 	}
 	return 0, false
 }
+
+// inputsRefPattern matches ${inputs.NAME} and ${inputs.NAME:-fallback}.
+//
+//	group 1: input name
+//	group 2: raw ":-fallback" (empty when no fallback)
+//	group 3: fallback text only
+var inputsRefPattern = regexp.MustCompile(`\$\{inputs\.([A-Za-z0-9_]+)(:-([^}]*))?\}`)
+
+// ScanInputRefs returns every distinct input name that MUST be declared,
+// referenced via ${inputs.NAME} in value, in source order. References that
+// carry a `:-fallback` are omitted: like cross-repo refs, they tolerate an
+// absent target (SubstituteInputs uses the fallback), so the caller does not
+// require them to be declared. Returns nil if none are present.
+func ScanInputRefs(value string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range inputsRefPattern.FindAllStringSubmatch(value, -1) {
+		if m[2] != "" { // has :-fallback => optional, not required to be declared
+			continue
+		}
+		if name := m[1]; !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// looseInputsRefPattern matches any ${inputs.…} placeholder, including ones
+// whose name or shape is malformed. It exists so InvalidInputRefs can report
+// such placeholders rather than letting the strict inputsRefPattern silently
+// skip them (leaving the literal text behind).
+var looseInputsRefPattern = regexp.MustCompile(`\$\{inputs\.[^}]*\}`)
+
+// InvalidInputRefs returns every ${inputs.…} placeholder in value that is not a
+// usable reference: a malformed name/shape (e.g. a name with characters outside
+// [A-Za-z0-9_]), or a well-formed ref whose inline :-fallback contains a nested
+// ${...} (the fallback class stops at the first '}', so it can't represent a
+// nested reference). Returns nil when every placeholder is fine. The service
+// name "inputs" is reserved, so any ${inputs.…} is unambiguously an input
+// reference and a bad one is an error rather than surviving as a literal.
+func InvalidInputRefs(value string) []string {
+	var out []string
+	for _, m := range looseInputsRefPattern.FindAllString(value, -1) {
+		sub := inputsRefPattern.FindStringSubmatch(m)
+		if sub == nil {
+			out = append(out, m) // malformed name or shape
+			continue
+		}
+		if strings.Contains(sub[3], "${") {
+			out = append(out, m) // nested ${...} in :-fallback is not representable
+		}
+	}
+	return out
+}
+
+// SubstituteInputs replaces ${inputs.NAME} (and ${inputs.NAME:-fallback})
+// references in value with the resolved value from inputs. When an input is
+// absent, the inline :-fallback is used if present; otherwise it is an
+// unresolved-reference error. Inputs are resolved before the normal expansion
+// pass, so other ${...} forms in value are left untouched here.
+func SubstituteInputs(value string, inputs map[string]string) (string, error) {
+	var firstErr error
+	out := inputsRefPattern.ReplaceAllStringFunc(value, func(match string) string {
+		m := inputsRefPattern.FindStringSubmatch(match)
+		name := m[1]
+		if v, ok := inputs[name]; ok {
+			return v
+		}
+		if m[2] != "" { // has :-fallback
+			return m[3]
+		}
+		if firstErr == nil {
+			firstErr = fmt.Errorf("unresolved input reference %s", match)
+		}
+		return match
+	})
+	if firstErr != nil {
+		return "", firstErr
+	}
+	return out, nil
+}

--- a/internal/envexpand/inputs_test.go
+++ b/internal/envexpand/inputs_test.go
@@ -1,0 +1,86 @@
+package envexpand
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSubstituteInputs(t *testing.T) {
+	inputs := map[string]string{"api_branch": "main", "empty": ""}
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr string
+	}{
+		{"no refs", "hello", "hello", ""},
+		{"single", "${inputs.api_branch}", "main", ""},
+		{"embedded", "http://host:${inputs.api_branch}/x", "http://host:main/x", ""},
+		{"empty value resolves", "${inputs.empty}", "", ""},
+		{"fallback used when absent", "${inputs.missing:-fb}", "fb", ""},
+		{"value wins over fallback", "${inputs.api_branch:-fb}", "main", ""},
+		{"undeclared no fallback", "${inputs.missing}", "", "unresolved input reference ${inputs.missing}"},
+		{"leaves other refs untouched", "${db.port}-${inputs.api_branch}", "${db.port}-main", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SubstituteInputs(tt.in, inputs)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInvalidInputRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"valid", "${inputs.api_branch}", nil},
+		{"valid with fallback", "${inputs.x:-main}", nil},
+		{"non-input refs ignored", "hello ${db.port}", nil},
+		{"bad name", "${inputs.api-branch}", []string{"${inputs.api-branch}"}},
+		{"empty name", "${inputs.}", []string{"${inputs.}"}},
+		{"dotted name", "${inputs.a.b}", []string{"${inputs.a.b}"}},
+		{"nested ref in fallback", "${inputs.host:-${api.port}}", []string{"${inputs.host:-${api.port}"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InvalidInputRefs(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("InvalidInputRefs(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanInputRefs(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"no refs here", nil},
+		{"${inputs.a}", []string{"a"}},
+		{"${inputs.a}-${inputs.b}-${inputs.a}", []string{"a", "b"}}, // distinct, source order
+		{"${inputs.a:-x}", nil},                                     // fallback => optional, not required to be declared
+		{"${inputs.a}-${inputs.b:-x}", []string{"a"}},               // only the no-fallback ref is required
+		{"${db.port}", nil},
+	}
+	for _, tt := range tests {
+		got := ScanInputRefs(tt.in)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("ScanInputRefs(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds an `inputs:` section to `mdp.yaml` plus a `mdp run -i` flag that prompts for declared values — with a live pick-list of the orchestrator's active groups — so cross-repo branch names no longer have to be typed as `--link` flags. Resolved inputs are referenced as `${inputs.<name>}` in service/global `env` (value/`ref`/`default`), `command`, `setup`, `shutdown`, `dir`, `env_file`, and a new `links:` section that feeds the existing `--link` machinery (CLI overrides config per repo). Inputs are validated as plain literals (malformed refs, undeclared refs, nested fallbacks, and use in unsupported fields like `group`/`tls_cert` all error at load), path fields resolve correctly after substitution, and prompting handles defaults, empty answers, EOF, and numeric pick-list selection. Docs (`mdp-yaml-reference.md`, `cli.md`) and tests across `envexpand`, `config`, and `cmd/mdp` are included.