### PR TITLE
fix: let cross-repo links fall back to the current group via @{current}

### DIFF
--- a/cmd/mdp/inputs.go
+++ b/cmd/mdp/inputs.go
@@ -43,8 +43,9 @@ func fetchActiveGroups(client *http.Client, controlURL string) []string {
 // inputs. When interactive, each input is prompted for (groupsFor populates
 // `choices: groups` lists, fetched at most once) reading from in; otherwise
 // every input resolves to its Default, and an input with no default is an
-// error. in/out are injectable for testing.
-func resolveInputs(cfg *config.Config, interactive bool, groupsFor func() []string, in io.Reader, out io.Writer) (map[string]string, error) {
+// error. currentGroup is the caller's own group, shown on the "@{current}"
+// pick-list entry. in/out are injectable for testing.
+func resolveInputs(cfg *config.Config, interactive bool, currentGroup string, groupsFor func() []string, in io.Reader, out io.Writer) (map[string]string, error) {
 	if len(cfg.Inputs) == 0 {
 		return nil, nil
 	}
@@ -64,7 +65,7 @@ func resolveInputs(cfg *config.Config, interactive bool, groupsFor func() []stri
 			groups = groupsFor()
 			groupsLoaded = true
 		}
-		val, err := promptInput(spec, groups, reader, out)
+		val, err := promptInput(spec, currentGroup, groups, reader, out)
 		if err != nil {
 			return nil, err
 		}
@@ -75,25 +76,35 @@ func resolveInputs(cfg *config.Config, interactive bool, groupsFor func() []stri
 
 // promptInput asks for one input on out, reading the answer from r, and returns
 // the resolved value. For `choices: groups` it prints a numbered list of active
-// groups (marking the default) and accepts a list number or a typed value; an
-// answer matching a group name is taken literally (so a numerically-named group
-// stays selectable), and an out-of-range number is taken as a literal value (so
-// a not-yet-running branch named "3" can still be entered). An empty answer
-// uses the default when one is declared, else re-prompts. EOF (Ctrl-D / end of
-// input) aborts. The resolved value — typed or picked — is rejected if it
-// contains ${...}, so inputs stay plain literals (no smuggled port/peer refs).
-func promptInput(spec config.InputSpec, groups []string, r *bufio.Reader, out io.Writer) (string, error) {
+// groups plus a final "@{current}" entry (marking the default) and accepts a list
+// number or a typed value; an answer matching a list entry is taken literally
+// (so a numerically-named group stays selectable), and an out-of-range number
+// is taken as a literal value (so a not-yet-running branch named "3" can still
+// be entered). An empty answer uses the default when one is declared, else
+// re-prompts. EOF (Ctrl-D / end of input) aborts. The resolved value — typed or
+// picked — is rejected if it contains ${...}, so inputs stay plain literals (no
+// smuggled port/peer refs).
+func promptInput(spec config.InputSpec, currentGroup string, groups []string, r *bufio.Reader, out io.Writer) (string, error) {
 	label := spec.Prompt
 	if label == "" {
 		label = spec.Name
 	}
 	pickList := spec.Choices == "groups" && len(groups) > 0
+	var choices []string
 	if pickList {
+		// "@{current}" is appended as a pickable entry so the fallback-to-own-group
+		// sentinel is discoverable; it resolves at lookup time (effectiveGroup).
+		choices = append(append([]string(nil), groups...), currentGroupSentinel)
 		fmt.Fprintf(out, "%s\n", label)
-		for i, g := range groups {
+		for i, g := range choices {
 			marker := ""
 			if g == spec.Default {
 				marker = " (default)"
+			}
+			// Annotated with the workspace's group; a service-level `group:`
+			// override resolves @{current} to its own group instead (effectiveGroup).
+			if g == currentGroupSentinel {
+				marker = fmt.Sprintf(" — this checkout's default group (%s)%s", currentGroup, marker)
 			}
 			fmt.Fprintf(out, "  %d) %s%s\n", i+1, g, marker)
 		}
@@ -128,12 +139,12 @@ func promptInput(spec config.InputSpec, groups []string, r *bufio.Reader, out io
 
 		value := answer
 		// In a pick-list, a bare number selects by 1-based index. An exact
-		// group-name match wins first (so a group literally named "456" stays
+		// entry-name match wins first (so a group literally named "456" stays
 		// selectable), and an out-of-range number is taken as a literal value
 		// (so a not-yet-running branch named "3" can still be entered).
-		if pickList && !slices.Contains(groups, answer) {
-			if n, convErr := strconv.Atoi(answer); convErr == nil && n >= 1 && n <= len(groups) {
-				value = groups[n-1]
+		if pickList && !slices.Contains(choices, answer) {
+			if n, convErr := strconv.Atoi(answer); convErr == nil && n >= 1 && n <= len(choices) {
+				value = choices[n-1]
 			}
 		}
 		// Guard the resolved value — covers both the typed and pick-list paths.

--- a/cmd/mdp/inputs_test.go
+++ b/cmd/mdp/inputs_test.go
@@ -26,6 +26,9 @@ func TestPromptInput(t *testing.T) {
 		wantErr string
 	}{
 		{"pick by number", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "2\n", "derek/foo", ""},
+		{"pick @{current} by number", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "3\n", "@{current}", ""},
+		{"typed @{current}", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "@{current}\n", "@{current}", ""},
+		{"empty uses @{current} default", config.InputSpec{Name: "b", Choices: "groups", Default: "@{current}", HasDefault: true}, groups, "\n", "@{current}", ""},
 		{"empty uses default", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "\n", "main", ""},
 		{"custom typed branch", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "other/branch\n", "other/branch", ""},
 		{"out-of-range number is literal", config.InputSpec{Name: "b", Choices: "groups", Default: "main", HasDefault: true}, groups, "9\n", "9", ""},
@@ -42,7 +45,7 @@ func TestPromptInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := bufio.NewReader(strings.NewReader(tt.input))
 			var out bytes.Buffer
-			got, err := promptInput(tt.spec, tt.groups, r, &out)
+			got, err := promptInput(tt.spec, "feature-x", tt.groups, r, &out)
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("want error containing %q, got %v", tt.wantErr, err)
@@ -59,12 +62,30 @@ func TestPromptInput(t *testing.T) {
 	}
 }
 
+// The pick-list ends with an "@{current}" entry annotated with the caller's
+// actual group, so the fallback-to-own-group sentinel is discoverable.
+func TestPromptInputPickListShowsCurrent(t *testing.T) {
+	spec := config.InputSpec{Name: "b", Choices: "groups", Default: "@{current}", HasDefault: true}
+	r := bufio.NewReader(strings.NewReader("\n"))
+	var out bytes.Buffer
+	got, err := promptInput(spec, "feature-x", []string{"main", "derek/foo"}, r, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "@{current}" {
+		t.Fatalf("got %q, want @{current}", got)
+	}
+	if !strings.Contains(out.String(), "3) @{current} — this checkout's default group (feature-x) (default)") {
+		t.Fatalf("pick-list missing @{current} entry, got:\n%s", out.String())
+	}
+}
+
 func TestResolveInputsDefaults(t *testing.T) {
 	cfg := &config.Config{Inputs: config.Inputs{
 		{Name: "a", Default: "x", HasDefault: true},
 		{Name: "b", Default: "y", HasDefault: true},
 	}}
-	vals, err := resolveInputs(cfg, false, nil, strings.NewReader(""), io.Discard)
+	vals, err := resolveInputs(cfg, false, "feature-x", nil, strings.NewReader(""), io.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,7 +96,7 @@ func TestResolveInputsDefaults(t *testing.T) {
 
 func TestResolveInputsMissingDefault(t *testing.T) {
 	cfg := &config.Config{Inputs: config.Inputs{{Name: "a"}}}
-	_, err := resolveInputs(cfg, false, nil, strings.NewReader(""), io.Discard)
+	_, err := resolveInputs(cfg, false, "feature-x", nil, strings.NewReader(""), io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "has no default") {
 		t.Fatalf("want missing-default error, got %v", err)
 	}
@@ -85,7 +106,7 @@ func TestResolveInputsMissingDefault(t *testing.T) {
 // default, so the non-interactive path resolves it to "" without erroring.
 func TestResolveInputsEmptyDefault(t *testing.T) {
 	cfg := &config.Config{Inputs: config.Inputs{{Name: "a", Default: "", HasDefault: true}}}
-	vals, err := resolveInputs(cfg, false, nil, strings.NewReader(""), io.Discard)
+	vals, err := resolveInputs(cfg, false, "feature-x", nil, strings.NewReader(""), io.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +119,7 @@ func TestResolveInputsEmptyDefault(t *testing.T) {
 // never invoked.
 func TestResolveInputsPromptDisabled(t *testing.T) {
 	cfg := &config.Config{Inputs: config.Inputs{{Name: "a", Default: "x", HasDefault: true, Choices: "groups"}}}
-	vals, err := resolveInputs(cfg, false, func() []string {
+	vals, err := resolveInputs(cfg, false, "feature-x", func() []string {
 		t.Fatal("groups fetcher must not be called when prompting is disabled")
 		return nil
 	}, strings.NewReader("ignored\n"), io.Discard)
@@ -125,7 +146,7 @@ func TestResolveInputsPrompting(t *testing.T) {
 		return []string{"main", "derek/foo"}
 	}
 	// branch: pick #2; region: typed; tier: empty => default.
-	vals, err := resolveInputs(cfg, true, groupsFor, strings.NewReader("2\neu\n\n"), io.Discard)
+	vals, err := resolveInputs(cfg, true, "feature-x", groupsFor, strings.NewReader("2\neu\n\n"), io.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -291,6 +312,27 @@ func TestCheckLinkGroups(t *testing.T) {
 	// Without the override the empty link is rejected.
 	if err := checkLinkGroups(mergeLinks(cfg.Links, nil)); err == nil {
 		t.Fatalf("want empty-group error for un-overridden empty link")
+	}
+	// "@{current}" is a valid (non-empty) group: it resolves to the caller's own
+	// group at lookup time.
+	if err := checkLinkGroups(map[string]string{"api": "@{current}"}); err != nil {
+		t.Fatalf("@{current} should be accepted, got %v", err)
+	}
+}
+
+// An input answered with "@{current}" flows through the link pipeline and makes
+// the lookup fall back to the caller's own group.
+func TestInputCurrentFallsBackToOwnGroup(t *testing.T) {
+	cfg := &config.Config{Links: map[string]string{"api": "${inputs.x}"}}
+	if err := applyInputs(cfg, map[string]string{"x": "@{current}"}); err != nil {
+		t.Fatalf("applyInputs: %v", err)
+	}
+	merged := mergeLinks(cfg.Links, nil)
+	if err := checkLinkGroups(merged); err != nil {
+		t.Fatalf("checkLinkGroups: %v", err)
+	}
+	if g := effectiveGroup("api", "feature-x", merged); g != "feature-x" {
+		t.Fatalf("effectiveGroup = %q, want feature-x", g)
 	}
 }
 

--- a/cmd/mdp/peers.go
+++ b/cmd/mdp/peers.go
@@ -67,11 +67,21 @@ func extractPeerRefs(svc config.ServiceConfig) []peerRef {
 	return out
 }
 
+// currentGroupSentinel is the link-group value meaning "the caller's own
+// group". It is resolved here rather than rewritten in the linkMap because
+// the caller's group varies per resolver (services may carry a `group:`
+// override). Git forbids "@{" anywhere in a ref name (and uses it for
+// symbolic revisions like @{u}), so the sentinel can never collide with a
+// real branch.
+const currentGroupSentinel = "@{current}"
+
 // effectiveGroup returns the group to query for a given peer repo. linkMap
 // overrides the caller's group on a per-repo basis when --link <repo>=<group>
-// was passed at startup.
+// was passed at startup. The sentinel value "@{current}" (from an input
+// answer, a config link, or --link) means no override — the caller's group is
+// used.
 func effectiveGroup(repo, defaultGroup string, linkMap map[string]string) string {
-	if g, ok := linkMap[repo]; ok && g != "" {
+	if g, ok := linkMap[repo]; ok && g != "" && g != currentGroupSentinel {
 		return g
 	}
 	return defaultGroup

--- a/cmd/mdp/peers_test.go
+++ b/cmd/mdp/peers_test.go
@@ -161,6 +161,10 @@ func TestEffectiveGroup(t *testing.T) {
 	if g := effectiveGroup("backend", "feature-x", map[string]string{"backend": ""}); g != "feature-x" {
 		t.Errorf("empty override: got %q, want feature-x", g)
 	}
+	// "@{current}" explicitly means no override — fall back to the caller's group.
+	if g := effectiveGroup("backend", "feature-x", map[string]string{"backend": "@{current}"}); g != "feature-x" {
+		t.Errorf("@{current} override: got %q, want feature-x", g)
+	}
 }
 
 func TestRefreshPeerRefsLogsConnectDisconnect(t *testing.T) {

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -76,7 +76,7 @@ func init() {
 	runCmd.Flags().String("env", "PORT", "Environment variable name for the assigned port")
 	runCmd.Flags().Int("control-port", 13100, "Orchestrator control port")
 	runCmd.Flags().String("log-split", "", `Demultiplex combined-stream logs. Values: "compose" (docker-compose format) or "regex:<pattern>" with named captures 'name' and 'msg'.`)
-	runCmd.Flags().StringArray("link", nil, "Override the lookup group for cross-repo @<repo>.* env refs: repo=group (repeatable, last-wins per repo). Used when a peer service runs in a different group than the caller (e.g. backend on main, frontend on a feature branch).")
+	runCmd.Flags().StringArray("link", nil, "Override the lookup group for cross-repo @<repo>.* env refs: repo=group (repeatable, last-wins per repo). Used when a peer service runs in a different group than the caller (e.g. backend on main, frontend on a feature branch). repo=@{current} resets that repo to the caller's own group.")
 	runCmd.Flags().BoolP("interactive", "i", false, "Prompt for the inputs declared in mdp.yaml (see the `inputs:` section); without it, inputs use their defaults.")
 	runCmd.Flags().StringSlice("service", nil, "Only start the listed services from mdp.yaml (repeatable or comma-separated). Transitive depends_on are auto-included. Falls back to env MDP_SERVICES. Default: start all.")
 }
@@ -341,7 +341,7 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 	// Resolve declared inputs (prompting when -i, else defaults), then
 	// substitute ${inputs.X} refs throughout the config so the env/link
 	// pipeline below never sees an input reference.
-	inputs, err := resolveInputs(cfg, interactive, func() []string { return fetchActiveGroups(client, controlURL) }, os.Stdin, os.Stderr)
+	inputs, err := resolveInputs(cfg, interactive, group, func() []string { return fetchActiveGroups(client, controlURL) }, os.Stdin, os.Stderr)
 	if err != nil {
 		return err
 	}

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -130,7 +130,7 @@ services:
 
 Resolution:
 
-- **`mdp run -i`**: each input is prompted in declaration order, reading from stdin (a terminal, or piped answers such as `mdp run -i < answers.txt`). A `choices: groups` input prints the active groups (marking the `default`); enter a number, type a custom value, or press enter to accept the `default`. Pressing enter on an input that has no `default` re-prompts; `Ctrl-D` / end-of-input aborts the run.
+- **`mdp run -i`**: each input is prompted in declaration order, reading from stdin (a terminal, or piped answers such as `mdp run -i < answers.txt`). A `choices: groups` input prints the active groups plus a final `@{current}` entry — "this checkout's default group" — for [links](#links) that should fall back to the caller's own group (marking the `default`); enter a number, type a custom value, or press enter to accept the `default`. Pressing enter on an input that has no `default` re-prompts; `Ctrl-D` / end-of-input aborts the run.
 - **`mdp run`** (no `-i`): every input resolves to its `default`. An input with no `default` is an error — provide a `default` or run with `-i`.
 
 Input values are plain literals: an answer (or `default`) containing `${...}` is rejected, so an input can never smuggle in a port or peer reference. An undeclared `${inputs.X}` reference in a supported field is a load-time error, and the service name `inputs` is reserved.
@@ -143,7 +143,10 @@ Input values are plain literals: an answer (or `default`) containing `${...}` is
 links:
   api: ${inputs.api_branch}   # group chosen interactively
   auth: stable                # fixed group
+  db: "@{current}"            # explicitly the caller's own group
 ```
+
+The special value `@{current}` means "the caller's own group" — the lookup behaves as if the link were not declared. It is accepted anywhere a link group can come from: a literal `links:` value, an input answer or `default`, or `--link repo=@{current}`. Note that YAML requires quoting (`"@{current}"`) because a plain scalar cannot start with `@`. A link that resolves to an empty group (e.g. from an empty input) is still an error — `@{current}` is the explicit way to fall back. The sentinel can never collide with a real group: git forbids `@{` anywhere in a branch name (it's reserved for symbolic revisions like `@{u}`).
 
 ## Service
 
@@ -620,7 +623,21 @@ links:
   api: ${inputs.api_branch}
 ```
 
-`mdp run -i` then prompts for `api_branch` (offering the active groups), and `mdp run` without `-i` uses the `main` default. A `--link api=<group>` on the command line still overrides the config value.
+`mdp run -i` then prompts for `api_branch` (offering the active groups plus `@{current}`), and `mdp run` without `-i` uses the `main` default. A `--link api=<group>` on the command line still overrides the config value.
+
+To default to the caller's own group instead of a fixed branch, use the `@{current}` sentinel (quoted — YAML reserves a leading `@`):
+
+```yaml
+inputs:
+  api_branch:
+    prompt: "Which branch is the API on?"
+    default: "@{current}"
+    choices: groups
+links:
+  api: ${inputs.api_branch}
+```
+
+Now plain `mdp run` resolves `@api.*` references against the caller's own group, and `mdp run -i` lets you pick a different one. `--link api=@{current}` works the same way from the command line.
 
 ## Path resolution
 


### PR DESCRIPTION
Adds an `@{current}` sentinel for cross-repo link groups, meaning "the caller's own branch/group". It is accepted anywhere a link group can come from: input answers and defaults, literal `links:` values, and CLI `--link repo=@{current}`. The `choices: groups` interactive pick-list now ends with a discoverable `@{current}` entry annotated with the checkout's group. Git forbids `@{` in branch names, so the sentinel can never collide with a real group. Resolution happens at lookup time in `effectiveGroup`, so per-service `group:` overrides resolve correctly.
