### PR TITLE
feat: run post_start hooks after service readiness

### DIFF
--- a/cmd/mdp/inputs_test.go
+++ b/cmd/mdp/inputs_test.go
@@ -254,6 +254,9 @@ func TestApplyInputs(t *testing.T) {
 				EnvFile:  "/repo/worktrees/${inputs.x}/.env",
 				Setup:    []string{"setup ${inputs.x}"},
 				Shutdown: []string{"teardown ${inputs.x}"},
+				PostStart: config.PostStartConfig{
+					Commands: []string{"seed ${inputs.x}"},
+				},
 				Env: map[string]config.EnvValue{
 					"A": {Value: "v-${inputs.x}"},
 					"B": {Ref: "api.port", Default: &def},
@@ -281,6 +284,9 @@ func TestApplyInputs(t *testing.T) {
 	}
 	if web.Setup[0] != "setup main" || web.Shutdown[0] != "teardown main" {
 		t.Fatalf("setup/shutdown = %v / %v", web.Setup, web.Shutdown)
+	}
+	if web.PostStart.Commands[0] != "seed main" {
+		t.Fatalf("post_start = %v", web.PostStart.Commands)
 	}
 	if got := web.Env["A"].Value; got != "v-main" {
 		t.Fatalf("env A = %q", got)

--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/derekgould/multi-dev-proxy/internal/detect"
 	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
 	"github.com/derekgould/multi-dev-proxy/internal/envexport"
+	"github.com/derekgould/multi-dev-proxy/internal/health"
 	"github.com/derekgould/multi-dev-proxy/internal/orchestrator"
 	"github.com/derekgould/multi-dev-proxy/internal/ports"
 	"github.com/derekgould/multi-dev-proxy/internal/portstore"
@@ -45,6 +46,7 @@ type batchRuntime struct {
 	readyTimeout time.Duration
 	readyPoll    time.Duration
 	tcpCheck     func(int) bool
+	buildProbe   func(*config.HealthCheck, int, string) func() bool
 }
 
 func defaultBatchRuntime() batchRuntime {
@@ -52,6 +54,7 @@ func defaultBatchRuntime() batchRuntime {
 		readyTimeout: 60 * time.Second,
 		readyPoll:    200 * time.Millisecond,
 		tcpCheck:     registry.TCPCheck,
+		buildProbe:   health.Build,
 	}
 }
 
@@ -672,6 +675,85 @@ func launchBatchService(
 		}
 	}
 
+	color := nextColor()
+	pw := newPrefixWriter(a.name, color, os.Stdout)
+	pwErr := newPrefixWriter(a.name, color, os.Stderr)
+
+	// postStartHooks runs the service's post_start hooks. Best-effort: failures
+	// only warn. waitTCP re-polls TCP readiness first (restart path). When
+	// health_check names docker compose services, hooks additionally wait for
+	// that gate before running.
+	postStartHooks := func(env []string, waitTCP bool) {
+		if len(a.svc.PostStart.Commands) == 0 {
+			return
+		}
+		if waitTCP && len(probePorts) > 0 {
+			if err := depwait.TCPReady(ctx, probePorts, rt.readyTimeout, rt.readyPoll, rt.tcpCheck); err != nil {
+				slog.Warn("post_start skipped; service not ready", "name", a.name, "err", err)
+				return
+			}
+		}
+		if hc := a.svc.HealthCheck; hc != nil && len(hc.DockerServices) > 0 {
+			probe := rt.buildProbe(hc, 0, a.svc.Dir)
+			deadline := time.Now().Add(rt.readyTimeout)
+			for !probe() {
+				if time.Now().After(deadline) {
+					slog.Warn("post_start skipped; docker health gate not ready", "name", a.name, "timeout", rt.readyTimeout)
+					return
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(rt.readyPoll):
+				}
+			}
+		}
+		for i, raw := range a.svc.PostStart.Commands {
+			parts, err := orchestrator.SplitHookArgs(raw)
+			if err != nil {
+				slog.Warn("post_start hook parse failed", "name", a.name, "step", i+1, "cmd", raw, "err", err)
+				continue
+			}
+			if len(parts) == 0 {
+				continue
+			}
+			slog.Info("service hook", "name", a.name, "phase", "post_start", "step", i+1, "cmd", raw)
+			h := exec.CommandContext(ctx, parts[0], parts[1:]...)
+			// pw/pwErr are not *os.Files, so exec wires the hook up via pipes;
+			// a hook that exits leaving a background child holding them (or one
+			// killed by ctx cancellation) would block Run in the pipe drain
+			// forever without this bound. The hook itself may run arbitrarily
+			// long — only post-exit/post-cancel I/O is cut off.
+			h.WaitDelay = postStartWaitDelay
+			h.Env = append(os.Environ(), env...)
+			if a.svc.Dir != "" {
+				h.Dir = a.svc.Dir
+			}
+			h.Stdout = pw
+			h.Stderr = pwErr
+			if err := h.Run(); err != nil {
+				slog.Warn("post_start hook failed", "name", a.name, "step", i+1, "cmd", raw, "err", err)
+			}
+		}
+	}
+
+	// runPostStart runs the hooks on a goroutine so signalReady timing is
+	// never affected and the supervise loop is never blocked.
+	var postStartWG sync.WaitGroup
+	var postStartMu sync.Mutex // serializes initial run vs restart re-runs
+	runPostStart := func(env []string, waitTCP bool) {
+		if len(a.svc.PostStart.Commands) == 0 {
+			return
+		}
+		postStartWG.Add(1)
+		go func() {
+			defer postStartWG.Done()
+			postStartMu.Lock()
+			defer postStartMu.Unlock()
+			postStartHooks(env, waitTCP)
+		}()
+	}
+
 	if a.svc.Command == "" {
 		// External upstream (mdp isn't starting a process). Register upfront
 		// and probe TCP so dependents only unblock once the externally-managed
@@ -687,16 +769,18 @@ func launchBatchService(
 			if err := depwait.TCPReady(ctx, probePorts, rt.readyTimeout, rt.readyPoll, rt.tcpCheck); err != nil {
 				slog.Error("external service not ready", "name", a.name, "err", err)
 				state.Err = err
+				return
 			}
 		}
+		signalReady()
+		// Nothing else to supervise on this path, so the hooks run inline.
+		postStartHooks(a.env, false)
+		pw.Flush()
+		pwErr.Flush()
 		return
 	}
 
 	env := a.env
-
-	color := nextColor()
-	pw := newPrefixWriter(a.name, color, os.Stdout)
-	pwErr := newPrefixWriter(a.name, color, os.Stderr)
 
 	// If log_split is enabled, demultiplex combined output into per-sub-service
 	// colored lanes. Hooks keep the outer service prefix — only the main
@@ -773,8 +857,15 @@ func launchBatchService(
 	// Signal dependents now; the rest of this goroutine just drains the cmd
 	// and (if this service has cross-repo peers) restarts it on peer change.
 	signalReady()
+	if state.Err == nil {
+		runPostStart(env, false)
+	}
 
-	superviseProcess(ctx, cmd, bt, client, controlURL, a, registered, registerAll, portMap, resolver, linkMap, pw, pwErr)
+	superviseProcess(ctx, cmd, bt, client, controlURL, a, registered, registerAll, runPostStart, portMap, resolver, linkMap, pw, pwErr)
+
+	// In-flight post_start hooks are ctx-bound, so after shutdown this wait is
+	// short; it keeps hook output ahead of shutdown hooks and the final flush.
+	postStartWG.Wait()
 
 	for i, raw := range a.svc.Shutdown {
 		parts, err := orchestrator.SplitHookArgs(raw)
@@ -812,6 +903,11 @@ func launchBatchService(
 
 const shutdownHookTimeout = 30 * time.Second
 
+// postStartWaitDelay bounds how long a post_start hook's Run may linger in
+// the pipe drain after the hook process exits or ctx is cancelled. It is not
+// a limit on the hook's own runtime.
+const postStartWaitDelay = 10 * time.Second
+
 // peerWatchInterval is how often supervisor goroutines poll the orchestrator
 // for cross-repo peer state changes. Package-level so tests can shorten it.
 var peerWatchInterval = 2 * time.Second
@@ -828,6 +924,7 @@ func superviseProcess(
 	a *batchAlloc,
 	registered []string,
 	registerAll func() ([]string, error),
+	runPostStart func(env []string, waitTCP bool),
 	portMap envexpand.PortMap,
 	resolver envexpand.Resolver,
 	linkMap map[string]string,
@@ -901,6 +998,11 @@ func superviseProcess(
 		}
 		for _, sn := range registered {
 			updatePIDWithOrchestrator(controlURL, sn, newCmd.Process.Pid)
+		}
+		if a.svc.PostStart.OnRestart {
+			// Readiness re-polling happens inside the hook goroutine, so the
+			// supervise loop is never blocked.
+			runPostStart(newEnv, true)
 		}
 		cmd = newCmd
 	}

--- a/cmd/mdp/run_test.go
+++ b/cmd/mdp/run_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -568,6 +569,383 @@ func TestLaunchBatchServiceSetupFailureSkipsRegistration(t *testing.T) {
 	}
 }
 
+func TestLaunchBatchServicePostStartRunsAfterReady(t *testing.T) {
+	rt := batchRuntime{
+		readyTimeout: time.Second,
+		readyPoll:    10 * time.Millisecond,
+		tcpCheck:     func(int) bool { return true },
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.log")
+	appendCmd := func(tag string) string {
+		return "sh -c 'echo " + tag + " >> " + logPath + "'"
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := batchAlloc{
+		name:         "web",
+		svcGroup:     "main",
+		assignedPort: 40103,
+		svc: config.ServiceConfig{
+			Command:   "sh -c 'echo main >> " + logPath + "; sleep 0.4'",
+			PostStart: config.PostStartConfig{Commands: []string{appendCmd("post_start")}},
+			Shutdown:  []string{appendCmd("shutdown")},
+			Proxy:     3000,
+		},
+	}
+
+	bt := &batchTracker{}
+	bt.wg.Add(1)
+	states := depwait.NewStates([]string{"web"})
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
+
+	lines := strings.Split(strings.TrimSpace(readFile(t, logPath)), "\n")
+	post := slices.Index(lines, "post_start")
+	shutdown := slices.Index(lines, "shutdown")
+	if post == -1 {
+		t.Fatalf("post_start hook did not run; log=%v", lines)
+	}
+	if shutdown == -1 || shutdown < post {
+		t.Errorf("shutdown hooks must run after post_start; log=%v", lines)
+	}
+	if states["web"].Err != nil {
+		t.Errorf("state.Err = %v, want nil", states["web"].Err)
+	}
+}
+
+func TestLaunchBatchServicePostStartFailureKeepsRunning(t *testing.T) {
+	rt := batchRuntime{
+		readyTimeout: time.Second,
+		readyPoll:    10 * time.Millisecond,
+		tcpCheck:     func(int) bool { return true },
+	}
+
+	dir := t.TempDir()
+	secondSentinel := filepath.Join(dir, "second-ran")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := batchAlloc{
+		name:         "web",
+		svcGroup:     "main",
+		assignedPort: 40104,
+		svc: config.ServiceConfig{
+			Command: "sh -c 'sleep 0.3'",
+			PostStart: config.PostStartConfig{Commands: []string{
+				"sh -c 'exit 1'",
+				"sh -c 'touch " + secondSentinel + "'",
+			}},
+			Proxy: 3000,
+		},
+	}
+
+	bt := &batchTracker{}
+	bt.wg.Add(1)
+	states := depwait.NewStates([]string{"web"})
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
+
+	if _, err := os.Stat(secondSentinel); err != nil {
+		t.Error("second post_start command did not run after the first failed")
+	}
+	if states["web"].Err != nil {
+		t.Errorf("state.Err = %v, want nil (post_start failures are best-effort)", states["web"].Err)
+	}
+}
+
+func TestLaunchBatchServicePostStartWaitsForDockerGate(t *testing.T) {
+	var probeCalls atomic.Int64
+	rt := batchRuntime{
+		readyTimeout: time.Second,
+		readyPoll:    10 * time.Millisecond,
+		tcpCheck:     func(int) bool { return true },
+		buildProbe: func(*config.HealthCheck, int, string) func() bool {
+			return func() bool { return probeCalls.Add(1) >= 3 }
+		},
+	}
+
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "hook-ran")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := batchAlloc{
+		name:         "web",
+		svcGroup:     "main",
+		assignedPort: 40105,
+		svc: config.ServiceConfig{
+			Command:     "sh -c 'sleep 0.1'",
+			HealthCheck: &config.HealthCheck{DockerServices: []string{"db"}},
+			PostStart:   config.PostStartConfig{Commands: []string{"sh -c 'touch " + sentinel + "'"}},
+			Proxy:       3000,
+		},
+	}
+
+	bt := &batchTracker{}
+	bt.wg.Add(1)
+	states := depwait.NewStates([]string{"web"})
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Error("post_start hook did not run after docker gate passed")
+	}
+	if got := probeCalls.Load(); got < 3 {
+		t.Errorf("probe called %d times, want >= 3 (hooks must wait for the gate)", got)
+	}
+}
+
+func TestLaunchBatchServicePostStartSkippedWhenDockerGateTimesOut(t *testing.T) {
+	rt := batchRuntime{
+		readyTimeout: 200 * time.Millisecond,
+		readyPoll:    10 * time.Millisecond,
+		tcpCheck:     func(int) bool { return true },
+		buildProbe: func(*config.HealthCheck, int, string) func() bool {
+			return func() bool { return false }
+		},
+	}
+
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "hook-ran")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := batchAlloc{
+		name:         "web",
+		svcGroup:     "main",
+		assignedPort: 40106,
+		svc: config.ServiceConfig{
+			Command:     "sh -c 'sleep 0.1'",
+			HealthCheck: &config.HealthCheck{DockerServices: []string{"db"}},
+			PostStart:   config.PostStartConfig{Commands: []string{"sh -c 'touch " + sentinel + "'"}},
+			Proxy:       3000,
+		},
+	}
+
+	bt := &batchTracker{}
+	bt.wg.Add(1)
+	states := depwait.NewStates([]string{"web"})
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
+
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Error("post_start hook ran but the docker gate never passed")
+	}
+	if states["web"].Err != nil {
+		t.Errorf("state.Err = %v, want nil (a skipped post_start must not fail the service)", states["web"].Err)
+	}
+}
+
+func TestLaunchBatchServicePostStartDoesNotBlockReady(t *testing.T) {
+	rt := batchRuntime{
+		readyTimeout: time.Second,
+		readyPoll:    10 * time.Millisecond,
+		tcpCheck:     func(int) bool { return true },
+	}
+
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "hook-ran")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := batchAlloc{
+		name:         "web",
+		svcGroup:     "main",
+		assignedPort: 40107,
+		svc: config.ServiceConfig{
+			Command:   "sh -c 'sleep 2'",
+			PostStart: config.PostStartConfig{Commands: []string{"sh -c 'sleep 0.5; touch " + sentinel + "'"}},
+			Proxy:     3000,
+		},
+	}
+
+	bt := &batchTracker{}
+	bt.wg.Add(1)
+	states := depwait.NewStates([]string{"web"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		launchBatchService(ctx, bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		bt.killAll()
+		<-done
+	})
+
+	select {
+	case <-states["web"].Done:
+	case <-time.After(time.Second):
+		t.Fatal("state.Done did not close; readiness must not wait on post_start")
+	}
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Error("post_start finished before readiness was signaled; expected it to still be running")
+	}
+}
+
+func TestLaunchBatchServicePostStartExternalUpstream(t *testing.T) {
+	rt := batchRuntime{
+		readyTimeout: time.Second,
+		readyPoll:    10 * time.Millisecond,
+		tcpCheck:     func(int) bool { return true },
+	}
+
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "hook-ran")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := batchAlloc{
+		name:         "infra",
+		svcGroup:     "main",
+		assignedPort: 40108,
+		svc: config.ServiceConfig{
+			// Command empty → external upstream path.
+			PostStart: config.PostStartConfig{Commands: []string{"sh -c 'touch " + sentinel + "'"}},
+			Proxy:     3000,
+		},
+	}
+
+	bt := &batchTracker{}
+	bt.wg.Add(1)
+	states := depwait.NewStates([]string{"infra"})
+	launchBatchService(context.Background(), bt, http.DefaultClient, srv.URL, "c1", "test-repo", &a, states, rt, envexpand.PortMap{}, nil, nil)
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Error("post_start hook did not run for external upstream")
+	}
+}
+
+func TestSuperviseProcessPostStartOnRestart(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		onRestart bool
+		wantCalls int64
+	}{
+		{"on_restart true reruns hooks", true, 1},
+		{"default does not rerun", false, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var port atomic.Int64
+			port.Store(9001)
+			var peerHits atomic.Int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/__mdp/peers" {
+					json.NewEncoder(w).Encode(map[string]any{
+						"port": port.Load(),
+						"env":  map[string]string{},
+					})
+					peerHits.Add(1)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			prev := peerWatchInterval
+			peerWatchInterval = 20 * time.Millisecond
+			t.Cleanup(func() { peerWatchInterval = prev })
+
+			command := "sh -c 'exec sleep 60'"
+			a := &batchAlloc{
+				name:     "frontend",
+				svcGroup: "dev",
+				svc: config.ServiceConfig{
+					Command: command,
+					PostStart: config.PostStartConfig{
+						Commands:  []string{"echo seeded"},
+						OnRestart: tc.onRestart,
+					},
+					Env: map[string]config.EnvValue{
+						"TARGET_PORT": {Ref: "@backend.api.port"},
+					},
+				},
+			}
+			resolver := newPeerResolver(http.DefaultClient, srv.URL, "dev", nil)
+			initialEnv, err := buildBatchEnv(*a, envexpand.PortMap{}, resolver)
+			if err != nil {
+				t.Fatalf("initial env: %v", err)
+			}
+			a.env = initialEnv
+
+			bt := &batchTracker{}
+			pw := newPrefixWriter("test", "0;0", os.Stdout)
+			pwErr := newPrefixWriter("test", "0;0", os.Stderr)
+			cmd, err := startBatchCommand(bt, command, "", initialEnv, pw, pwErr)
+			if err != nil {
+				t.Fatalf("startBatchCommand: %v", err)
+			}
+
+			var hookCalls atomic.Int64
+			hookWaitTCP := make(chan bool, 4)
+			runPostStart := func(env []string, waitTCP bool) {
+				hookCalls.Add(1)
+				hookWaitTCP <- waitTCP
+			}
+
+			registerAll := func() ([]string, error) { return nil, nil }
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				superviseProcess(ctx, cmd, bt, http.DefaultClient, srv.URL, a, nil, registerAll, runPostStart, envexpand.PortMap{}, resolver, nil, pw, pwErr)
+				close(done)
+			}()
+			t.Cleanup(func() {
+				cancel()
+				<-done
+				bt.killAll()
+				bt.wg.Wait()
+			})
+
+			// Wait for the supervisor to seed its peer baseline before flipping:
+			// the 1st /__mdp/peers hit is buildBatchEnv's initial resolve, the
+			// 2nd is superviseProcess's seed.
+			seedDeadline := time.Now().Add(2 * time.Second)
+			for peerHits.Load() < 2 && time.Now().Before(seedDeadline) {
+				time.Sleep(5 * time.Millisecond)
+			}
+			port.Store(9999) // trigger a peer-change restart
+
+			deadline := time.Now().Add(2 * time.Second)
+			for hookCalls.Load() < tc.wantCalls && time.Now().Before(deadline) {
+				time.Sleep(10 * time.Millisecond)
+			}
+			if tc.onRestart {
+				if got := hookCalls.Load(); got != 1 {
+					t.Fatalf("runPostStart called %d times, want 1", got)
+				}
+				if waitTCP := <-hookWaitTCP; !waitTCP {
+					t.Error("restart re-run must pass waitTCP=true")
+				}
+			} else {
+				// Give the restart time to land, then confirm no call.
+				time.Sleep(300 * time.Millisecond)
+				if got := hookCalls.Load(); got != 0 {
+					t.Fatalf("runPostStart called %d times, want 0", got)
+				}
+			}
+		})
+	}
+}
+
 func TestRunSoloNoEnvOverride(t *testing.T) {
 	err := runSolo([]string{"sh", "-c", `test -z "$MDP" && test -z "$PORT"`}, config.LogSplitConfig{})
 	if err != nil {
@@ -802,7 +1180,7 @@ func TestSuperviseProcessRestartsOnPeerChange(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		superviseProcess(ctx, cmd, bt, http.DefaultClient, srv.URL, a, nil, registerAll, envexpand.PortMap{}, resolver, nil, pw, pwErr)
+		superviseProcess(ctx, cmd, bt, http.DefaultClient, srv.URL, a, nil, registerAll, func([]string, bool) {}, envexpand.PortMap{}, resolver, nil, pw, pwErr)
 		close(done)
 	}()
 	t.Cleanup(func() {

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,7 +31,7 @@ services:
 port_range: "10000-60000"  # optional
 ```
 
-**Hooks:** `setup` commands run sequentially before `command` — if any exits non-zero the service is marked failed and `command` is not started. `shutdown` commands run sequentially after `command` exits (for any reason), best-effort with a 30s per-step timeout. Both share the same `dir` and `env` as `command`.
+**Hooks:** `setup` commands run sequentially before `command` — if any exits non-zero the service is marked failed and `command` is not started. `shutdown` commands run sequentially after `command` exits (for any reason), best-effort with a 30s per-step timeout. `post_start` commands run sequentially after the service becomes ready (e.g. seed a database once its container is healthy) — best-effort, and `depends_on` dependents never wait on them. All hooks share the same `dir` and `env` as `command`. See the [`post_start` reference](./mdp-yaml-reference.md#post_start-hooks) for details and the restart re-run option.
 
 **Other service fields:**
 

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -100,7 +100,7 @@ The file is written after all ports are allocated and before any service `comman
 
 `inputs` declares values that `mdp run -i` prompts for at startup. Each resolved value is referenced elsewhere as `${inputs.<name>}`. The motivating case is supplying a cross-repo branch name interactively instead of typing `--link repo=branch` on the command line.
 
-`${inputs.<name>}` is supported in these fields: a service's `command`, `dir`, `setup`, `shutdown`, `env` (scalar value, `ref:`, and `default:`), and `env_file`; the `global.env` block and `global.env_file`; and [`links`](#links) values. Using it in `group`, `tls_cert`, or `tls_key` is a load-time error (use [`links`](#links) for cross-repo groups); it is not expanded in other fields such as `port_range` or `health_check`.
+`${inputs.<name>}` is supported in these fields: a service's `command`, `dir`, `setup`, `shutdown`, `post_start`, `env` (scalar value, `ref:`, and `default:`), and `env_file`; the `global.env` block and `global.env_file`; and [`links`](#links) values. Using it in `group`, `tls_cert`, or `tls_key` is a load-time error (use [`links`](#links) for cross-repo groups); it is not expanded in other fields such as `port_range` or `health_check`.
 
 Input names may contain only letters, digits, and underscore (so they are always referenceable as `${inputs.<name>}`).
 
@@ -161,6 +161,7 @@ Keys under `services.<name>`.
 | `command` | string | `""` | Shell command to run. If empty and `port > 0`, the service is treated as externally managed: registered with the proxy but not started by `mdp`. |
 | `setup` | list of strings | `[]` | Commands run sequentially **before** `command`. First non-zero exit fails the service and `command` is not started. Shares `dir` and `env`. |
 | `shutdown` | list of strings | `[]` | Commands run sequentially **after** `command` exits (for any reason). Best-effort with a 30s per-step timeout. Shares `dir` and `env`. |
+| `post_start` | list of strings \| `{commands: [...], on_restart: bool}` | `[]` | Commands run sequentially **after the service becomes ready** (TCP-reachable, plus the docker gate when `health_check` names compose services). Best-effort and non-blocking: failures only warn, and `depends_on` dependents never wait on them. Shares `dir` and `env`. See [`post_start` hooks](#post_start-hooks). |
 | `dir` | string path | `""` | Working directory for `command`, `setup`, and `shutdown`. Relative paths resolve against the `mdp.yaml` directory. `~` is expanded. |
 | `port` | int | `0` | Fixed upstream port (for externally managed processes like Docker containers). When `0`, a free port is allocated from `port_range`. Ignored when `ports:` is set. |
 | `proxy` | int | `0` | Proxy port to register this service on. `0` means do not register with any proxy — useful for DB-only services. |
@@ -212,6 +213,37 @@ services:
 ```
 
 If `bun install` exits non-zero, `web` is marked failed and `bun dev` is never started. `shutdown` runs whenever `command` exits — clean exit, crash, or `Ctrl-C`.
+
+### `post_start` hooks
+
+`post_start` runs one-shot commands once the service is **ready** — its TCP port(s) accept connections, and, when `health_check` names docker compose services, those containers are running and healthy. Use it for work that needs the running service (seeding a database, warming a cache) without defining a separate service for it.
+
+```yaml
+services:
+  db:
+    command: docker compose up
+    health_check:
+      docker: [postgres]
+    post_start:
+      - ./scripts/migrate.sh
+      - ./scripts/seed-db.sh
+```
+
+Semantics:
+
+- **Best-effort** — a non-zero exit logs a warning and the next command still runs; the service is unaffected.
+- **Non-blocking** — `depends_on` dependents unblock on readiness as usual; they never wait for `post_start` to finish.
+- Commands run sequentially and share the service's `dir` and `env`, like `setup` and `shutdown`.
+- If the docker health gate never passes within the readiness timeout, the hooks are skipped with a warning.
+
+By default the hooks run only on the initial start. To re-run them after a cross-repo peer change restarts the service, use the mapping form:
+
+```yaml
+post_start:
+  commands:
+    - ./scripts/seed-db.sh
+  on_restart: true
+```
 
 ### `port` — fixed vs auto-allocated
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,6 +188,12 @@ type ServiceConfig struct {
 	Command  string              `yaml:"command"`
 	Setup    []string            `yaml:"setup"`    // commands run sequentially before Command
 	Shutdown []string            `yaml:"shutdown"` // commands run sequentially after Command exits
+
+	// PostStart lists commands run after the service becomes ready (TCP ports
+	// reachable, plus the docker health gate when health_check names compose
+	// services). Best-effort and non-blocking: failures only warn, and
+	// depends_on dependents never wait on these hooks.
+	PostStart PostStartConfig `yaml:"post_start"`
 	Dir      string              `yaml:"dir"`
 	Proxy    int                 `yaml:"proxy"`
 	Port     int                 `yaml:"port"`
@@ -211,6 +217,27 @@ type ServiceConfig struct {
 	// service is still up after its command has exited. Nil falls back to
 	// a TCP probe on the service's registered port.
 	HealthCheck *HealthCheck `yaml:"health_check"`
+}
+
+// PostStartConfig configures the post-readiness hooks of a service. It accepts
+// either a plain command list or a mapping with commands/on_restart fields.
+type PostStartConfig struct {
+	Commands  []string `yaml:"commands"`
+	OnRestart bool     `yaml:"on_restart"` // re-run after a peer-change auto-restart
+}
+
+// UnmarshalYAML accepts either a sequence of commands or a mapping with
+// commands/on_restart fields.
+func (p *PostStartConfig) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return node.Decode(&p.Commands)
+	case yaml.MappingNode:
+		type raw PostStartConfig
+		return node.Decode((*raw)(p))
+	default:
+		return fmt.Errorf("line %d: post_start must be a command list or a mapping", node.Line)
+	}
 }
 
 // HealthCheck customizes the liveness probe used to decide whether a service
@@ -565,6 +592,9 @@ func (cfg *Config) VisitInputRefFields(visit func(where, value string) (string, 
 		}
 		for i := range svc.Shutdown {
 			apply(fmt.Sprintf("%s shutdown[%d]", where, i), svc.Shutdown[i], func(v string) { svc.Shutdown[i] = v })
+		}
+		for i := range svc.PostStart.Commands {
+			apply(fmt.Sprintf("%s post_start[%d]", where, i), svc.PostStart.Commands[i], func(v string) { svc.PostStart.Commands[i] = v })
 		}
 		visitEnv(where, svc.Env)
 		apply(where+" env_file", svc.EnvFile, func(v string) { svc.EnvFile = v })

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -325,6 +325,81 @@ services:
 	}
 }
 
+func TestLoadPostStartList(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  web:
+    command: bun dev
+    post_start:
+      - ./scripts/seed-db.sh
+      - bun run warm-cache
+    proxy: 3000
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	web := cfg.Services["web"]
+	want := []string{"./scripts/seed-db.sh", "bun run warm-cache"}
+	if len(web.PostStart.Commands) != len(want) {
+		t.Fatalf("post_start len = %d, want %d", len(web.PostStart.Commands), len(want))
+	}
+	for i, s := range want {
+		if web.PostStart.Commands[i] != s {
+			t.Errorf("post_start[%d] = %q, want %q", i, web.PostStart.Commands[i], s)
+		}
+	}
+	if web.PostStart.OnRestart {
+		t.Error("on_restart = true, want false default")
+	}
+}
+
+func TestLoadPostStartObject(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  web:
+    command: bun dev
+    post_start:
+      commands:
+        - ./scripts/seed-db.sh
+      on_restart: true
+    proxy: 3000
+`), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	web := cfg.Services["web"]
+	if len(web.PostStart.Commands) != 1 || web.PostStart.Commands[0] != "./scripts/seed-db.sh" {
+		t.Errorf("post_start commands = %v, want [./scripts/seed-db.sh]", web.PostStart.Commands)
+	}
+	if !web.PostStart.OnRestart {
+		t.Error("on_restart = false, want true")
+	}
+}
+
+func TestLoadPostStartInvalidShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mdp.yaml")
+	os.WriteFile(path, []byte(`
+services:
+  web:
+    command: bun dev
+    post_start: ./scripts/seed-db.sh
+    proxy: 3000
+`), 0644)
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load() error = nil, want error for scalar post_start")
+	}
+}
+
 func TestFind(t *testing.T) {
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "a", "b")


### PR DESCRIPTION
Adds a per-service `post_start` hook list to `mdp.yaml`: one-shot commands that run after the service becomes ready (TCP-reachable, plus the docker compose health gate when `health_check` names services), e.g. seeding a database without defining a separate service. Hooks are best-effort (failures only warn) and non-blocking (`depends_on` dependents never wait on them), and a mapping form with `on_restart: true` opts into re-running them after peer-change auto-restarts. Hook commands set `WaitDelay` so a background child holding the output pipes can't stall shutdown. Includes config parsing + batch-runner tests and documentation updates.