### PR TITLE
fix: scope group inputs by repo and skip the prompt when no groups match

### DIFF
--- a/cmd/mdp/inputs.go
+++ b/cmd/mdp/inputs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"slices"
 	"sort"
 	"strconv"
@@ -16,10 +17,16 @@ import (
 )
 
 // fetchActiveGroups returns the sorted list of groups currently registered with
-// the orchestrator, used to populate `choices: groups` pick-lists. Returns nil
-// on any error — prompting then degrades to free-text entry.
-func fetchActiveGroups(client *http.Client, controlURL string) []string {
-	resp, err := client.Get(controlURL + "/__mdp/groups")
+// the orchestrator, used to populate `choices: groups` pick-lists. A non-empty
+// repo restricts the list to groups containing services from that repo. Returns
+// nil on any error and a non-nil empty slice when no groups match — resolveInputs
+// prompts free-text on error but skips the input (default) when genuinely empty.
+func fetchActiveGroups(client *http.Client, controlURL, repo string) []string {
+	target := controlURL + "/__mdp/groups"
+	if repo != "" {
+		target += "?repo=" + url.QueryEscape(repo)
+	}
+	resp, err := client.Get(target)
 	if err != nil {
 		return nil
 	}
@@ -41,18 +48,23 @@ func fetchActiveGroups(client *http.Client, controlURL string) []string {
 
 // resolveInputs produces the {name -> value} map for the config's declared
 // inputs. When interactive, each input is prompted for (groupsFor populates
-// `choices: groups` lists, fetched at most once) reading from in; otherwise
-// every input resolves to its Default, and an input with no default is an
-// error. currentGroup is the caller's own group, shown on the "@{current}"
-// pick-list entry. in/out are injectable for testing.
-func resolveInputs(cfg *config.Config, interactive bool, currentGroup string, groupsFor func() []string, in io.Reader, out io.Writer) (map[string]string, error) {
+// `choices: groups` lists, fetched at most once per repo filter) reading from
+// in; otherwise every input resolves to its Default, and an input with no
+// default is an error. A `choices: groups` input with no active groups and a
+// declared default is skipped silently — exactly like non-interactive — so
+// `mdp run -i` only prompts when there is something to select; a failed groups
+// fetch (nil) instead degrades to a free-text prompt, since "couldn't list
+// groups" must not silently pick the default. currentGroup is
+// the caller's own group, shown on the "@{current}" pick-list entry. in/out
+// are injectable for testing.
+func resolveInputs(cfg *config.Config, interactive bool, currentGroup string, groupsFor func(repo string) []string, in io.Reader, out io.Writer) (map[string]string, error) {
 	if len(cfg.Inputs) == 0 {
 		return nil, nil
 	}
 	values := make(map[string]string, len(cfg.Inputs))
 	reader := bufio.NewReader(in)
-	var groups []string
-	var groupsLoaded bool
+	groupsByRepo := make(map[string][]string) // cache, keyed by repo filter ("" = all)
+	groupsFetched := make(map[string]bool)    // separate from the cache: a nil (failed) fetch is cached too
 	for _, spec := range cfg.Inputs {
 		if !interactive {
 			if !spec.HasDefault {
@@ -61,9 +73,19 @@ func resolveInputs(cfg *config.Config, interactive bool, currentGroup string, gr
 			values[spec.Name] = spec.Default
 			continue
 		}
-		if spec.Choices == "groups" && !groupsLoaded {
-			groups = groupsFor()
-			groupsLoaded = true
+		var groups []string
+		if spec.Choices == "groups" {
+			if !groupsFetched[spec.Repo] {
+				groupsByRepo[spec.Repo] = groupsFor(spec.Repo)
+				groupsFetched[spec.Repo] = true
+			}
+			groups = groupsByRepo[spec.Repo]
+			// Skip only on a confirmed-empty list (non-nil): a failed fetch (nil)
+			// falls through to a free-text prompt instead of silently defaulting.
+			if groups != nil && len(groups) == 0 && spec.HasDefault {
+				values[spec.Name] = spec.Default
+				continue
+			}
 		}
 		val, err := promptInput(spec, currentGroup, groups, reader, out)
 		if err != nil {
@@ -81,9 +103,11 @@ func resolveInputs(cfg *config.Config, interactive bool, currentGroup string, gr
 // (so a numerically-named group stays selectable), and an out-of-range number
 // is taken as a literal value (so a not-yet-running branch named "3" can still
 // be entered). An empty answer uses the default when one is declared, else
-// re-prompts. EOF (Ctrl-D / end of input) aborts. The resolved value — typed or
-// picked — is rejected if it contains ${...}, so inputs stay plain literals (no
-// smuggled port/peer refs).
+// re-prompts. EOF (Ctrl-D / end of input) aborts. A `choices: groups` spec
+// only reaches here with an empty groups list when it has no default or the
+// fetch failed (resolveInputs skips otherwise); it degrades to free text. The resolved
+// value — typed or picked — is rejected if it contains ${...}, so inputs stay
+// plain literals (no smuggled port/peer refs).
 func promptInput(spec config.InputSpec, currentGroup string, groups []string, r *bufio.Reader, out io.Writer) (string, error) {
 	label := spec.Prompt
 	if label == "" {

--- a/cmd/mdp/inputs_test.go
+++ b/cmd/mdp/inputs_test.go
@@ -119,7 +119,7 @@ func TestResolveInputsEmptyDefault(t *testing.T) {
 // never invoked.
 func TestResolveInputsPromptDisabled(t *testing.T) {
 	cfg := &config.Config{Inputs: config.Inputs{{Name: "a", Default: "x", HasDefault: true, Choices: "groups"}}}
-	vals, err := resolveInputs(cfg, false, "feature-x", func() []string {
+	vals, err := resolveInputs(cfg, false, "feature-x", func(string) []string {
 		t.Fatal("groups fetcher must not be called when prompting is disabled")
 		return nil
 	}, strings.NewReader("ignored\n"), io.Discard)
@@ -141,8 +141,11 @@ func TestResolveInputsPrompting(t *testing.T) {
 		{Name: "tier", Default: "free", HasDefault: true},
 	}}
 	fetches := 0
-	groupsFor := func() []string {
+	groupsFor := func(repo string) []string {
 		fetches++
+		if repo != "" {
+			t.Fatalf("groupsFor repo = %q, want empty (no repo filter declared)", repo)
+		}
 		return []string{"main", "derek/foo"}
 	}
 	// branch: pick #2; region: typed; tier: empty => default.
@@ -155,6 +158,89 @@ func TestResolveInputsPrompting(t *testing.T) {
 	}
 	if fetches != 1 {
 		t.Fatalf("groups fetched %d times, want 1", fetches)
+	}
+}
+
+// A `choices: groups` input with no active groups and a declared default is
+// skipped silently — no prompt output, no stdin consumed — so `mdp run -i`
+// only prompts when there is something to select. An input with no default
+// still prompts (free text), since a value is required.
+func TestResolveInputsSkipsGroupChoiceWithoutGroups(t *testing.T) {
+	cfg := &config.Config{Inputs: config.Inputs{
+		{Name: "branch", Default: "@{current}", HasDefault: true, Choices: "groups"},
+		{Name: "region", Default: "us", HasDefault: true},
+	}}
+	groupsFor := func(string) []string { return []string{} }
+	var out bytes.Buffer
+	// "eu" must be read by region, not swallowed by the skipped branch input.
+	vals, err := resolveInputs(cfg, true, "feature-x", groupsFor, strings.NewReader("eu\n"), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["branch"] != "@{current}" || vals["region"] != "eu" {
+		t.Fatalf("got %v", vals)
+	}
+	if strings.Contains(out.String(), "branch") {
+		t.Fatalf("skipped input must not prompt, got:\n%s", out.String())
+	}
+
+	// No default: still prompts free-text.
+	cfg = &config.Config{Inputs: config.Inputs{{Name: "branch", Choices: "groups"}}}
+	vals, err = resolveInputs(cfg, true, "feature-x", groupsFor, strings.NewReader("other/branch\n"), io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["branch"] != "other/branch" {
+		t.Fatalf("got %v", vals)
+	}
+}
+
+// A failed groups fetch (nil, e.g. orchestrator unreachable) must not be
+// mistaken for "no groups exist": instead of silently taking the default, the
+// input degrades to a free-text prompt so -i still lets the user choose.
+func TestResolveInputsFetchErrorPromptsFreeText(t *testing.T) {
+	cfg := &config.Config{Inputs: config.Inputs{
+		{Name: "branch", Default: "main", HasDefault: true, Choices: "groups"},
+	}}
+	groupsFor := func(string) []string { return nil }
+	var out bytes.Buffer
+	vals, err := resolveInputs(cfg, true, "feature-x", groupsFor, strings.NewReader("derek/foo\n"), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["branch"] != "derek/foo" {
+		t.Fatalf("got %v, want typed value (not skipped to default)", vals)
+	}
+	if out.Len() == 0 {
+		t.Fatal("expected a prompt to be written")
+	}
+}
+
+// The groups fetch is cached per repo filter: same repo => one fetch,
+// different repos => separate fetches with the declared repo passed through.
+func TestResolveInputsGroupsPerRepo(t *testing.T) {
+	cfg := &config.Config{Inputs: config.Inputs{
+		{Name: "a", Default: "main", HasDefault: true, Choices: "groups", Repo: "api"},
+		{Name: "b", Default: "main", HasDefault: true, Choices: "groups", Repo: "api"},
+		{Name: "c", Default: "main", HasDefault: true, Choices: "groups", Repo: "auth"},
+	}}
+	fetches := map[string]int{}
+	groupsFor := func(repo string) []string {
+		fetches[repo]++
+		if repo == "auth" {
+			return []string{} // no active auth groups => input c skipped
+		}
+		return []string{"main", "derek/foo"}
+	}
+	vals, err := resolveInputs(cfg, true, "feature-x", groupsFor, strings.NewReader("2\n\n"), io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["a"] != "derek/foo" || vals["b"] != "main" || vals["c"] != "main" {
+		t.Fatalf("got %v", vals)
+	}
+	if !reflect.DeepEqual(fetches, map[string]int{"api": 1, "auth": 1}) {
+		t.Fatalf("fetches = %v, want one per repo", fetches)
 	}
 }
 
@@ -339,12 +425,33 @@ func TestInputCurrentFallsBackToOwnGroup(t *testing.T) {
 func TestFetchActiveGroups(t *testing.T) {
 	client := &http.Client{}
 
+	var gotRepo string
 	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRepo = r.URL.Query().Get("repo")
 		w.Write([]byte(`{"main":["a"],"derek/foo":["b"]}`))
 	}))
 	defer ok.Close()
-	if got := fetchActiveGroups(client, ok.URL); !reflect.DeepEqual(got, []string{"derek/foo", "main"}) {
+	if got := fetchActiveGroups(client, ok.URL, ""); !reflect.DeepEqual(got, []string{"derek/foo", "main"}) {
 		t.Fatalf("success: got %v, want sorted [derek/foo main]", got)
+	}
+	if gotRepo != "" {
+		t.Fatalf("repo param = %q, want unset", gotRepo)
+	}
+
+	// A repo filter is forwarded as the ?repo= query param.
+	fetchActiveGroups(client, ok.URL, "my repo")
+	if gotRepo != "my repo" {
+		t.Fatalf("repo param = %q, want %q", gotRepo, "my repo")
+	}
+
+	// A successful response with zero groups is a non-nil empty slice — distinct
+	// from the nil error paths below, so resolveInputs can skip vs prompt.
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	}))
+	defer empty.Close()
+	if got := fetchActiveGroups(client, empty.URL, ""); got == nil || len(got) != 0 {
+		t.Fatalf("empty: got %#v, want non-nil empty slice", got)
 	}
 
 	// Each degradation path returns nil so prompting falls back to free text.
@@ -352,7 +459,7 @@ func TestFetchActiveGroups(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer bad.Close()
-	if got := fetchActiveGroups(client, bad.URL); got != nil {
+	if got := fetchActiveGroups(client, bad.URL, ""); got != nil {
 		t.Fatalf("non-200: got %v, want nil", got)
 	}
 
@@ -360,11 +467,11 @@ func TestFetchActiveGroups(t *testing.T) {
 		w.Write([]byte("not json"))
 	}))
 	defer junk.Close()
-	if got := fetchActiveGroups(client, junk.URL); got != nil {
+	if got := fetchActiveGroups(client, junk.URL, ""); got != nil {
 		t.Fatalf("bad json: got %v, want nil", got)
 	}
 
-	if got := fetchActiveGroups(client, "http://127.0.0.1:1"); got != nil {
+	if got := fetchActiveGroups(client, "http://127.0.0.1:1", ""); got != nil {
 		t.Fatalf("connection error: got %v, want nil", got)
 	}
 }

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -341,7 +341,7 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 	// Resolve declared inputs (prompting when -i, else defaults), then
 	// substitute ${inputs.X} refs throughout the config so the env/link
 	// pipeline below never sees an input reference.
-	inputs, err := resolveInputs(cfg, interactive, group, func() []string { return fetchActiveGroups(client, controlURL) }, os.Stdin, os.Stderr)
+	inputs, err := resolveInputs(cfg, interactive, group, func(repo string) []string { return fetchActiveGroups(client, controlURL, repo) }, os.Stdin, os.Stderr)
 	if err != nil {
 		return err
 	}

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ Each proxy instance serves these endpoints on its listen port (e.g. `:3000`, `:4
 | `DELETE` | `/__mdp/register/{name}`               | Deregister from all proxies       |
 | `POST`   | `/__mdp/proxies/{port}/default/{name}` | Set default on a specific proxy   |
 | `DELETE` | `/__mdp/proxies/{port}/default`        | Clear default on a specific proxy |
-| `GET`    | `/__mdp/groups`                        | List all groups                   |
+| `GET`    | `/__mdp/groups`                        | List all groups (`?repo=` filters to groups containing that repo's services) |
 | `POST`   | `/__mdp/groups/{name}/switch`          | Switch group (set defaults)       |
 | `GET`    | `/__mdp/services`                      | List managed services             |
 | `POST`   | `/__mdp/shutdown`                      | Graceful shutdown                 |

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -111,6 +111,7 @@ Keys under `inputs.<name>`:
 | `prompt` | string | the input name | Question shown when prompting. |
 | `default` | string | none | Fallback used when not prompting, or when the answer is empty. Omitting the key (or writing a bare `default:` with no value) means **no default** — such an input errors under plain `mdp run` and must be prompted with `-i`. Use `default: ""` for an explicit empty default. Must be a plain literal — it cannot contain `${...}` references. |
 | `choices` | string | `""` | Set to `groups` to offer a numbered pick-list of the orchestrator's currently active groups (you may still type a custom value). Any other value is rejected at load. |
+| `repo` | string | `""` | Only valid with `choices: groups`. Limits the pick-list to groups containing services from this repo — useful when the input chooses a peer repo's branch for a [link](#links). Must be a plain literal. |
 
 ```yaml
 inputs:
@@ -118,6 +119,7 @@ inputs:
     prompt: "Which branch is the API running on?"
     default: main
     choices: groups
+    repo: api
 
 links:
   api: ${inputs.api_branch}
@@ -132,7 +134,7 @@ services:
 
 Resolution:
 
-- **`mdp run -i`**: each input is prompted in declaration order, reading from stdin (a terminal, or piped answers such as `mdp run -i < answers.txt`). A `choices: groups` input prints the active groups plus a final `@{current}` entry — "this checkout's default group" — for [links](#links) that should fall back to the caller's own group (marking the `default`); enter a number, type a custom value, or press enter to accept the `default`. Pressing enter on an input that has no `default` re-prompts; `Ctrl-D` / end-of-input aborts the run.
+- **`mdp run -i`**: each input is prompted in declaration order, reading from stdin (a terminal, or piped answers such as `mdp run -i < answers.txt`). A `choices: groups` input prints the active groups (filtered by `repo` if set) plus a final `@{current}` entry — "this checkout's default group" — for [links](#links) that should fall back to the caller's own group (marking the `default`); enter a number, type a custom value, or press enter to accept the `default`. A `choices: groups` input with no matching active groups and a declared `default` is skipped silently — exactly like plain `mdp run` — so `-i` only prompts when there is actually something to select (skipped inputs consume no line from piped answers); with no `default` it degrades to a free-text prompt since a value is still required. If the group listing fails (e.g. the orchestrator can't be reached), the input also falls back to a free-text prompt rather than silently taking the `default`. Pressing enter on an input that has no `default` re-prompts; `Ctrl-D` / end-of-input aborts the run.
 - **`mdp run`** (no `-i`): every input resolves to its `default`. An input with no `default` is an error — provide a `default` or run with `-i`.
 
 Input values are plain literals: an answer (or `default`) containing `${...}` is rejected, so an input can never smuggle in a port or peer reference. An undeclared `${inputs.X}` reference in a supported field is a load-time error, and the service name `inputs` is reserved.
@@ -621,11 +623,12 @@ inputs:
     prompt: "Which branch is the API on?"
     default: main
     choices: groups
+    repo: api
 links:
   api: ${inputs.api_branch}
 ```
 
-`mdp run -i` then prompts for `api_branch` (offering the active groups plus `@{current}`), and `mdp run` without `-i` uses the `main` default. A `--link api=<group>` on the command line still overrides the config value.
+`mdp run -i` then prompts for `api_branch` (offering the active groups containing `api` services plus `@{current}`, or skipping straight to the `default` when there are none), and `mdp run` without `-i` uses the `main` default. A `--link api=<group>` on the command line still overrides the config value.
 
 To default to the caller's own group instead of a fixed branch, use the `@{current}` sentinel (quoted — YAML reserves a leading `@`):
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,6 +124,7 @@ type InputSpec struct {
 	Default    string // fallback when not prompting or the answer is empty
 	HasDefault bool   // whether `default:` was present (distinguishes `default: ""` from absent)
 	Choices    string // optional; "groups" => live orchestrator group pick-list
+	Repo       string // optional; with `choices: groups`, limits the pick-list to groups containing services from this repo
 }
 
 // Inputs is an ordered list of declared inputs. YAML mappings lose key order,
@@ -167,8 +168,10 @@ func (in *Inputs) UnmarshalYAML(node *yaml.Node) error {
 				spec.HasDefault = true
 			case "choices":
 				dst = &spec.Choices
+			case "repo":
+				dst = &spec.Repo
 			default:
-				return fmt.Errorf("line %d: unknown key %q in input %q (only `prompt`, `default`, and `choices` are supported)", k.Line, k.Value, keyNode.Value)
+				return fmt.Errorf("line %d: unknown key %q in input %q (only `prompt`, `default`, `choices`, and `repo` are supported)", k.Line, k.Value, keyNode.Value)
 			}
 			if err := v.Decode(dst); err != nil {
 				return fmt.Errorf("line %d: input %q %s: %w", v.Line, keyNode.Value, k.Value, err)
@@ -419,8 +422,9 @@ func (cfg *Config) FinalizePaths(configDir string) {
 var inputNamePattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 
 // validateInputs checks the `inputs:` and `links:` sections: input names are
-// valid and unique, `choices` is empty or "groups", defaults are plain
-// literals, the reserved service name "inputs" is unused, and every
+// valid and unique, `choices` is empty or "groups", defaults and repos are
+// plain literals, `repo` only appears with `choices: groups`, the reserved
+// service name "inputs" is unused, and every
 // ${inputs.X} reference names a declared input. The reference scan drives
 // VisitInputRefFields, so it covers exactly the fields where substitution
 // applies — the two cannot drift apart — and in a deterministic order, so the
@@ -445,6 +449,12 @@ func validateInputs(cfg *Config) error {
 		}
 		if in.HasDefault && strings.Contains(in.Default, "${") {
 			return fmt.Errorf("input %q: default must be a plain literal (it cannot contain ${...} references)", in.Name)
+		}
+		if in.Repo != "" && in.Choices != "groups" {
+			return fmt.Errorf("input %q: repo is only valid with `choices: groups`", in.Name)
+		}
+		if strings.Contains(in.Repo, "${") {
+			return fmt.Errorf("input %q: repo must be a plain literal (it cannot contain ${...} references)", in.Name)
 		}
 	}
 	if _, ok := cfg.Services["inputs"]; ok {

--- a/internal/config/inputs_test.go
+++ b/internal/config/inputs_test.go
@@ -16,6 +16,7 @@ inputs:
     prompt: "Which branch?"
     default: main
     choices: groups
+    repo: api
   region:
     default: us
 links:
@@ -41,7 +42,7 @@ services:
 		t.Fatalf("input order not preserved: %+v", cfg.Inputs)
 	}
 	got := cfg.Inputs[0]
-	if got.Prompt != "Which branch?" || got.Default != "main" || got.Choices != "groups" {
+	if got.Prompt != "Which branch?" || got.Default != "main" || got.Choices != "groups" || got.Repo != "api" {
 		t.Fatalf("api_branch spec wrong: %+v", got)
 	}
 	if cfg.Links["api"] != "${inputs.api_branch}" || cfg.Links["auth"] != "stable" {
@@ -246,6 +247,33 @@ services:
     group: ${inputs.branch}
 `,
 			"group does not support ${inputs.X}",
+		},
+		{
+			"repo without choices groups",
+			`
+inputs:
+  x:
+    default: main
+    repo: api
+services:
+  web: {command: x, proxy: 3000}
+`,
+			"repo is only valid with `choices: groups`",
+		},
+		{
+			"repo is not a plain literal",
+			`
+inputs:
+  a:
+    default: main
+  b:
+    default: main
+    choices: groups
+    repo: "${inputs.a}"
+services:
+  web: {command: x, proxy: 3000}
+`,
+			`input "b": repo must be a plain literal`,
 		},
 		{
 			"unknown spec key",

--- a/internal/orchestrator/controlapi.go
+++ b/internal/orchestrator/controlapi.go
@@ -254,7 +254,7 @@ func (c *ControlAPI) handleClearDefault(w http.ResponseWriter, r *http.Request) 
 }
 
 func (c *ControlAPI) handleListGroups(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, c.orch.Groups())
+	writeJSON(w, http.StatusOK, c.orch.GroupsForRepo(r.URL.Query().Get("repo")))
 }
 
 func (c *ControlAPI) handleSwitchGroup(w http.ResponseWriter, r *http.Request) {

--- a/internal/orchestrator/controlapi_test.go
+++ b/internal/orchestrator/controlapi_test.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -263,6 +265,45 @@ func TestControlAPIListGroups(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&groups)
 	if len(groups) != 2 {
 		t.Errorf("expected 2 groups, got %d", len(groups))
+	}
+}
+
+// ?repo= restricts the listing to groups containing services from that repo.
+func TestControlAPIListGroupsRepoFilter(t *testing.T) {
+	o, handler := setupControlAPI(t)
+	o.mu.Lock()
+	o.proxies[3000].Registry.Register(&registry.ServerEntry{Name: "api/dev", Repo: "api", Port: 4003, PID: 300, Group: "dev"})
+	o.mu.Unlock()
+
+	for _, tc := range []struct {
+		repo string
+		want map[string][]string
+	}{
+		{"api", map[string][]string{"dev": {"api/dev"}}},
+		{"app", map[string][]string{"dev": {"app/dev"}, "staging": {"app/staging"}}},
+		{"nope", map[string][]string{}},
+		{"", map[string][]string{"dev": {"app/dev", "api/dev"}, "staging": {"app/staging"}}},
+	} {
+		req := httptest.NewRequest("GET", "/__mdp/groups?repo="+tc.repo, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("repo %q: expected 200, got %d", tc.repo, rec.Code)
+		}
+		var groups map[string][]string
+		json.NewDecoder(rec.Body).Decode(&groups)
+		if len(groups) != len(tc.want) {
+			t.Errorf("repo %q: groups = %v, want %v", tc.repo, groups, tc.want)
+			continue
+		}
+		for g, members := range tc.want {
+			got := groups[g]
+			sort.Strings(got)
+			sort.Strings(members)
+			if !slices.Equal(got, members) {
+				t.Errorf("repo %q group %q: members = %v, want %v", tc.repo, g, got, members)
+			}
+		}
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -476,11 +476,24 @@ func (o *Orchestrator) Groups() map[string][]string {
 	return o.groupsLocked()
 }
 
+// GroupsForRepo is Groups restricted to groups containing at least one service
+// from the given repo (only that repo's services are listed per group). An
+// empty repo is equivalent to Groups.
+func (o *Orchestrator) GroupsForRepo(repo string) map[string][]string {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.groupsForRepoLocked(repo)
+}
+
 func (o *Orchestrator) groupsLocked() map[string][]string {
+	return o.groupsForRepoLocked("")
+}
+
+func (o *Orchestrator) groupsForRepoLocked(repo string) map[string][]string {
 	groups := make(map[string][]string)
 	for _, pi := range o.proxies {
 		for _, entry := range pi.Registry.List() {
-			if entry.Group != "" {
+			if entry.Group != "" && (repo == "" || entry.Repo == repo) {
 				groups[entry.Group] = append(groups[entry.Group], entry.Name)
 			}
 		}


### PR DESCRIPTION
Adds an optional `repo:` key to `choices: groups` inputs in `mdp.yaml`, limiting the pick-list to groups containing services from that repo (via a new `?repo=` filter on `GET /__mdp/groups`). When a group input has no matching active groups and a declared `default`, `mdp run -i` now skips the prompt silently — so `-i` is always safe to pass and only prompts when there's actually something to select. A failed group listing (orchestrator unreachable) still degrades to a free-text prompt instead of silently taking the default. Includes tests and doc updates.