### PR TITLE
feat: forward interactive hook prompts to the user's terminal

### DIFF
--- a/cmd/mdp/run.go
+++ b/cmd/mdp/run.go
@@ -32,6 +32,7 @@ import (
 	"github.com/derekgould/multi-dev-proxy/internal/envexpand"
 	"github.com/derekgould/multi-dev-proxy/internal/envexport"
 	"github.com/derekgould/multi-dev-proxy/internal/health"
+	"github.com/derekgould/multi-dev-proxy/internal/hookpty"
 	"github.com/derekgould/multi-dev-proxy/internal/orchestrator"
 	"github.com/derekgould/multi-dev-proxy/internal/ports"
 	"github.com/derekgould/multi-dev-proxy/internal/portstore"
@@ -47,6 +48,7 @@ type batchRuntime struct {
 	readyPoll    time.Duration
 	tcpCheck     func(int) bool
 	buildProbe   func(*config.HealthCheck, int, string) func() bool
+	hookMgr      *hookpty.Manager // nil: hooks run on plain pipes (CI, Windows, MDP_NO_HOOK_PTY)
 }
 
 func defaultBatchRuntime() batchRuntime {
@@ -509,6 +511,14 @@ func runBatchMode(cmd *cobra.Command, controlPort int, groupFlag string, linkMap
 	states := depwait.NewStates(names)
 
 	rt := defaultBatchRuntime()
+	// Interactive hook forwarding: setup/shutdown hooks run on a PTY so a
+	// hook stuck on a prompt can be detected and attached to from this
+	// terminal. nil when stdin/stdout is not a TTY or MDP_NO_HOOK_PTY is set.
+	// Closed after bt.wg drains so shutdown hooks stay attachable.
+	rt.hookMgr = hookpty.NewManager(os.Stdin, os.Stdout, os.Stderr, hookpty.RealTerm{})
+	if rt.hookMgr != nil {
+		defer rt.hookMgr.Close()
+	}
 	for i := range allocations {
 		bt.wg.Add(1)
 		go launchBatchService(batchCtx, bt, client, controlURL, clientID, repo, &allocations[i], states, rt, portMap, allocResolvers[i], linkMap)
@@ -709,29 +719,8 @@ func launchBatchService(
 			}
 		}
 		for i, raw := range a.svc.PostStart.Commands {
-			parts, err := orchestrator.SplitHookArgs(raw)
-			if err != nil {
-				slog.Warn("post_start hook parse failed", "name", a.name, "step", i+1, "cmd", raw, "err", err)
-				continue
-			}
-			if len(parts) == 0 {
-				continue
-			}
 			slog.Info("service hook", "name", a.name, "phase", "post_start", "step", i+1, "cmd", raw)
-			h := exec.CommandContext(ctx, parts[0], parts[1:]...)
-			// pw/pwErr are not *os.Files, so exec wires the hook up via pipes;
-			// a hook that exits leaving a background child holding them (or one
-			// killed by ctx cancellation) would block Run in the pipe drain
-			// forever without this bound. The hook itself may run arbitrarily
-			// long — only post-exit/post-cancel I/O is cut off.
-			h.WaitDelay = postStartWaitDelay
-			h.Env = append(os.Environ(), env...)
-			if a.svc.Dir != "" {
-				h.Dir = a.svc.Dir
-			}
-			h.Stdout = pw
-			h.Stderr = pwErr
-			if err := h.Run(); err != nil {
+			if err := runServiceHook(ctx, rt.hookMgr, raw, a.name, "post_start", env, a.svc.Dir, pw, pwErr, postStartWaitDelay); err != nil {
 				slog.Warn("post_start hook failed", "name", a.name, "step", i+1, "cmd", raw, "err", err)
 			}
 		}
@@ -800,24 +789,8 @@ func launchBatchService(
 	// Run setup before registering so routing never points at a service
 	// whose setup is still running (or has failed).
 	for i, raw := range a.svc.Setup {
-		parts, err := orchestrator.SplitHookArgs(raw)
-		if err != nil {
-			slog.Error("setup hook parse failed", "name", a.name, "step", i+1, "cmd", raw, "err", err)
-			state.Err = err
-			return
-		}
-		if len(parts) == 0 {
-			continue
-		}
 		slog.Info("service hook", "name", a.name, "phase", "setup", "step", i+1, "cmd", raw)
-		h := exec.CommandContext(ctx, parts[0], parts[1:]...)
-		h.Env = append(os.Environ(), env...)
-		if a.svc.Dir != "" {
-			h.Dir = a.svc.Dir
-		}
-		h.Stdout = pw
-		h.Stderr = pwErr
-		if err := h.Run(); err != nil {
+		if err := runServiceHook(ctx, rt.hookMgr, raw, a.name, "setup", env, a.svc.Dir, pw, pwErr, 0); err != nil {
 			slog.Error("setup hook failed", "name", a.name, "step", i+1, "cmd", raw, "err", err)
 			state.Err = err
 			return
@@ -868,24 +841,9 @@ func launchBatchService(
 	postStartWG.Wait()
 
 	for i, raw := range a.svc.Shutdown {
-		parts, err := orchestrator.SplitHookArgs(raw)
-		if err != nil {
-			slog.Warn("shutdown hook parse failed", "name", a.name, "step", i+1, "cmd", raw, "err", err)
-			continue
-		}
-		if len(parts) == 0 {
-			continue
-		}
 		slog.Info("service hook", "name", a.name, "phase", "shutdown", "step", i+1, "cmd", raw)
 		hCtx, hCancel := context.WithTimeout(context.Background(), shutdownHookTimeout)
-		h := exec.CommandContext(hCtx, parts[0], parts[1:]...)
-		h.Env = append(os.Environ(), a.env...)
-		if a.svc.Dir != "" {
-			h.Dir = a.svc.Dir
-		}
-		h.Stdout = pw
-		h.Stderr = pwErr
-		if err := h.Run(); err != nil {
+		if err := runServiceHook(hCtx, rt.hookMgr, raw, a.name, "shutdown", a.env, a.svc.Dir, pw, pwErr, 0); err != nil {
 			slog.Warn("shutdown hook failed", "name", a.name, "step", i+1, "cmd", raw, "err", err)
 		}
 		hCancel()
@@ -907,6 +865,47 @@ const shutdownHookTimeout = 30 * time.Second
 // the pipe drain after the hook process exits or ctx is cancelled. It is not
 // a limit on the hook's own runtime.
 const postStartWaitDelay = 10 * time.Second
+
+// runServiceHook executes one setup/shutdown/post_start hook command. When
+// mgr is non-nil the hook runs on a PTY (stderr merges into stdout — PTYs
+// have one stream) so a hook stuck on a prompt is detected and can be
+// attached to; otherwise output pipes to the prefixed writers with stdin
+// disconnected. waitDelay (when non-zero) bounds the pipe-fallback Run's
+// post-exit pipe drain and post-cancel wait — not the hook's own runtime.
+func runServiceHook(ctx context.Context, mgr *hookpty.Manager, raw, name, phase string, env []string, dir string, pw, pwErr io.Writer, waitDelay time.Duration) error {
+	parts, err := orchestrator.SplitHookArgs(raw)
+	if err != nil {
+		return err
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	newCmd := func(extraEnv ...string) *exec.Cmd {
+		h := exec.CommandContext(ctx, parts[0], parts[1:]...)
+		h.Env = append(append(os.Environ(), extraEnv...), env...)
+		if dir != "" {
+			h.Dir = dir
+		}
+		return h
+	}
+	if mgr != nil {
+		// On a PTY, TTY-detecting tools turn interactive — disable pagers by
+		// default so e.g. `git log` doesn't hang in `less` unattended. The
+		// service's own env (appended after) still overrides. The PTY path
+		// needs no waitDelay: it has no pipes to drain, and ctx cancellation
+		// already escalates SIGINT→SIGKILL inside hookpty.
+		ran, err := mgr.RunHook(ctx, newCmd("PAGER=cat", "GIT_PAGER=cat"), name+" "+phase, pw)
+		if ran {
+			return err
+		}
+		slog.Debug("hook PTY unavailable; falling back to pipes", "name", name, "err", err)
+	}
+	h := newCmd()
+	h.WaitDelay = waitDelay
+	h.Stdout = pw
+	h.Stderr = pwErr
+	return h.Run()
+}
 
 // peerWatchInterval is how often supervisor goroutines poll the orchestrator
 // for cross-repo peer state changes. Package-level so tests can shorten it.

--- a/docs/mdp-yaml-reference.md
+++ b/docs/mdp-yaml-reference.md
@@ -214,6 +214,8 @@ services:
 
 If `bun install` exits non-zero, `web` is marked failed and `bun dev` is never started. `shutdown` runs whenever `command` exits — clean exit, crash, or `Ctrl-C`.
 
+When `mdp run` is connected to a terminal (unix only), hooks run on a pseudo-terminal so a hook that prompts for input doesn't hang silently. If a hook's output stalls mid-line (or right after a line ending in `:`, `?`, or `>`), mdp prints a notice — press `Enter` to attach your terminal to it (when several hooks are waiting, type the listed number then `Enter`). While attached, keystrokes go to the hook (`Ctrl-C` included) and `Ctrl-]` detaches. Because a PTY has a single output stream, hook stderr is merged into stdout in this mode. This applies to `setup`, `shutdown`, and [`post_start`](#post_start-hooks) hooks. Set `MDP_NO_HOOK_PTY=1` to disable and run hooks on plain pipes; non-TTY environments (CI) and Windows always use plain pipes.
+
 ### `post_start` hooks
 
 `post_start` runs one-shot commands once the service is **ready** — its TCP port(s) accept connections, and, when `health_check` names docker compose services, those containers are running and healthy. Use it for work that needs the running service (seeding a database, warming a cache) without defining a separate service for it.

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/andybalholm/brotli v1.2.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/creack/pty v1.1.24
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/sys v0.36.0
+	golang.org/x/term v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod 
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -51,6 +53,8 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
+golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/hookpty/detector.go
+++ b/internal/hookpty/detector.go
@@ -1,0 +1,100 @@
+// Package hookpty runs service setup/shutdown hooks on a pseudo-terminal so
+// hooks that prompt for input can be detected and forwarded to the user's
+// terminal instead of hanging silently.
+package hookpty
+
+import (
+	"bytes"
+	"regexp"
+	"sync"
+	"time"
+)
+
+// ansiSeqRe matches ANSI CSI escape sequences (SGR colors, cursor codes,
+// erase-line, etc.) so a stalled line consisting only of terminal control
+// traffic is not mistaken for a prompt. Intentionally broader than the
+// similar regex in cmd/mdp/run.go: PTY output includes private-mode
+// sequences like \x1b[?25l (cursor hide), which the `?` in the class covers;
+// run.go's variant only needs to strip compose log-prefix coloring.
+var ansiSeqRe = regexp.MustCompile(`\x1b\[[0-9;?]*[A-Za-z]`)
+
+// partialCap bounds the retained partial line so a pathological
+// no-newline stream cannot grow memory without bound.
+const partialCap = 4096
+
+// detector tracks a hook's output stream and decides whether the hook looks
+// like it is waiting for input: no output for a stall window AND either the
+// last output line is unterminated (no trailing \n or \r) and non-blank once
+// ANSI sequences are stripped, OR the last complete line looks like a prompt
+// (ends with ':', '?', or '>') — catching e.g. `echo "Enter API key:"` before
+// a `read`. Newline-terminated silence (slow compiles) and \r-rewriting
+// spinners leave an empty partial and a non-promptish last line, so neither
+// fires.
+type detector struct {
+	mu        sync.Mutex
+	partial   []byte // bytes after the last \n or \r
+	lastLine  []byte // most recent complete line (between the last two \n/\r)
+	lastWrite time.Time
+}
+
+// observe records an output chunk read from the PTY at time now.
+func (d *detector) observe(p []byte, now time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lastWrite = now
+	if idx := bytes.LastIndexAny(p, "\n\r"); idx >= 0 {
+		head := p[:idx]
+		if j := bytes.LastIndexAny(head, "\n\r"); j >= 0 {
+			d.lastLine = append(d.lastLine[:0], head[j+1:]...)
+		} else {
+			d.lastLine = append(append(d.lastLine[:0], d.partial...), head...)
+		}
+		d.partial = append(d.partial[:0], p[idx+1:]...)
+	} else {
+		d.partial = append(d.partial, p...)
+	}
+	if len(d.partial) > partialCap {
+		d.partial = d.partial[len(d.partial)-partialCap:]
+	}
+	if len(d.lastLine) > partialCap {
+		d.lastLine = d.lastLine[len(d.lastLine)-partialCap:]
+	}
+}
+
+// pending returns the bytes to replay on attach so the user sees what the
+// hook is asking: the unterminated partial line, or — when the prompt ended
+// with a newline — the last complete line.
+func (d *detector) pending() []byte {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.partial) > 0 {
+		return append([]byte(nil), d.partial...)
+	}
+	if len(d.lastLine) > 0 {
+		return append(append([]byte(nil), d.lastLine...), '\r', '\n')
+	}
+	return nil
+}
+
+// waiting reports whether the stream looks input-starved at time now: at
+// least stallAfter has elapsed since the last output, and the pending partial
+// line has visible text or the last complete line ends prompt-like.
+func (d *detector) waiting(now time.Time, stallAfter time.Duration) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.lastWrite.IsZero() || now.Sub(d.lastWrite) < stallAfter {
+		return false
+	}
+	if visible := bytes.TrimSpace(ansiSeqRe.ReplaceAll(d.partial, nil)); len(visible) > 0 {
+		return true
+	}
+	last := bytes.TrimSpace(ansiSeqRe.ReplaceAll(d.lastLine, nil))
+	if len(last) == 0 {
+		return false
+	}
+	switch last[len(last)-1] {
+	case ':', '?', '>':
+		return true
+	}
+	return false
+}

--- a/internal/hookpty/detector_test.go
+++ b/internal/hookpty/detector_test.go
@@ -1,0 +1,143 @@
+package hookpty
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectorPromptStall(t *testing.T) {
+	var d detector
+	t0 := time.Now()
+	d.observe([]byte("installing...\nPassword: "), t0)
+	if d.waiting(t0.Add(time.Second), 5*time.Second) {
+		t.Fatal("waiting before stall window elapsed")
+	}
+	if !d.waiting(t0.Add(6*time.Second), 5*time.Second) {
+		t.Fatal("not waiting after stall on unterminated prompt")
+	}
+}
+
+func TestDetectorNewlineTerminatedPrompt(t *testing.T) {
+	var d detector
+	t0 := time.Now()
+	// Prompt printed on its own line before a read — no partial remains, but
+	// the last complete line ends prompt-like.
+	d.observe([]byte("Enter API key:\n"), t0)
+	if d.waiting(t0.Add(time.Second), 5*time.Second) {
+		t.Fatal("waiting before stall window elapsed")
+	}
+	if !d.waiting(t0.Add(6*time.Second), 5*time.Second) {
+		t.Fatal("newline-terminated prompt not flagged as waiting")
+	}
+	if got := string(d.pending()); got != "Enter API key:\r\n" {
+		t.Fatalf("pending = %q, want prompt line replay", got)
+	}
+}
+
+func TestDetectorPromptLineSpansChunks(t *testing.T) {
+	var d detector
+	t0 := time.Now()
+	d.observe([]byte("Are you"), t0)
+	d.observe([]byte(" sure?\n"), t0)
+	if !d.waiting(t0.Add(6*time.Second), 5*time.Second) {
+		t.Fatal("chunk-split prompt line not flagged as waiting")
+	}
+}
+
+func TestDetectorNewlineTerminatedSilence(t *testing.T) {
+	var d detector
+	t0 := time.Now()
+	d.observe([]byte("compiling step 3 of 9\n"), t0)
+	if d.waiting(t0.Add(time.Minute), 5*time.Second) {
+		t.Fatal("newline-terminated silence flagged as waiting")
+	}
+}
+
+func TestDetectorSpinnerCarriageReturn(t *testing.T) {
+	var d detector
+	t0 := time.Now()
+	// A stalled spinner's last write typically ends with \r (rewinding for
+	// the next frame), leaving an empty partial line.
+	d.observe([]byte("downloading 50%\rdownloading 51%\r"), t0)
+	if d.waiting(t0.Add(time.Minute), 5*time.Second) {
+		t.Fatal("spinner output flagged as waiting")
+	}
+}
+
+func TestDetectorANSIOnlyPartial(t *testing.T) {
+	var d detector
+	t0 := time.Now()
+	d.observe([]byte("done\n\x1b[2K\x1b[0m"), t0)
+	if d.waiting(t0.Add(time.Minute), 5*time.Second) {
+		t.Fatal("ANSI-only partial flagged as waiting")
+	}
+}
+
+func TestDetectorOutputResumeClears(t *testing.T) {
+	var d detector
+	t0 := time.Now()
+	d.observe([]byte("Continue? (y/n) "), t0)
+	if !d.waiting(t0.Add(6*time.Second), 5*time.Second) {
+		t.Fatal("expected waiting")
+	}
+	d.observe([]byte("y\nproceeding\n"), t0.Add(7*time.Second))
+	if d.waiting(t0.Add(8*time.Second), 5*time.Second) {
+		t.Fatal("waiting after output resumed")
+	}
+}
+
+func TestDetectorNoOutputAtAll(t *testing.T) {
+	var d detector
+	if d.waiting(time.Now(), 5*time.Second) {
+		t.Fatal("zero-output session flagged as waiting")
+	}
+}
+
+func TestDetectorPartialAccumulatesAcrossChunks(t *testing.T) {
+	var d detector
+	t0 := time.Now()
+	d.observe([]byte("Pass"), t0)
+	d.observe([]byte("word: "), t0)
+	if got := string(d.pending()); got != "Password: " {
+		t.Fatalf("pending = %q, want %q", got, "Password: ")
+	}
+}
+
+func TestDetectorPartialCap(t *testing.T) {
+	var d detector
+	d.observe(bytes.Repeat([]byte("x"), partialCap*3), time.Now())
+	if n := len(d.pending()); n != partialCap {
+		t.Fatalf("partial len = %d, want cap %d", n, partialCap)
+	}
+}
+
+func TestCRToLF(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"a\r\nb\r\n", "a\nb\n"},
+		{"spin\rspin2\rdone\n", "spin\nspin2\ndone\n"},
+		{"plain\n", "plain\n"},
+	}
+	for _, c := range cases {
+		var buf bytes.Buffer
+		w := &crToLF{w: &buf}
+		w.Write([]byte(c.in))
+		if buf.String() != c.want {
+			t.Errorf("crToLF(%q) = %q, want %q", c.in, buf.String(), c.want)
+		}
+	}
+}
+
+func TestCRToLFSplitAcrossWrites(t *testing.T) {
+	var buf bytes.Buffer
+	w := &crToLF{w: &buf}
+	w.Write([]byte("a\r"))
+	w.Write([]byte("\nb"))
+	if got := buf.String(); got != "a\nb" {
+		t.Fatalf("got %q, want %q", got, "a\nb")
+	}
+	if strings.Contains(buf.String(), "\r") {
+		t.Fatal("carriage return leaked through")
+	}
+}

--- a/internal/hookpty/manager.go
+++ b/internal/hookpty/manager.go
@@ -1,0 +1,310 @@
+package hookpty
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// detachByte is the attach-mode escape key (Ctrl-]).
+const detachByte = 0x1d
+
+// drainGrace bounds how long RunHook waits for the PTY master to reach EOF
+// after the hook exits before force-closing it (a grandchild may still hold
+// the slave side open).
+const drainGrace = 2 * time.Second
+
+// Manager runs hooks on PTYs, watches them for input-starved stalls, and
+// lets the user attach their terminal to a waiting hook. One Manager is
+// created per `mdp run` batch invocation; a nil Manager means the feature is
+// off and callers should run hooks on plain pipes.
+type Manager struct {
+	stdin, stdout *os.File
+	notify        io.Writer
+	tc            termController
+	stallAfter    time.Duration
+	pollEvery     time.Duration
+
+	mu          sync.Mutex
+	waiting     []*Session // flagged input-starved, in flag order
+	attached    *Session
+	restoreTerm func() error
+	resizeStop  chan struct{}
+	lineBuf     []byte
+	listenerOn  bool
+	closed      bool
+	done        chan struct{}
+}
+
+// NewManager returns a Manager wired to the user's terminal, or nil when
+// interactive hook forwarding is unavailable: stdin/stdout is not a TTY
+// (e.g. CI — a PTY would make tools prompt with nobody able to attach), or
+// MDP_NO_HOOK_PTY is set.
+func NewManager(stdin, stdout *os.File, notify io.Writer, tc termController) *Manager {
+	if os.Getenv("MDP_NO_HOOK_PTY") != "" {
+		return nil
+	}
+	if !tc.IsTerminal(int(stdin.Fd())) || !tc.IsTerminal(int(stdout.Fd())) {
+		return nil
+	}
+	return &Manager{
+		stdin:      stdin,
+		stdout:     stdout,
+		notify:     notify,
+		tc:         tc,
+		stallAfter: 5 * time.Second,
+		pollEvery:  time.Second,
+		done:       make(chan struct{}),
+	}
+}
+
+// RunHook starts cmd on a PTY, streams its output to prefixed, and waits for
+// it to exit, flagging the session as attachable whenever it looks like it
+// is waiting for input. The returned bool is false when the PTY could not be
+// started (cmd has not run) — the caller should fall back to plain pipes.
+func (m *Manager) RunHook(ctx context.Context, cmd *exec.Cmd, label string, prefixed io.Writer) (bool, error) {
+	master, err := startPTY(cmd, m.stdin)
+	if err != nil {
+		return false, err
+	}
+	s := &Session{label: label, master: master, prefixed: &crToLF{w: prefixed}}
+	s.sink = s.prefixed
+	m.register(s)
+
+	pumpDone := make(chan struct{})
+	go func() { s.pump(); close(pumpDone) }()
+
+	watchDone := make(chan struct{})
+	go func() {
+		t := time.NewTicker(m.pollEvery)
+		defer t.Stop()
+		for {
+			select {
+			case <-watchDone:
+				return
+			case <-t.C:
+				m.setWaiting(s, s.det.waiting(time.Now(), m.stallAfter))
+			}
+		}
+	}()
+
+	err = cmd.Wait()
+	close(watchDone)
+	// Drain remaining output: the master reads EOF (EIO on Linux) once the
+	// child exits, unless a grandchild still holds the slave open.
+	select {
+	case <-pumpDone:
+	case <-time.After(drainGrace):
+	}
+	// Unregister (detaching and stopping the resize watcher) before closing
+	// the master so nothing touches a closed file.
+	m.unregister(s)
+	master.Close()
+	<-pumpDone
+	return true, err
+}
+
+// Close stops the stdin listener and restores the terminal if a session is
+// still attached. Idempotent.
+func (m *Manager) Close() {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	m.detachLocked()
+	close(m.done)
+	m.mu.Unlock()
+	// Unblock a pending listener read; best-effort (not all stdins support
+	// deadlines, in which case the goroutine exits with the process).
+	m.stdin.SetReadDeadline(time.Now())
+}
+
+func (m *Manager) register(s *Session) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.listenerOn && !m.closed {
+		m.listenerOn = true
+		go m.listen()
+	}
+}
+
+func (m *Manager) unregister(s *Session) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.attached == s {
+		m.detachLocked()
+	}
+	if slices.Contains(m.waiting, s) {
+		m.dropWaitingLocked(s)
+	}
+}
+
+// setWaiting flags or clears a session as input-starved. Any change to the
+// waiting list prints a fresh notice (so picker numbers always match a
+// printed listing) and discards buffered keystrokes typed against the old
+// listing.
+func (m *Manager) setWaiting(s *Session, w bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return
+	}
+	flagged := slices.Contains(m.waiting, s)
+	if !w {
+		if flagged {
+			m.dropWaitingLocked(s)
+		}
+		return
+	}
+	if flagged || m.attached == s {
+		return
+	}
+	// Discard any bytes typed before this notice (stray keystrokes, escape
+	// sequences) so the next Enter attaches instead of failing the pick parse.
+	m.lineBuf = nil
+	m.waiting = append(m.waiting, s)
+	m.printNoticeLocked()
+}
+
+// dropWaitingLocked removes s from the waiting list, invalidates any
+// half-typed pick (the numbering it referred to is gone), and reprints the
+// notice for the sessions still waiting.
+func (m *Manager) dropWaitingLocked(s *Session) {
+	m.waiting = removeSession(m.waiting, s)
+	m.lineBuf = nil
+	if len(m.waiting) > 0 {
+		m.printNoticeLocked()
+	}
+}
+
+func (m *Manager) printNoticeLocked() {
+	if len(m.waiting) == 1 {
+		fmt.Fprintf(m.notify, "mdp: [%s] looks like it is waiting for input — press Enter to attach\n", m.waiting[0].label)
+		return
+	}
+	labels := make([]string, len(m.waiting))
+	for i, w := range m.waiting {
+		labels[i] = fmt.Sprintf("[%d] %s", i+1, w.label)
+	}
+	fmt.Fprintf(m.notify, "mdp: hooks waiting for input: %s — type a number then Enter to attach\n", strings.Join(labels, ", "))
+}
+
+// listen reads the user's terminal for the life of the manager. Stdin stays
+// in cooked mode while no session is attached (so Ctrl-C still interrupts
+// mdp normally); raw mode is entered only for the attached state.
+func (m *Manager) listen() {
+	buf := make([]byte, 256)
+	for {
+		n, err := m.stdin.Read(buf)
+		select {
+		case <-m.done:
+			return
+		default:
+		}
+		if n > 0 {
+			m.handleInput(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (m *Manager) handleInput(p []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if s := m.attached; s != nil {
+		// Raw mode: forward bytes to the hook's PTY; Ctrl-] detaches. Ctrl-C
+		// arrives as a plain 0x03 byte here and goes to the hook, not mdp.
+		// Writing under m.mu means RunHook's unregister/Close (which take the
+		// lock) cannot close the master mid-write; if the hook stops reading,
+		// the write unblocks with EIO once the child exits and the slave
+		// closes.
+		if i := bytes.IndexByte(p, detachByte); i >= 0 {
+			if i > 0 {
+				s.master.Write(p[:i])
+			}
+			m.detachLocked()
+			return
+		}
+		s.master.Write(p)
+		return
+	}
+
+	// Cooked mode: buffer until Enter, then interpret the line as a pick.
+	m.lineBuf = append(m.lineBuf, p...)
+	idx := bytes.IndexByte(m.lineBuf, '\n')
+	if idx < 0 {
+		return
+	}
+	line := strings.TrimSpace(string(m.lineBuf[:idx]))
+	m.lineBuf = m.lineBuf[idx+1:]
+	if len(m.waiting) == 0 {
+		return
+	}
+	pick := 0 // bare Enter attaches to the longest-waiting session
+	if line != "" {
+		n, err := strconv.Atoi(line)
+		if err != nil || n < 1 || n > len(m.waiting) {
+			return
+		}
+		pick = n - 1
+	}
+	m.attachLocked(m.waiting[pick])
+}
+
+func (m *Manager) attachLocked(s *Session) {
+	restore, err := m.tc.MakeRaw(int(m.stdin.Fd()))
+	if err != nil {
+		fmt.Fprintf(m.notify, "mdp: cannot attach to [%s]: %v\n", s.label, err)
+		return
+	}
+	m.restoreTerm = restore
+	m.attached = s
+	// No notice reprint here (it would garble the raw session) — just drop
+	// the picked session and any leftover typed bytes.
+	m.waiting = removeSession(m.waiting, s)
+	m.lineBuf = nil
+	fmt.Fprintf(m.stdout, "\r\n--- attached to [%s] — Ctrl-] to detach, Ctrl-C is sent to the hook ---\r\n", s.label)
+	// Replay the pending prompt so the user sees what the hook is asking.
+	m.stdout.Write(s.det.pending())
+	s.setSink(m.stdout)
+	m.resizeStop = make(chan struct{})
+	watchResize(m.stdin, s.master, m.resizeStop)
+}
+
+func (m *Manager) detachLocked() {
+	s := m.attached
+	if s == nil {
+		return
+	}
+	m.attached = nil
+	if m.resizeStop != nil {
+		close(m.resizeStop)
+		m.resizeStop = nil
+	}
+	s.setSink(s.prefixed)
+	if m.restoreTerm != nil {
+		m.restoreTerm()
+		m.restoreTerm = nil
+	}
+	fmt.Fprintf(m.notify, "\r\n--- detached from [%s] ---\n", s.label)
+}
+
+func removeSession(list []*Session, s *Session) []*Session {
+	if i := slices.Index(list, s); i >= 0 {
+		return slices.Delete(list, i, i+1)
+	}
+	return list
+}

--- a/internal/hookpty/manager_test.go
+++ b/internal/hookpty/manager_test.go
@@ -1,0 +1,305 @@
+package hookpty
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeTerm records raw-mode transitions without touching a real terminal.
+type fakeTerm struct {
+	mu       sync.Mutex
+	isTTY    bool
+	raws     int
+	restores int
+}
+
+func (f *fakeTerm) IsTerminal(fd int) bool { return f.isTTY }
+
+func (f *fakeTerm) MakeRaw(fd int) (func() error, error) {
+	f.mu.Lock()
+	f.raws++
+	f.mu.Unlock()
+	return func() error {
+		f.mu.Lock()
+		f.restores++
+		f.mu.Unlock()
+		return nil
+	}, nil
+}
+
+func (f *fakeTerm) counts() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.raws, f.restores
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer for capturing notices.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// testManager builds a Manager over OS pipes (stdin writable by the test,
+// stdout readable by the test) plus a fake terminal controller.
+func testManager(t *testing.T) (m *Manager, stdinW *os.File, stdoutR *os.File, notify *syncBuffer, tc *fakeTerm) {
+	t.Helper()
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		stdinR.Close()
+		stdinW.Close()
+		stdoutR.Close()
+		stdoutW.Close()
+	})
+	notify = &syncBuffer{}
+	tc = &fakeTerm{isTTY: true}
+	m = &Manager{
+		stdin:      stdinR,
+		stdout:     stdoutW,
+		notify:     notify,
+		tc:         tc,
+		stallAfter: 50 * time.Millisecond,
+		pollEvery:  10 * time.Millisecond,
+		done:       make(chan struct{}),
+	}
+	t.Cleanup(m.Close)
+	return m, stdinW, stdoutR, notify, tc
+}
+
+// testSession builds a registered session whose master is one end of an OS
+// pipe; the test reads forwarded input from the other end.
+func testSession(t *testing.T, m *Manager, label string) (*Session, *os.File, *bytes.Buffer) {
+	t.Helper()
+	masterR, masterW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		masterR.Close()
+		masterW.Close()
+	})
+	var logBuf bytes.Buffer
+	s := &Session{label: label, master: masterW, prefixed: &crToLF{w: &logBuf}}
+	s.sink = s.prefixed
+	m.register(s)
+	return s, masterR, &logBuf
+}
+
+func TestNewManagerNonTTY(t *testing.T) {
+	if m := NewManager(os.Stdin, os.Stdout, io.Discard, &fakeTerm{isTTY: false}); m != nil {
+		t.Fatal("expected nil manager when stdin/stdout is not a TTY")
+	}
+}
+
+func TestNewManagerEnvDisable(t *testing.T) {
+	t.Setenv("MDP_NO_HOOK_PTY", "1")
+	if m := NewManager(os.Stdin, os.Stdout, io.Discard, &fakeTerm{isTTY: true}); m != nil {
+		t.Fatal("expected nil manager when MDP_NO_HOOK_PTY is set")
+	}
+}
+
+func TestWaitingNoticePrinted(t *testing.T) {
+	m, _, _, notify, _ := testManager(t)
+	s, _, _ := testSession(t, m, "api setup")
+	m.setWaiting(s, true)
+	if got := notify.String(); !bytes.Contains([]byte(got), []byte("[api setup] looks like it is waiting for input")) {
+		t.Fatalf("notice not printed, got %q", got)
+	}
+	// Re-flagging is a no-op.
+	m.setWaiting(s, true)
+	if n := bytes.Count([]byte(notify.String()), []byte("waiting for input")); n != 1 {
+		t.Fatalf("notice printed %d times, want 1", n)
+	}
+}
+
+func TestAttachForwardDetach(t *testing.T) {
+	m, stdinW, stdoutR, notify, tc := testManager(t)
+	s, masterR, _ := testSession(t, m, "api setup")
+	m.setWaiting(s, true)
+
+	// Bare Enter attaches to the (only) waiting session.
+	stdinW.Write([]byte("\n"))
+	waitFor(t, "raw mode", func() bool { raws, _ := tc.counts(); return raws == 1 })
+
+	// Separator + replayed prompt appear on the raw terminal.
+	sepBuf := make([]byte, 256)
+	n, _ := stdoutR.Read(sepBuf)
+	if !bytes.Contains(sepBuf[:n], []byte("attached to [api setup]")) {
+		t.Fatalf("separator missing, got %q", sepBuf[:n])
+	}
+
+	// Typed bytes are forwarded to the hook's PTY master.
+	stdinW.Write([]byte("yes\n"))
+	fwd := make([]byte, 16)
+	n, _ = masterR.Read(fwd)
+	if string(fwd[:n]) != "yes\n" {
+		t.Fatalf("forwarded %q, want %q", fwd[:n], "yes\n")
+	}
+
+	// Ctrl-] detaches and restores the terminal.
+	stdinW.Write([]byte{detachByte})
+	waitFor(t, "restore", func() bool { _, r := tc.counts(); return r == 1 })
+	waitFor(t, "detach notice", func() bool {
+		return bytes.Contains([]byte(notify.String()), []byte("detached from [api setup]"))
+	})
+}
+
+func TestPickerSelectsNumberedSession(t *testing.T) {
+	m, stdinW, stdoutR, notify, tc := testManager(t)
+	s1, _, _ := testSession(t, m, "api setup")
+	s2, master2R, _ := testSession(t, m, "web setup")
+	m.setWaiting(s1, true)
+	m.setWaiting(s2, true)
+
+	if got := notify.String(); !bytes.Contains([]byte(got), []byte("[1] api setup")) || !bytes.Contains([]byte(got), []byte("[2] web setup")) {
+		t.Fatalf("numbered picker notice missing, got %q", got)
+	}
+
+	stdinW.Write([]byte("2\n"))
+	waitFor(t, "raw mode", func() bool { raws, _ := tc.counts(); return raws == 1 })
+	m.mu.Lock()
+	attached := m.attached
+	m.mu.Unlock()
+	if attached != s2 {
+		t.Fatalf("attached to %v, want web setup", attached)
+	}
+
+	// Drain stdout so the writer side never blocks, then verify forwarding
+	// reaches the picked session's master.
+	go io.Copy(io.Discard, stdoutR)
+	stdinW.Write([]byte("ok"))
+	fwd := make([]byte, 8)
+	n, _ := master2R.Read(fwd)
+	if string(fwd[:n]) != "ok" {
+		t.Fatalf("forwarded %q to picked session, want %q", fwd[:n], "ok")
+	}
+}
+
+func TestWaitingListShrinkInvalidatesTypedPick(t *testing.T) {
+	m, stdinW, stdoutR, notify, tc := testManager(t)
+	s1, _, _ := testSession(t, m, "api setup")
+	s2, _, _ := testSession(t, m, "web setup")
+	m.setWaiting(s1, true)
+	m.setWaiting(s2, true)
+	go io.Copy(io.Discard, stdoutR)
+
+	// User types "2" (meaning web setup) but doesn't press Enter yet.
+	stdinW.Write([]byte("2"))
+	waitFor(t, "pick buffered", func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return len(m.lineBuf) > 0
+	})
+
+	// api setup resumes output and leaves the list — the old numbering is
+	// stale, so the half-typed pick must be discarded and the notice reprinted.
+	m.setWaiting(s1, false)
+	if got := notify.String(); !bytes.Contains([]byte(got), []byte("[web setup] looks like it is waiting")) {
+		t.Fatalf("notice not reprinted after list shrink, got %q", got)
+	}
+
+	// Enter now attaches to the only waiting session instead of being
+	// swallowed by an out-of-range "2".
+	stdinW.Write([]byte("\n"))
+	waitFor(t, "raw mode", func() bool { raws, _ := tc.counts(); return raws == 1 })
+	m.mu.Lock()
+	attached := m.attached
+	m.mu.Unlock()
+	if attached != s2 {
+		t.Fatalf("attached to %v, want web setup", attached)
+	}
+}
+
+func TestSessionExitWhileAttachedDetaches(t *testing.T) {
+	m, stdinW, stdoutR, _, tc := testManager(t)
+	s, _, _ := testSession(t, m, "api setup")
+	m.setWaiting(s, true)
+	go io.Copy(io.Discard, stdoutR)
+
+	stdinW.Write([]byte("\n"))
+	waitFor(t, "raw mode", func() bool { raws, _ := tc.counts(); return raws == 1 })
+
+	m.unregister(s) // RunHook cleanup path when the hook exits mid-attach
+	if _, restores := tc.counts(); restores != 1 {
+		t.Fatalf("restores = %d, want 1", restores)
+	}
+}
+
+func TestCloseRestoresWhileAttached(t *testing.T) {
+	m, stdinW, stdoutR, _, tc := testManager(t)
+	s, _, _ := testSession(t, m, "api setup")
+	m.setWaiting(s, true)
+	go io.Copy(io.Discard, stdoutR)
+
+	stdinW.Write([]byte("\n"))
+	waitFor(t, "raw mode", func() bool { raws, _ := tc.counts(); return raws == 1 })
+
+	m.Close()
+	if _, restores := tc.counts(); restores != 1 {
+		t.Fatalf("restores = %d, want 1", restores)
+	}
+	m.Close() // idempotent
+}
+
+func TestStrayInputBeforeNoticeDoesNotBlockAttach(t *testing.T) {
+	m, stdinW, stdoutR, _, tc := testManager(t)
+	s, _, _ := testSession(t, m, "api setup")
+	go io.Copy(io.Discard, stdoutR)
+
+	// Stray keystrokes (no newline) typed while no hook is waiting.
+	stdinW.Write([]byte("ab\x1b[A"))
+	waitFor(t, "stray bytes buffered", func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return len(m.lineBuf) > 0
+	})
+
+	// Flagging a session discards the stale buffer, so bare Enter attaches.
+	m.setWaiting(s, true)
+	stdinW.Write([]byte("\n"))
+	waitFor(t, "raw mode", func() bool { raws, _ := tc.counts(); return raws == 1 })
+}
+
+func TestEnterWithNothingWaitingIsIgnored(t *testing.T) {
+	m, stdinW, _, _, tc := testManager(t)
+	testSession(t, m, "api setup") // registered but not waiting
+	stdinW.Write([]byte("\n\n3\n"))
+	time.Sleep(50 * time.Millisecond)
+	if raws, _ := tc.counts(); raws != 0 {
+		t.Fatalf("attached with nothing waiting (raws=%d)", raws)
+	}
+}

--- a/internal/hookpty/session.go
+++ b/internal/hookpty/session.go
@@ -1,0 +1,86 @@
+package hookpty
+
+import (
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// Session is one hook process running on a PTY. Its pump goroutine copies
+// master output to the current sink: the service's prefixed log writer while
+// detached, or the raw terminal while the user is attached.
+type Session struct {
+	label  string
+	master *os.File
+	det    detector
+
+	mu       sync.Mutex
+	sink     io.Writer
+	prefixed io.Writer // crToLF-wrapped service log writer (detached sink)
+}
+
+func (s *Session) setSink(w io.Writer) {
+	s.mu.Lock()
+	s.sink = w
+	s.mu.Unlock()
+}
+
+func (s *Session) writeSink(p []byte) {
+	s.mu.Lock()
+	w := s.sink
+	s.mu.Unlock()
+	w.Write(p)
+}
+
+// pump copies PTY master output to the session sink, feeding the stall
+// detector. Returns when the master reaches EOF (child exited). On Linux a
+// master read after child exit fails with EIO — treated as EOF.
+func (s *Session) pump() {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := s.master.Read(buf)
+		if n > 0 {
+			s.det.observe(buf[:n], time.Now())
+			s.writeSink(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// crToLF rewrites \r\n and bare \r to \n so PTY output (where the line
+// discipline emits \r\n, and spinners rewrite lines with \r) does not
+// accumulate into one giant buffered line inside a prefixWriter that only
+// splits on \n.
+type crToLF struct {
+	w         io.Writer
+	pendingCR bool
+}
+
+func (c *crToLF) Write(p []byte) (int, error) {
+	out := make([]byte, 0, len(p))
+	for _, b := range p {
+		switch b {
+		case '\r':
+			if c.pendingCR {
+				out = append(out, '\n')
+			}
+			c.pendingCR = true
+		case '\n':
+			out = append(out, '\n')
+			c.pendingCR = false
+		default:
+			if c.pendingCR {
+				out = append(out, '\n')
+				c.pendingCR = false
+			}
+			out = append(out, b)
+		}
+	}
+	if _, err := c.w.Write(out); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/internal/hookpty/session_unix_test.go
+++ b/internal/hookpty/session_unix_test.go
@@ -1,0 +1,193 @@
+//go:build unix
+
+package hookpty
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRunHookEndToEnd runs a real prompting shell hook on a PTY, waits for
+// the stall detector to flag it, attaches via simulated stdin, answers the
+// prompt, and verifies the answer round-trips and the terminal is restored.
+func TestRunHookEndToEnd(t *testing.T) {
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		stdinR.Close()
+		stdinW.Close()
+		stdoutR.Close()
+		stdoutW.Close()
+	})
+	go func() { // drain raw output so writes never block
+		buf := make([]byte, 4096)
+		for {
+			if _, err := stdoutR.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	notify := &syncBuffer{}
+	tc := &fakeTerm{isTTY: true}
+	m := &Manager{
+		stdin:      stdinR,
+		stdout:     stdoutW,
+		notify:     notify,
+		tc:         tc,
+		stallAfter: 100 * time.Millisecond,
+		pollEvery:  20 * time.Millisecond,
+		done:       make(chan struct{}),
+	}
+	t.Cleanup(m.Close)
+
+	var logBuf syncBuffer
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", `printf "Continue? (y/n) "; read a; echo "got $a"`)
+	hookDone := make(chan error, 1)
+	go func() {
+		ran, err := m.RunHook(context.Background(), cmd, "demo setup", &logBuf)
+		if !ran {
+			t.Errorf("RunHook fell back to pipes: %v", err)
+		}
+		hookDone <- err
+	}()
+
+	waitFor(t, "waiting notice", func() bool {
+		return strings.Contains(notify.String(), "[demo setup] looks like it is waiting for input")
+	})
+
+	stdinW.Write([]byte("\n")) // attach
+	waitFor(t, "raw mode", func() bool { raws, _ := tc.counts(); return raws == 1 })
+
+	stdinW.Write([]byte("y\n")) // answer the prompt through the PTY
+
+	select {
+	case err := <-hookDone:
+		if err != nil {
+			t.Fatalf("hook failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("hook did not exit after answering prompt")
+	}
+
+	// The hook's exit detaches and restores the terminal.
+	if _, restores := tc.counts(); restores != 1 {
+		t.Fatalf("restores = %d, want 1", restores)
+	}
+	if got := logBuf.String(); !bytes.Contains([]byte(got), []byte("got y")) && !strings.Contains(notify.String(), "got y") {
+		// While attached the output goes to the raw terminal (drained above),
+		// so the echo may not be in the prefixed log — the round-trip is
+		// already proven by the hook exiting with status 0.
+		t.Logf("note: echoed answer went to raw terminal (log=%q)", got)
+	}
+}
+
+// TestRunHookPlainCompletion verifies a non-interactive hook runs to
+// completion on the PTY with output reaching the prefixed writer.
+func TestRunHookPlainCompletion(t *testing.T) {
+	notify := &syncBuffer{}
+	tc := &fakeTerm{isTTY: true}
+	stdinR, stdinW, _ := os.Pipe()
+	t.Cleanup(func() { stdinR.Close(); stdinW.Close() })
+	m := &Manager{
+		stdin:      stdinR,
+		stdout:     os.Stdout,
+		notify:     notify,
+		tc:         tc,
+		stallAfter: time.Second,
+		pollEvery:  100 * time.Millisecond,
+		done:       make(chan struct{}),
+	}
+	t.Cleanup(m.Close)
+
+	var logBuf syncBuffer
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", `echo hello`)
+	ran, err := m.RunHook(context.Background(), cmd, "plain", &logBuf)
+	if !ran || err != nil {
+		t.Fatalf("RunHook ran=%v err=%v", ran, err)
+	}
+	if !strings.Contains(logBuf.String(), "hello") {
+		t.Fatalf("prefixed log missing output, got %q", logBuf.String())
+	}
+	if strings.Contains(logBuf.String(), "\r") {
+		t.Fatal("carriage returns leaked into prefixed log")
+	}
+}
+
+// TestRunHookCancelSendsSIGINT verifies ctx cancellation delivers a catchable
+// SIGINT to the hook's process group (not the default SIGKILL) so traps run.
+func TestRunHookCancelSendsSIGINT(t *testing.T) {
+	notify := &syncBuffer{}
+	stdinR, stdinW, _ := os.Pipe()
+	t.Cleanup(func() { stdinR.Close(); stdinW.Close() })
+	m := &Manager{
+		stdin:      stdinR,
+		stdout:     os.Stdout,
+		notify:     notify,
+		tc:         &fakeTerm{isTTY: true},
+		stallAfter: time.Minute,
+		pollEvery:  100 * time.Millisecond,
+		done:       make(chan struct{}),
+	}
+	t.Cleanup(m.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var logBuf syncBuffer
+	cmd := exec.CommandContext(ctx, "sh", "-c", `trap 'echo INT-CAUGHT; exit 0' INT; echo ready; sleep 30`)
+	hookDone := make(chan error, 1)
+	go func() {
+		_, err := m.RunHook(ctx, cmd, "trap", &logBuf)
+		hookDone <- err
+	}()
+
+	waitFor(t, "hook ready", func() bool { return strings.Contains(logBuf.String(), "ready") })
+	cancel()
+
+	select {
+	case <-hookDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("hook did not exit after cancel")
+	}
+	if !strings.Contains(logBuf.String(), "INT-CAUGHT") {
+		t.Fatalf("hook was not SIGINTed gracefully, log=%q", logBuf.String())
+	}
+}
+
+// TestRunHookFailurePropagates verifies a failing hook returns its exit error.
+func TestRunHookFailurePropagates(t *testing.T) {
+	notify := &syncBuffer{}
+	stdinR, stdinW, _ := os.Pipe()
+	t.Cleanup(func() { stdinR.Close(); stdinW.Close() })
+	m := &Manager{
+		stdin:      stdinR,
+		stdout:     os.Stdout,
+		notify:     notify,
+		tc:         &fakeTerm{isTTY: true},
+		stallAfter: time.Second,
+		pollEvery:  100 * time.Millisecond,
+		done:       make(chan struct{}),
+	}
+	t.Cleanup(m.Close)
+
+	var logBuf syncBuffer
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", `exit 3`)
+	ran, err := m.RunHook(context.Background(), cmd, "fail", &logBuf)
+	if !ran {
+		t.Fatal("expected hook to run on PTY")
+	}
+	if err == nil {
+		t.Fatal("expected exit error")
+	}
+}

--- a/internal/hookpty/start_unix.go
+++ b/internal/hookpty/start_unix.go
@@ -1,0 +1,53 @@
+//go:build unix
+
+package hookpty
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// startPTY starts cmd with its stdio attached to a new pseudo-terminal and
+// returns the master side, sized to match the user's terminal.
+func startPTY(cmd *exec.Cmd, tty *os.File) (*os.File, error) {
+	// pty.Start puts the hook in its own session (Setsid), so mdp's Ctrl-C no
+	// longer reaches it at kernel level — and exec.CommandContext's default
+	// Cancel is SIGKILL. Restore graceful shutdown: SIGINT the hook's process
+	// group on ctx cancel, escalating to SIGKILL after WaitDelay.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+	}
+	cmd.WaitDelay = 5 * time.Second
+	master, err := pty.Start(cmd)
+	if err != nil {
+		return nil, err
+	}
+	pty.InheritSize(tty, master)
+	return master, nil
+}
+
+// watchResize forwards terminal size changes to the PTY master until stop is
+// closed. Used only while a session is attached.
+func watchResize(tty, master *os.File, stop <-chan struct{}) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	go func() {
+		defer signal.Stop(ch)
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ch:
+				pty.InheritSize(tty, master)
+			}
+		}
+	}()
+}

--- a/internal/hookpty/start_windows.go
+++ b/internal/hookpty/start_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package hookpty
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+var errPTYUnsupported = errors.New("hookpty: PTY not supported on windows")
+
+// startPTY is unsupported on Windows — callers fall back to plain pipes.
+func startPTY(cmd *exec.Cmd, tty *os.File) (*os.File, error) {
+	return nil, errPTYUnsupported
+}
+
+func watchResize(tty, master *os.File, stop <-chan struct{}) {}

--- a/internal/hookpty/term.go
+++ b/internal/hookpty/term.go
@@ -1,0 +1,24 @@
+package hookpty
+
+import "golang.org/x/term"
+
+// termController abstracts raw-mode control of the user's terminal so the
+// attach state machine can be tested with a fake.
+type termController interface {
+	IsTerminal(fd int) bool
+	// MakeRaw switches the terminal to raw mode and returns a restore func.
+	MakeRaw(fd int) (restore func() error, err error)
+}
+
+// RealTerm implements termController with golang.org/x/term.
+type RealTerm struct{}
+
+func (RealTerm) IsTerminal(fd int) bool { return term.IsTerminal(fd) }
+
+func (RealTerm) MakeRaw(fd int) (func() error, error) {
+	st, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	return func() error { return term.Restore(fd, st) }, nil
+}


### PR DESCRIPTION
During `mdp run` batch mode, `setup`, `shutdown`, and `post_start` hooks now run on a PTY (unix): when a hook stalls on a prompt, mdp prints a notice and the user can attach their terminal to answer it (Enter to attach, numbered picker when several hooks wait, Ctrl-] to detach). The new `internal/hookpty` package handles stall/prompt detection, raw-mode attach/detach with terminal-restore safety, and graceful SIGINT-on-cancel for PTY hooks. Non-TTY environments (CI), Windows, and `MDP_NO_HOOK_PTY=1` keep today's pipe behavior exactly. Adds `creack/pty` (unix-only via build tags) and `golang.org/x/term`; covered by unit tests, a real-PTY integration test, and docs in `mdp-yaml-reference.md`.