### PR TITLE
feat: drive UI refresh via SSE instead of 5s polling

### DIFF
--- a/cmd/mdp/log_split_e2e_test.go
+++ b/cmd/mdp/log_split_e2e_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +27,14 @@ func TestLogSplitRealDockerCompose(t *testing.T) {
 	// `info` probes the daemon; compose commands hang without it.
 	if err := exec.Command("docker", "info").Run(); err != nil {
 		t.Skipf("docker daemon not reachable: %v", err)
+	}
+	// Pre-pull the compose image so an unreachable registry (e.g. Docker Hub
+	// rate limiting on shared CI runners) skips the test instead of failing
+	// it. `--pull missing` below then finds the image cached.
+	pullCtx, cancelPull := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancelPull()
+	if out, err := exec.CommandContext(pullCtx, "docker", "pull", "alpine:3").CombinedOutput(); err != nil {
+		t.Skipf("cannot pull alpine:3 (registry unreachable?): %v\n%s", err, out)
 	}
 
 	// Build the mdp binary into a tempdir so the test runs against the

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -211,6 +211,10 @@ func (o *Orchestrator) EnsureProxy(port int) (*ProxyInstance, error) {
 
 func (o *Orchestrator) createProxyLocked(port int, label string) (*ProxyInstance, error) {
 	reg := registry.New()
+	// Per-proxy API handlers and the dead-server pruner mutate the registry
+	// directly (bypassing the orchestrator's emit), so the registry notifies
+	// the SSE broadcaster itself — UIs refresh on SSE events, not polling.
+	reg.SetNotify(o.broadcaster.Notify)
 	cookieName := routing.CookieNameForPort(port)
 	prx := proxy.NewProxy(reg, port, cookieName)
 	inj := inject.New()
@@ -650,11 +654,17 @@ func (o *Orchestrator) ServiceStatus(name string) (string, bool) {
 func (o *Orchestrator) UpdateServiceStatus(name, status string) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	if svc, ok := o.services[name]; ok {
-		svc.Status = status
-		if status == "stopped" || status == "failed" {
-			o.emit(Event{Type: "service_stopped", Name: name})
-		}
+	svc, ok := o.services[name]
+	if !ok || svc.Status == status {
+		return
+	}
+	svc.Status = status
+	if status == "stopped" || status == "failed" {
+		o.emit(Event{Type: "service_stopped", Name: name})
+	} else {
+		// Non-terminal transitions (waiting/starting/running) aren't TUI
+		// events, but SSE clients still need to refetch.
+		o.broadcaster.Notify()
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/derekgould/multi-dev-proxy/internal/config"
 	"github.com/derekgould/multi-dev-proxy/internal/registry"
@@ -188,6 +189,39 @@ func TestUpdateServiceStatus(t *testing.T) {
 
 	// updating non-existent service is a no-op
 	o.UpdateServiceStatus("nonexistent", "failed")
+}
+
+// Non-terminal status transitions don't emit TUI events, but SSE clients
+// still need a broadcast — without polling, the dashboard would otherwise
+// never see waiting → starting → running.
+func TestUpdateServiceStatusNotifiesSSE(t *testing.T) {
+	o := newTestOrch()
+	o.SetService("web/main", &ManagedService{Name: "web/main", Status: "waiting"})
+
+	// Subscribe after SetService and drain its debounced broadcast so the
+	// signal below is attributable to UpdateServiceStatus alone.
+	ch, unsub := o.Broadcaster().Subscribe()
+	defer unsub()
+	select {
+	case <-ch:
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	o.UpdateServiceStatus("web/main", "running")
+
+	select {
+	case <-ch:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected SSE broadcast for non-terminal status change")
+	}
+
+	// An unchanged status must not broadcast.
+	o.UpdateServiceStatus("web/main", "running")
+	select {
+	case <-ch:
+		t.Fatal("unchanged status should not broadcast")
+	case <-time.After(300 * time.Millisecond):
+	}
 }
 
 func TestGetProxy(t *testing.T) {

--- a/internal/proxy/smartlistener.go
+++ b/internal/proxy/smartlistener.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 	"sync"
+	"time"
 )
 
 // SmartListener wraps a net.Listener and transparently handles both plain HTTP
@@ -15,12 +16,18 @@ type SmartListener struct {
 	inner     net.Listener
 	mu        sync.RWMutex
 	tlsConfig *tls.Config // nil means TLS is not available
+
+	// peekTimeout bounds how long Accept waits for a connection's first
+	// byte. The peek runs serially in the accept loop, so an open-but-silent
+	// socket (e.g. a browser preconnect that Chrome holds idle for ~10s)
+	// would otherwise stall every other new connection until it closes.
+	peekTimeout time.Duration
 }
 
 // NewSmartListener creates a SmartListener around an existing net.Listener.
 // tlsConfig may be nil (TLS disabled initially).
 func NewSmartListener(ln net.Listener, tlsConfig *tls.Config) *SmartListener {
-	return &SmartListener{inner: ln, tlsConfig: tlsConfig}
+	return &SmartListener{inner: ln, tlsConfig: tlsConfig, peekTimeout: 5 * time.Second}
 }
 
 // SetTLSConfig replaces the TLS configuration. Pass nil to disable TLS.
@@ -35,33 +42,44 @@ func (sl *SmartListener) SetTLSConfig(cfg *tls.Config) {
 // Accept waits for the next connection, peeks the first byte, and returns
 // either a plain or TLS-unwrapped net.Conn.
 func (sl *SmartListener) Accept() (net.Conn, error) {
-	conn, err := sl.inner.Accept()
-	if err != nil {
-		return nil, err
-	}
-
-	// Read and buffer the first byte to detect protocol.
-	buf := make([]byte, 1)
-	n, err := conn.Read(buf)
-	if err != nil || n == 0 {
-		if err == nil {
-			// n=0 with no error shouldn't happen per io.Reader, pass through.
-			return conn, nil
+	for {
+		conn, err := sl.inner.Accept()
+		if err != nil {
+			return nil, err
 		}
-		conn.Close()
-		return nil, err
-	}
-	peeked := &peekedConn{Conn: conn, buf: buf[:n]}
 
-	sl.mu.RLock()
-	cfg := sl.tlsConfig
-	sl.mu.RUnlock()
+		// Read and buffer the first byte to detect protocol, bounded by
+		// peekTimeout. The deadline is cleared immediately after so it never
+		// leaks into the returned connection's reads.
+		conn.SetReadDeadline(time.Now().Add(sl.peekTimeout))
+		buf := make([]byte, 1)
+		n, err := conn.Read(buf)
+		conn.SetReadDeadline(time.Time{})
+		if err != nil || n == 0 {
+			if err == nil {
+				// n=0 with no error shouldn't happen per io.Reader, pass through.
+				return conn, nil
+			}
+			// Per-connection peek error: EOF from a preconnect socket closed
+			// before sending data, or a timeout from one still sitting idle.
+			// Surfacing it here would make http.Server.Serve exit — it treats
+			// Accept errors as fatal to the listener — so drop the connection
+			// and keep accepting.
+			conn.Close()
+			continue
+		}
+		peeked := &peekedConn{Conn: conn, buf: buf[:n]}
 
-	if buf[0] == 0x16 && cfg != nil {
-		// TLS ClientHello — wrap with TLS.
-		return tls.Server(peeked, cfg), nil
+		sl.mu.RLock()
+		cfg := sl.tlsConfig
+		sl.mu.RUnlock()
+
+		if buf[0] == 0x16 && cfg != nil {
+			// TLS ClientHello — wrap with TLS.
+			return tls.Server(peeked, cfg), nil
+		}
+		return peeked, nil
 	}
-	return peeked, nil
 }
 
 // Close closes the underlying listener.

--- a/internal/proxy/smartlistener_test.go
+++ b/internal/proxy/smartlistener_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -220,5 +221,120 @@ func TestPeekedConnRead(t *testing.T) {
 	}
 	if string(buf) != "hello world" {
 		t.Errorf("got %q, want %q", buf, "hello world")
+	}
+}
+
+// A connection closed before sending any data (e.g. a browser preconnect
+// socket) must not surface its EOF as an Accept error — http.Server.Serve
+// treats Accept errors as fatal and would tear down the whole listener.
+func TestSmartListenerSkipsConnClosedBeforeData(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sl := NewSmartListener(ln, nil)
+	defer sl.Close()
+
+	// Connect and close immediately without writing — peek sees EOF.
+	dead, err := net.Dial("tcp", sl.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dead.Close()
+
+	// A real client right behind it.
+	live, err := net.Dial("tcp", sl.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer live.Close()
+	if _, err := live.Write([]byte("GET")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Accept must skip the dead connection and return the live one.
+	got := make(chan error, 1)
+	go func() {
+		conn, err := sl.Accept()
+		if err != nil {
+			got <- err
+			return
+		}
+		buf := make([]byte, 3)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			got <- err
+			return
+		}
+		if string(buf) != "GET" {
+			got <- fmt.Errorf("peeked replay got %q, want %q", buf, "GET")
+			return
+		}
+		conn.Close()
+		got <- nil
+	}()
+
+	select {
+	case err := <-got:
+		if err != nil {
+			t.Fatalf("Accept should skip the closed connection, got error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Accept did not return within 2s")
+	}
+}
+
+// An open-but-silent connection (browser preconnect) must not stall Accept
+// beyond peekTimeout, and the peek deadline must not leak into the returned
+// connection's subsequent reads.
+func TestSmartListenerIdleConnDoesNotBlockOthers(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sl := NewSmartListener(ln, nil)
+	sl.peekTimeout = 100 * time.Millisecond
+	defer sl.Close()
+
+	// Idle socket: connects but never writes.
+	idle, err := net.Dial("tcp", sl.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idle.Close()
+
+	// Live client right behind it.
+	live, err := net.Dial("tcp", sl.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer live.Close()
+	if _, err := live.Write([]byte("G")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Accept must drop the idle socket after the peek timeout and return the
+	// live connection, instead of blocking until the idle socket closes.
+	start := time.Now()
+	conn, err := sl.Accept()
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	defer conn.Close()
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Accept blocked %v on an idle connection", elapsed)
+	}
+
+	// Deadline must be cleared: bytes arriving after the peek-timeout window
+	// still read fine on the accepted connection.
+	go func() {
+		time.Sleep(300 * time.Millisecond) // > peekTimeout
+		live.Write([]byte("ET"))
+	}()
+	buf := make([]byte, 3)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read after peek-timeout window: %v", err)
+	}
+	if string(buf) != "GET" {
+		t.Errorf("got %q, want %q", buf, "GET")
 	}
 }

--- a/internal/registry/pruner_test.go
+++ b/internal/registry/pruner_test.go
@@ -280,3 +280,28 @@ func TestPrunerSkipsClientOwnedServers(t *testing.T) {
 		t.Error("client-owned PID=0 server should NOT be pruned by registry pruner")
 	}
 }
+
+// Pruning is invisible to the orchestrator (it bypasses o.emit), so the
+// registry's notify hook is what keeps SSE-driven UIs in sync when a dead
+// server is removed. Exactly one notification fires — the failure-counter
+// ticks leading up to the prune must stay silent.
+func TestPrunerNotifiesOnPrune(t *testing.T) {
+	reg := New()
+	reg.Register(&ServerEntry{Name: "app/dead", Repo: "app", Port: 1002, PID: 1002, RegisteredAt: time.Now().Add(-60 * time.Second)})
+
+	var notified int
+	reg.SetNotify(func() { notified++ })
+
+	isAlive := func(pid int) bool { return false }
+	tcpCheck := func(port int) bool { return false }
+	for i := 0; i < tcpFailThreshold; i++ {
+		pruneOnce(reg, isAlive, tcpCheck)
+	}
+
+	if reg.Get("app/dead") != nil {
+		t.Fatal("dead server should have been pruned")
+	}
+	if notified != 1 {
+		t.Errorf("notify count = %d, want 1 (one Deregister, silent failure ticks)", notified)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,16 +23,43 @@ type ServerEntry struct {
 	Env                 map[string]string // resolved env vars exposed for cross-repo @-references
 }
 
+// EffectiveScheme returns the entry's scheme with the empty value defaulted
+// to "http". Registration paths disagree on whether they store "" or "http";
+// this method is the canonical home for that defaulting.
+func (e *ServerEntry) EffectiveScheme() string {
+	if e.Scheme == "" {
+		return "http"
+	}
+	return e.Scheme
+}
+
 // Registry holds all registered dev servers in memory.
 type Registry struct {
 	mu            sync.RWMutex
 	servers       map[string]*ServerEntry
 	defaultServer string
+	notify        func() // optional; see SetNotify
 }
 
 // New creates a new empty Registry.
 func New() *Registry {
 	return &Registry{servers: make(map[string]*ServerEntry)}
+}
+
+// SetNotify sets a callback invoked after every externally-visible mutation
+// (register/deregister/default/PID changes). SSE-driven UIs rely on it to
+// learn about mutations that bypass the orchestrator (per-proxy API handlers,
+// the dead-server pruner). Must be called before the registry is shared
+// across goroutines.
+func (r *Registry) SetNotify(fn func()) {
+	r.notify = fn
+}
+
+// notifyChange invokes the notify callback if set. Call without holding r.mu.
+func (r *Registry) notifyChange() {
+	if r.notify != nil {
+		r.notify()
+	}
 }
 
 // Register adds or replaces a server entry. Returns error if validation fails.
@@ -47,8 +74,19 @@ func (r *Registry) Register(entry *ServerEntry) error {
 		entry.RegisteredAt = time.Now()
 	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	prev := r.servers[entry.Name]
 	r.servers[entry.Name] = entry
+	// Notify only when something UI-visible changed — an identical
+	// re-register would make every SSE client refetch identical state.
+	// Compared under the lock: entry is published into the map above, so a
+	// concurrent UpdatePID may write through the same pointer.
+	changed := prev == nil || prev.Repo != entry.Repo || prev.Group != entry.Group ||
+		prev.Port != entry.Port || prev.PID != entry.PID ||
+		prev.EffectiveScheme() != entry.EffectiveScheme()
+	r.mu.Unlock()
+	if changed {
+		r.notifyChange()
+	}
 	return nil
 }
 
@@ -56,11 +94,14 @@ func (r *Registry) Register(entry *ServerEntry) error {
 // Clears the default if the deregistered server was the default.
 func (r *Registry) Deregister(name string) bool {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	_, exists := r.servers[name]
 	delete(r.servers, name)
 	if r.defaultServer == name {
 		r.defaultServer = ""
+	}
+	r.mu.Unlock()
+	if exists {
+		r.notifyChange()
 	}
 	return exists
 }
@@ -104,19 +145,28 @@ func (r *Registry) Count() int {
 // SetDefault sets the default upstream server. Returns error if the server is not registered.
 func (r *Registry) SetDefault(name string) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if _, ok := r.servers[name]; !ok {
+		r.mu.Unlock()
 		return errors.New("server not found: " + name)
 	}
+	changed := r.defaultServer != name
 	r.defaultServer = name
+	r.mu.Unlock()
+	if changed {
+		r.notifyChange()
+	}
 	return nil
 }
 
 // ClearDefault removes the default upstream setting.
 func (r *Registry) ClearDefault() {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	changed := r.defaultServer != ""
 	r.defaultServer = ""
+	r.mu.Unlock()
+	if changed {
+		r.notifyChange()
+	}
 }
 
 // GetDefault returns the current default upstream server name, or "".
@@ -129,13 +179,16 @@ func (r *Registry) GetDefault() string {
 // UpdatePID sets the PID for an existing server entry. Returns true if the entry existed.
 func (r *Registry) UpdatePID(name string, pid int) bool {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	e, ok := r.servers[name]
-	if !ok {
-		return false
+	changed := ok && e.PID != pid
+	if ok {
+		e.PID = pid
 	}
-	e.PID = pid
-	return true
+	r.mu.Unlock()
+	if changed {
+		r.notifyChange()
+	}
+	return ok
 }
 
 // IncrementFailures increments the consecutive failure counter for the named server.
@@ -166,7 +219,6 @@ func (r *Registry) DeregisterByClientID(clientID string) []string {
 		return nil
 	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	var removed []string
 	for name, e := range r.servers {
 		if e.ClientID == clientID {
@@ -176,6 +228,10 @@ func (r *Registry) DeregisterByClientID(clientID string) []string {
 				r.defaultServer = ""
 			}
 		}
+	}
+	r.mu.Unlock()
+	if len(removed) > 0 {
+		r.notifyChange()
 	}
 	return removed
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -530,3 +530,100 @@ func TestDeregisterByClientID(t *testing.T) {
 		}
 	})
 }
+
+func TestNotifyOnMutations(t *testing.T) {
+	r := New()
+	var notified int
+	r.SetNotify(func() { notified++ })
+
+	check := func(op string, want int) {
+		t.Helper()
+		if notified != want {
+			t.Errorf("after %s: notify count = %d, want %d", op, notified, want)
+		}
+	}
+
+	r.Register(&ServerEntry{Name: "app/main", Repo: "app", Port: 3000})
+	check("Register", 1)
+
+	if err := r.SetDefault("app/main"); err != nil {
+		t.Fatal(err)
+	}
+	check("SetDefault", 2)
+
+	r.ClearDefault()
+	check("ClearDefault", 3)
+
+	r.UpdatePID("app/main", 42)
+	check("UpdatePID", 4)
+
+	// Failure counters are pruner bookkeeping, not externally-visible state —
+	// ResetFailures fires every pruner tick for live servers, so notifying
+	// here would recreate periodic refetches.
+	r.IncrementFailures("app/main")
+	r.ResetFailures("app/main")
+	check("IncrementFailures/ResetFailures", 4)
+
+	r.Deregister("app/main")
+	check("Deregister", 5)
+
+	r.Register(&ServerEntry{Name: "app/owned", Repo: "app", Port: 3001, ClientID: "c1"})
+	check("Register owned", 6)
+	r.DeregisterByClientID("c1")
+	check("DeregisterByClientID", 7)
+}
+
+func TestNotifySkipsNoOps(t *testing.T) {
+	r := New()
+	var notified int
+	r.SetNotify(func() { notified++ })
+
+	if err := r.Register(&ServerEntry{}); err == nil {
+		t.Error("Register() with empty entry should fail")
+	}
+	r.Deregister("missing")
+	_ = r.SetDefault("missing")
+	r.ClearDefault() // default already empty
+	r.UpdatePID("missing", 1)
+	r.DeregisterByClientID("nobody")
+
+	if notified != 0 {
+		t.Errorf("no-op mutations should not notify, got %d notifications", notified)
+	}
+
+	// Mutations that leave externally-visible state unchanged are no-ops too.
+	r.Register(&ServerEntry{Name: "app/main", Repo: "app", Port: 3000, PID: 7})
+	if err := r.SetDefault("app/main"); err != nil {
+		t.Fatal(err)
+	}
+	notified = 0
+	r.Register(&ServerEntry{Name: "app/main", Repo: "app", Port: 3000, PID: 7})                 // identical re-register
+	r.Register(&ServerEntry{Name: "app/main", Repo: "app", Port: 3000, PID: 7, Scheme: "http"}) // "" and "http" are the same scheme
+	_ = r.SetDefault("app/main")                                                                // already the default
+	r.UpdatePID("app/main", 7)                                                                  // same PID
+
+	if notified != 0 {
+		t.Errorf("unchanged-state mutations should not notify, got %d notifications", notified)
+	}
+}
+
+// Register publishes the entry pointer into the map; the notify comparison
+// must therefore happen under the lock, or it races with a concurrent
+// UpdatePID writing through the same pointer.
+func TestRegisterUpdatePIDConcurrent(t *testing.T) {
+	r := New()
+	r.SetNotify(func() {}) // exercise the changed-field comparison path
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			r.Register(&ServerEntry{Name: "app/main", Repo: "app", Port: 3000, PID: 1})
+		}()
+		go func(pid int) {
+			defer wg.Done()
+			r.UpdatePID("app/main", pid)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -602,13 +602,22 @@ func renderDashboard(controlPort int) string {
     window.__closeMvCard = closeMvCard;
     window.__setMvColCount = setMvColCount;
 
-    // Initial fetch + SSE with polling fallback
+    // Initial fetch + SSE for real-time updates; if the browser closes the
+    // stream permanently (non-200/wrong-MIME response), recreate it after a
+    // delay.
     fetchState();
     if (typeof EventSource !== 'undefined') {
-      var es = new EventSource(API + '/__mdp/events');
-      es.onmessage = function() { fetchState(); };
+      var connectSSE = function() {
+        var es = new EventSource(API + '/__mdp/events');
+        es.onmessage = function() { fetchState(); };
+        es.onerror = function() {
+          if (es.readyState === EventSource.CLOSED) {
+            setTimeout(connectSSE, 5000);
+          }
+        };
+      };
+      connectSSE();
     }
-    setInterval(fetchState, 5000);
   })();
   </script>
 </body>

--- a/internal/ui/switch_page.go
+++ b/internal/ui/switch_page.go
@@ -233,16 +233,22 @@ func renderSwitchPage() string {
       }).catch(function() {});
     }
 
-    // SSE for real-time updates
+    // SSE for real-time updates; if the browser closes the stream permanently
+    // (non-200/wrong-MIME response), recreate it after a delay.
     if (typeof EventSource !== 'undefined') {
-      var es = new EventSource('/__mdp/events');
-      es.onopen = function() { statusEl.textContent = 'Live'; };
-      es.onmessage = function() { fetchAndRender(); };
-      es.onerror = function() { statusEl.textContent = 'Reconnecting...'; };
+      var connectSSE = function() {
+        var es = new EventSource('/__mdp/events');
+        es.onopen = function() { statusEl.textContent = 'Live'; };
+        es.onmessage = function() { fetchAndRender(); };
+        es.onerror = function() {
+          statusEl.textContent = 'Reconnecting...';
+          if (es.readyState === EventSource.CLOSED) {
+            setTimeout(connectSSE, 5000);
+          }
+        };
+      };
+      connectSSE();
     }
-
-    // Polling fallback
-    setInterval(fetchAndRender, 5000);
 
     // Initial fetch
     fetchAndRender();

--- a/internal/ui/widget.js
+++ b/internal/ui/widget.js
@@ -1,7 +1,6 @@
 (() => {
 	"use strict";
 
-	const POLL_MS = 5000;
 	const API_SERVERS = "/__mdp/servers";
 	const API_CONFIG = "/__mdp/config";
 
@@ -413,12 +412,23 @@
 	}
 
 	poll();
-	// SSE for real-time updates, with polling fallback
+	// SSE for real-time updates. The server sends an initial "connected"
+	// event on every (re)connect, so onmessage also resyncs after the
+	// browser's automatic EventSource reconnect. If the browser closes the
+	// stream permanently (non-200/wrong-MIME response, e.g. an intermediary
+	// 502), recreate it after a delay.
 	if (typeof EventSource !== "undefined") {
-		const es = new EventSource("/__mdp/events");
-		es.onmessage = () => poll();
+		const connectSSE = () => {
+			const es = new EventSource("/__mdp/events");
+			es.onmessage = () => poll();
+			es.onerror = () => {
+				if (es.readyState === EventSource.CLOSED) {
+					setTimeout(connectSSE, 5000);
+				}
+			};
+		};
+		connectSSE();
 	}
-	setInterval(poll, POLL_MS);
 
 	document.addEventListener("click", (e) => {
 		if (!host.contains(e.target) && open) {


### PR DESCRIPTION
Removes the hardcoded 5s polling from the widget, switch page, and dashboard — each now holds one SSE connection and refetches only when state changes, so proxied pages generate zero recurring `/__mdp/*` traffic. To make that safe, the registry gains a change-notify hook wired to the SSE broadcaster (covering per-proxy API handlers and the dead-server pruner, which bypass the orchestrator), service status transitions now broadcast, and no-op mutations are skipped. Also fixes a latent `SmartListener` bug where a connection closed (or idle) before sending its first byte returned a listener-fatal error from `Accept`, permanently killing the proxy port — observed against real proxies in the daemon log. EventSource streams now recreate themselves if the browser closes them permanently. Verified with `go test -race`, the testbed e2e suite (45/53, remaining 8 are pre-existing stale-topology tests), and a Puppeteer check confirming zero quiet-period requests and live SSE updates.