### PR TITLE
feat: gate readiness on named docker compose services via health_check

### DIFF
--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -173,7 +173,7 @@ Keys under `services.<name>`.
 | `ports` | list of [port mapping](#port-mapping) | `[]` | Multi-port mode. When present, `port` is ignored and ports are allocated per entry. |
 | `log_split` | string \| mapping | `""` | Demultiplex combined-stream logs into per-sub-service colored lanes. Accepts the scalar `"compose"` (built-in docker-compose parser) or a mapping `{ regex: '<pattern>' }` for arbitrary prefixes. See [`log_split`](#log_split--demultiplex-combined-stream-logs). |
 | `depends_on` | list of service names | `[]` | Wait for each dependency to be TCP-reachable on its assigned port(s) before starting. 60s per-dependency timeout. Unknown names and cycles are rejected at config load. |
-| `health_check` | [health check](#health_check) \| `"docker"` | nil (TCP on `port`) | Liveness probe used by the registry pruner. When unset, the default is a TCP dial of the service's registered port. See [Detached services and health checks](#detached-services-and-health-checks). |
+| `health_check` | [health check](#health_check) \| `"docker"` | nil (TCP on `port`) | Liveness probe used by the registry pruner. When unset, the default is a TCP dial of the service's registered port. The `docker: [svc, ...]` variant also gates startup readiness. See [Detached services and health checks](#detached-services-and-health-checks). |
 
 ### `command` — the basic case
 
@@ -451,6 +451,15 @@ services:
     port: 5432
     health_check: docker
 
+  # Named compose services: each must be running, and healthy if it defines
+  # a HEALTHCHECK. Also gates startup readiness — see below.
+  stack:
+    command: docker compose up -d
+    dir: ./stack
+    port: 5432
+    health_check:
+      docker: [db, redis]
+
   # For compose projects whose services are all short-lived, probe the
   # network directly instead.
   workers:
@@ -469,6 +478,9 @@ Variants (mutually exclusive):
 | `http: <url>` | an HTTP GET returns a 2xx or 3xx status |
 | `command: <shell tokens>` | the command exits 0 (run in the service's `dir`) |
 | shorthand `docker` | `docker compose ps -q` in the service's `dir` exits 0 with non-empty output |
+| `docker: [svc, ...]` | every named compose service has all containers in state `running`, and `healthy` if a `HEALTHCHECK` is defined |
+
+Unlike the other variants, which only affect post-exit liveness pruning, `docker: [svc, ...]` also gates **startup readiness**: the service isn't marked `running` (and `depends_on` dependents don't start) until the named compose services pass, in addition to TCP port reachability. It runs `docker compose ps` in the service's `dir` and requires Docker Compose v2.
 
 Command parsing honors single/double quotes but does not invoke a shell, so write `sh -c "..."` explicitly if you need shell features. Timeouts: TCP 2s, HTTP 3s, command/docker 5s.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,16 +214,19 @@ type ServiceConfig struct {
 }
 
 // HealthCheck customizes the liveness probe used to decide whether a service
-// is still up. Exactly one of TCP, HTTP, Command, or Docker must be set.
+// is still up. Exactly one of TCP, HTTP, Command, Docker, or DockerServices
+// must be set. DockerServices additionally gates startup readiness.
 type HealthCheck struct {
-	TCP     int    `yaml:"tcp"`     // TCP-dial localhost on this port
-	HTTP    string `yaml:"http"`    // HTTP GET on this absolute URL; 2xx/3xx = healthy
-	Command string `yaml:"command"` // shell tokens (same rules as service.command); exit 0 = healthy
-	Docker  bool   `yaml:"-"`       // set via the scalar shorthand `health_check: docker`
+	TCP            int      `yaml:"tcp"`     // TCP-dial localhost on this port
+	HTTP           string   `yaml:"http"`    // HTTP GET on this absolute URL; 2xx/3xx = healthy
+	Command        string   `yaml:"command"` // shell tokens (same rules as service.command); exit 0 = healthy
+	Docker         bool     `yaml:"-"`       // set via the scalar shorthand `health_check: docker`
+	DockerServices []string `yaml:"docker"`  // compose service names; each must be running (and healthy if it defines a HEALTHCHECK)
 }
 
 // UnmarshalYAML accepts either a scalar shorthand (currently only "docker") or
-// a mapping with tcp/http/command fields.
+// a mapping with tcp/http/command fields, or a docker field listing compose
+// service names.
 func (h *HealthCheck) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.ScalarNode:
@@ -255,8 +258,19 @@ func (h *HealthCheck) Validate() error {
 	if h.Docker {
 		set++
 	}
+	if h.DockerServices != nil {
+		if len(h.DockerServices) == 0 {
+			return fmt.Errorf("health_check: docker service list must not be empty")
+		}
+		set++
+		for _, s := range h.DockerServices {
+			if strings.TrimSpace(s) == "" {
+				return fmt.Errorf("health_check: docker service names must not be blank")
+			}
+		}
+	}
 	if set == 0 {
-		return fmt.Errorf("health_check: must set one of tcp, http, command, or the \"docker\" shorthand")
+		return fmt.Errorf("health_check: must set one of tcp, http, command, a docker service list, or the \"docker\" shorthand")
 	}
 	if set > 1 {
 		return fmt.Errorf("health_check: only one of tcp, http, command, or docker may be set")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -731,6 +731,114 @@ services:
 	}
 }
 
+func TestLoadHealthCheckDockerServices(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  db:
+    command: docker compose up -d
+    dir: ./db
+    port: 5432
+    health_check:
+      docker: [db, redis]
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	hc := cfg.Services["db"].HealthCheck
+	if hc == nil || hc.Docker {
+		t.Fatalf("expected Docker=false, got %+v", hc)
+	}
+	if len(hc.DockerServices) != 2 || hc.DockerServices[0] != "db" || hc.DockerServices[1] != "redis" {
+		t.Errorf("DockerServices = %v, want [db redis]", hc.DockerServices)
+	}
+}
+
+func TestLoadHealthCheckDockerServicesWithOtherVariant(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  db:
+    command: docker compose up -d
+    port: 5432
+    health_check:
+      tcp: 5432
+      docker: [db]
+`), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error when docker list is combined with another variant")
+	}
+	if !strings.Contains(err.Error(), "only one") {
+		t.Errorf("expected 'only one' error, got: %v", err)
+	}
+}
+
+func TestLoadHealthCheckDockerServicesEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  db:
+    command: docker compose up -d
+    port: 5432
+    health_check:
+      docker: []
+`), 0644)
+
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for empty docker service list")
+	}
+}
+
+func TestLoadHealthCheckDockerServicesEmptyWithOtherVariant(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  db:
+    command: docker compose up -d
+    port: 5432
+    health_check:
+      tcp: 5432
+      docker: []
+`), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for empty docker list alongside another variant")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected 'empty' error, got: %v", err)
+	}
+}
+
+func TestLoadHealthCheckDockerServicesBlankEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  db:
+    command: docker compose up -d
+    port: 5432
+    health_check:
+      docker: ["db", "  "]
+`), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for blank docker service name")
+	}
+	if !strings.Contains(err.Error(), "blank") {
+		t.Errorf("expected 'blank' error, got: %v", err)
+	}
+}
+
 func TestLoadLogSplit(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mdp.yaml")

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -3,6 +3,7 @@ package health
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -38,6 +39,9 @@ func Build(hc *config.HealthCheck, defaultPort int, workDir string) func() bool 
 	case hc.Command != "":
 		cmd := hc.Command
 		return func() bool { return commandProbe(cmd, workDir) }
+	case len(hc.DockerServices) > 0:
+		services := hc.DockerServices
+		return func() bool { return dockerServicesProbe(workDir, services) }
 	case hc.Docker:
 		return func() bool { return dockerProbe(workDir) }
 	}
@@ -86,6 +90,93 @@ func dockerProbe(workDir string) bool {
 		return false
 	}
 	return len(strings.TrimSpace(string(out))) > 0
+}
+
+// composeContainer is the subset of `docker compose ps --format json` output
+// the docker-services probe needs.
+type composeContainer struct {
+	Service string `json:"Service"`
+	State   string `json:"State"`
+	Health  string `json:"Health"`
+}
+
+// dockerServicesProbe is healthy when every named compose service has at least
+// one container running, and each of its containers reports healthy if it
+// defines a HEALTHCHECK. Requires Docker Compose v2 (`--format json`).
+//
+// Deliberately not `ps -a`: that would include exited one-off containers from
+// `docker compose run` under the same service name, failing the probe even
+// when the real stack is healthy. A named service with no running container
+// simply has no row, which reads as not-ready.
+func dockerServicesProbe(workDir string, services []string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+	args := append([]string{"compose", "ps", "--format", "json"}, services...)
+	c := exec.CommandContext(ctx, "docker", args...)
+	c.Dir = workDir
+	out, err := c.Output()
+	if err != nil {
+		return false
+	}
+	rows, err := parseComposePS(out)
+	if err != nil {
+		return false
+	}
+	return composeServicesReady(rows, services)
+}
+
+// parseComposePS handles both `docker compose ps --format json` output shapes:
+// a JSON array (compose < v2.21) and NDJSON, one object per line (>= v2.21).
+func parseComposePS(out []byte) ([]composeContainer, error) {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil, nil
+	}
+	if trimmed[0] == '[' {
+		var rows []composeContainer
+		if err := json.Unmarshal([]byte(trimmed), &rows); err != nil {
+			return nil, err
+		}
+		return rows, nil
+	}
+	var rows []composeContainer
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var row composeContainer
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// composeServicesReady reports whether every requested service has at least
+// one container and all of its containers (replicas) are running and, when a
+// HEALTHCHECK is defined, healthy.
+func composeServicesReady(rows []composeContainer, services []string) bool {
+	for _, svc := range services {
+		found := false
+		for _, row := range rows {
+			if row.Service != svc {
+				continue
+			}
+			found = true
+			if row.State != "running" {
+				return false
+			}
+			if row.Health != "" && row.Health != "healthy" {
+				return false
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // splitArgs tokenizes a command line honoring single and double quotes. Kept

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -130,6 +130,66 @@ func TestBuildDockerSkipsWhenDockerMissing(t *testing.T) {
 	}
 }
 
+func TestBuildDockerServicesSkipsWhenDockerMissing(t *testing.T) {
+	// Same shape as the plain-docker test: with or without docker installed,
+	// an empty temp dir has no compose project, so the probe reports unhealthy.
+	probe := Build(&config.HealthCheck{DockerServices: []string{"db"}}, 0, t.TempDir())
+	if probe() {
+		t.Error("expected docker services probe to fail in dir with no compose project")
+	}
+}
+
+func TestParseComposePS(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"empty", "", 0, false},
+		{"whitespace", "  \n", 0, false},
+		{"ndjson", "{\"Service\":\"db\",\"State\":\"running\",\"Health\":\"healthy\"}\n{\"Service\":\"redis\",\"State\":\"running\",\"Health\":\"\"}\n", 2, false},
+		{"array", `[{"Service":"db","State":"running","Health":""}]`, 1, false},
+		{"garbage", "not json", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := parseComposePS([]byte(tt.in))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if len(rows) != tt.want {
+				t.Errorf("got %d rows, want %d", len(rows), tt.want)
+			}
+		})
+	}
+}
+
+func TestComposeServicesReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		rows     []composeContainer
+		services []string
+		want     bool
+	}{
+		{"running no healthcheck", []composeContainer{{Service: "db", State: "running"}}, []string{"db"}, true},
+		{"running healthy", []composeContainer{{Service: "db", State: "running", Health: "healthy"}}, []string{"db"}, true},
+		{"health starting", []composeContainer{{Service: "db", State: "running", Health: "starting"}}, []string{"db"}, false},
+		{"exited", []composeContainer{{Service: "db", State: "exited"}}, []string{"db"}, false},
+		{"missing service", []composeContainer{{Service: "db", State: "running"}}, []string{"db", "redis"}, false},
+		{"extra service ignored", []composeContainer{{Service: "db", State: "running"}, {Service: "worker", State: "exited"}}, []string{"db"}, true},
+		{"one replica unhealthy", []composeContainer{{Service: "db", State: "running"}, {Service: "db", State: "running", Health: "unhealthy"}}, []string{"db"}, false},
+		{"no rows", nil, []string{"db"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := composeServicesReady(tt.rows, tt.services); got != tt.want {
+				t.Errorf("composeServicesReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTCPProbeClosedPort(t *testing.T) {
 	// Grab a port, release it, probe should fail.
 	ln, _ := net.Listen("tcp", "localhost:0")

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -28,8 +28,11 @@ var (
 	readyPoll    = 200 * time.Millisecond
 )
 
-// tcpCheck is overridable in tests.
-var tcpCheck = registry.TCPCheck
+// tcpCheck and buildHealthProbe are overridable in tests.
+var (
+	tcpCheck         = registry.TCPCheck
+	buildHealthProbe = health.Build
+)
 
 type serviceAlloc struct {
 	name            string
@@ -184,14 +187,22 @@ func (o *Orchestrator) StartConfigServices(ctx context.Context, group string) er
 				return
 			}
 
+			// Named docker compose services additionally gate readiness, on
+			// top of TCP port reachability. Other health_check variants only
+			// affect post-exit liveness pruning.
+			var extraProbe func() bool
+			if hc := a.svc.HealthCheck; hc != nil && len(hc.DockerServices) > 0 {
+				extraProbe = buildHealthProbe(hc, 0, a.svc.Dir)
+			}
+
 			probePorts := probePortsFor(a)
-			if len(probePorts) == 0 {
+			if len(probePorts) == 0 && extraProbe == nil {
 				if a.svc.Command != "" {
 					o.UpdateServiceStatus(serverName, "running")
 				}
 				return
 			}
-			if err := o.waitForReady(ctx, serverName, probePorts, readyTimeout); err != nil {
+			if err := o.waitForReady(ctx, serverName, probePorts, extraProbe, readyTimeout); err != nil {
 				slog.Error("service not ready", "name", a.name, "err", err)
 				state.Err = err
 				o.UpdateServiceStatus(serverName, "failed")
@@ -236,13 +247,12 @@ func probePortsFor(a serviceAlloc) []int {
 	return nil
 }
 
-// waitForReady polls TCP reachability on the given ports until all respond or
-// the timeout elapses. Returns early with an error if the service's status
-// becomes terminal (the process exited) before any port responds.
-func (o *Orchestrator) waitForReady(ctx context.Context, serverName string, probePorts []int, timeout time.Duration) error {
+// waitForReady polls TCP reachability on the given ports — plus extraProbe,
+// when non-nil — until all pass or the timeout elapses. Returns early with an
+// error if the service's status becomes terminal (the process exited) before
+// the checks pass.
+func (o *Orchestrator) waitForReady(ctx context.Context, serverName string, probePorts []int, extraProbe func() bool, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	ticker := time.NewTicker(readyPoll)
-	defer ticker.Stop()
 	for {
 		// Only treat "failed" as a terminal signal. A clean exit ("stopped")
 		// can be a detached service (e.g. `docker compose up -d`) whose port
@@ -257,16 +267,26 @@ func (o *Orchestrator) waitForReady(ctx context.Context, serverName string, prob
 				break
 			}
 		}
+		// Check the cheap TCP probes first so a failing port short-circuits
+		// the (potentially slow) docker probe.
+		if allReady && extraProbe != nil {
+			allReady = extraProbe()
+		}
 		if allReady {
 			return nil
 		}
 		if time.Now().After(deadline) {
+			if extraProbe != nil {
+				return fmt.Errorf("not ready (ports %v + health check) after %s", probePorts, timeout)
+			}
 			return fmt.Errorf("not ready on ports %v after %s", probePorts, timeout)
 		}
+		// A fresh timer (not a ticker) guarantees an idle gap after each
+		// round even when a probe takes longer than the poll interval.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ticker.C:
+		case <-time.After(readyPoll):
 		}
 	}
 }
@@ -293,7 +313,7 @@ func (o *Orchestrator) startSingleService(ctx context.Context, name string, svc 
 			Scheme:      scheme,
 			TLSCertPath: svc.TLSCert,
 			TLSKeyPath:  svc.TLSKey,
-			HealthCheck: health.Build(svc.HealthCheck, assignedPort, svc.Dir),
+			HealthCheck: buildHealthProbe(svc.HealthCheck, assignedPort, svc.Dir),
 			Env:         envSliceToMap(env),
 		}
 		if err := o.Register(svc.Proxy, entry); err != nil {
@@ -333,7 +353,7 @@ func (o *Orchestrator) startMultiPortService(ctx context.Context, name string, s
 			Repo:        o.repo,
 			Group:       group,
 			Port:        port,
-			HealthCheck: health.Build(svc.HealthCheck, port, svc.Dir),
+			HealthCheck: buildHealthProbe(svc.HealthCheck, port, svc.Dir),
 			Env:         envSliceToMap(env),
 		}
 		if err := o.Register(pm.Proxy, entry); err != nil {

--- a/internal/orchestrator/runner_test.go
+++ b/internal/orchestrator/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -343,6 +344,15 @@ func swapTimeouts(t *testing.T, timeout, poll time.Duration) {
 	origTimeout, origPoll := readyTimeout, readyPoll
 	readyTimeout, readyPoll = timeout, poll
 	t.Cleanup(func() { readyTimeout, readyPoll = origTimeout, origPoll })
+}
+
+// swapBuildHealthProbe replaces the package buildHealthProbe with fn for the
+// duration of the test and restores it on cleanup.
+func swapBuildHealthProbe(t *testing.T, fn func(*config.HealthCheck, int, string) func() bool) {
+	t.Helper()
+	orig := buildHealthProbe
+	buildHealthProbe = fn
+	t.Cleanup(func() { buildHealthProbe = orig })
 }
 
 func TestStartConfigServicesRespectsDependsOn(t *testing.T) {
@@ -720,5 +730,73 @@ func TestStartConfigServicesRegistersWithOrchRepo(t *testing.T) {
 	// that's the value the old bug stored in Repo.
 	if got := o.findPeers("main", "api", "api"); len(got) != 0 {
 		t.Errorf("findPeers(main, api, api) returned %d entries; expected 0", len(got))
+	}
+}
+
+func TestStartConfigServicesWaitsForDockerServicesProbe(t *testing.T) {
+	swapTimeouts(t, 5*time.Second, 10*time.Millisecond)
+	swapTCPCheck(t, func(int) bool { return true })
+
+	var probeReady atomic.Bool
+	swapBuildHealthProbe(t, func(hc *config.HealthCheck, port int, dir string) func() bool {
+		return func() bool { return probeReady.Load() }
+	})
+
+	cfg := &config.Config{
+		PortRange: "10000-60000",
+		Services: map[string]config.ServiceConfig{
+			"db": {
+				Command:     "sleep 30",
+				Port:        9921,
+				HealthCheck: &config.HealthCheck{DockerServices: []string{"db"}},
+				DependsOn:   []string{"other"}, // tracked so status is observable
+			},
+			"other": {Command: "sleep 30", Port: 9922},
+		},
+	}
+	o := New(cfg, "", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan struct{})
+	go func() {
+		_ = o.StartConfigServices(ctx, "test")
+		close(done)
+	}()
+
+	// Ports are "open" (tcpCheck stubbed true) but the docker probe is not
+	// ready yet — db must not reach "running".
+	if !waitForStatus(t, o, "test/db", "starting", 2*time.Second) {
+		t.Fatal("db did not reach 'starting'")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if status, _ := o.ServiceStatus("test/db"); status == "running" {
+		t.Fatal("db reached 'running' before docker probe passed")
+	}
+
+	probeReady.Store(true)
+	if !waitForStatus(t, o, "test/db", "running", 2*time.Second) {
+		t.Fatal("db did not transition to 'running' after docker probe passed")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("StartConfigServices did not return after cancel")
+	}
+}
+
+func TestWaitForReadyWithoutExtraProbeUnchanged(t *testing.T) {
+	swapTimeouts(t, time.Second, 10*time.Millisecond)
+	swapTCPCheck(t, func(int) bool { return true })
+	// Probe builder must not gate readiness when no DockerServices are set.
+	swapBuildHealthProbe(t, func(hc *config.HealthCheck, port int, dir string) func() bool {
+		return func() bool { return false }
+	})
+
+	o := New(&config.Config{}, "", "")
+	if err := o.waitForReady(context.Background(), "test/svc", []int{9931}, nil, time.Second); err != nil {
+		t.Fatalf("waitForReady() error = %v", err)
 	}
 }


### PR DESCRIPTION
Extends `health_check` with a `docker: [svc, ...]` variant that lists compose service names. Each named service must have all containers running — and healthy when a `HEALTHCHECK` is defined — probed via `docker compose ps --format json` (handles both array and NDJSON output shapes). Unlike other variants, this one also gates startup readiness: the service isn't marked running (and `depends_on` dependents don't start) until the containers pass, in addition to TCP port checks. The existing `health_check: docker` shorthand and the tcp/http/command variants are unchanged. Includes config validation, tests across config/health/orchestrator, and docs.