### PR TITLE
feat: add dashboard command and report dashboard URL on daemon start

### DIFF
--- a/cmd/mdp/browser_darwin.go
+++ b/cmd/mdp/browser_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package main
+
+import "os/exec"
+
+func openBrowser(url string) error {
+	return exec.Command("open", url).Start()
+}

--- a/cmd/mdp/browser_unix.go
+++ b/cmd/mdp/browser_unix.go
@@ -1,0 +1,9 @@
+//go:build unix && !darwin
+
+package main
+
+import "os/exec"
+
+func openBrowser(url string) error {
+	return exec.Command("xdg-open", url).Start()
+}

--- a/cmd/mdp/browser_windows.go
+++ b/cmd/mdp/browser_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os/exec"
+
+func openBrowser(url string) error {
+	return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+}

--- a/cmd/mdp/daemon_unix.go
+++ b/cmd/mdp/daemon_unix.go
@@ -72,7 +72,11 @@ func startDaemon(controlPort int) error {
 		slog.Warn("daemon may not have started correctly", "err", err)
 	}
 
-	fmt.Printf("mdp orchestrator started (PID %d, ctrl :%d)\n", pid, controlPort)
+	msg := fmt.Sprintf("mdp orchestrator started (PID %d, ctrl :%d", pid, controlPort)
+	if dashboardPort, ok := fetchDashboardPort(controlPort); ok && dashboardPort > 0 {
+		msg += fmt.Sprintf(", dashboard http://localhost:%d", dashboardPort)
+	}
+	fmt.Println(msg + ")")
 	return nil
 }
 

--- a/cmd/mdp/daemon_windows.go
+++ b/cmd/mdp/daemon_windows.go
@@ -72,7 +72,11 @@ func startDaemon(controlPort int) error {
 		slog.Warn("daemon may not have started correctly", "err", err)
 	}
 
-	fmt.Printf("mdp orchestrator started (PID %d, ctrl :%d)\n", pid, controlPort)
+	msg := fmt.Sprintf("mdp orchestrator started (PID %d, ctrl :%d", pid, controlPort)
+	if dashboardPort, ok := fetchDashboardPort(controlPort); ok && dashboardPort > 0 {
+		msg += fmt.Sprintf(", dashboard http://localhost:%d", dashboardPort)
+	}
+	fmt.Println(msg + ")")
 	return nil
 }
 

--- a/cmd/mdp/dashboard.go
+++ b/cmd/mdp/dashboard.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var dashboardCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "Open the web dashboard in your browser",
+	RunE:  runDashboard,
+}
+
+func init() {
+	rootCmd.AddCommand(dashboardCmd)
+	dashboardCmd.Flags().Int("control-port", 13100, "Control API port")
+	dashboardCmd.Flags().Int("dashboard-port", 0, "Dashboard web UI port (overrides the port reported by the daemon)")
+}
+
+func runDashboard(cmd *cobra.Command, args []string) error {
+	controlPort, _ := cmd.Flags().GetInt("control-port")
+
+	dashboardPort, ok := fetchDashboardPort(controlPort)
+	if !ok {
+		return fmt.Errorf("mdp orchestrator is not running — start it with 'mdp' or 'mdp -d'")
+	}
+	if cmd.Flags().Changed("dashboard-port") {
+		dashboardPort, _ = cmd.Flags().GetInt("dashboard-port")
+	}
+	if dashboardPort <= 0 {
+		return fmt.Errorf("dashboard is not running — check %s", logFilePath())
+	}
+
+	url := fmt.Sprintf("http://localhost:%d", dashboardPort)
+	fmt.Println(url)
+	return openBrowser(url)
+}
+
+// fetchDashboardPort queries the running daemon's control API for the actual
+// dashboard port. ok is false if the control API is unreachable; port is 0 if
+// the daemon's dashboard server is not running.
+func fetchDashboardPort(controlPort int) (port int, ok bool) {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/__mdp/health", controlPort))
+	if err != nil {
+		return 0, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, false
+	}
+	var body struct {
+		DashboardPort int `json:"dashboardPort"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return 0, false
+	}
+	return body.DashboardPort, true
+}

--- a/cmd/mdp/root.go
+++ b/cmd/mdp/root.go
@@ -66,6 +66,12 @@ func runOrchestrator(cmd *cobra.Command, args []string) error {
 		if err := startDaemon(controlPort); err != nil {
 			return err
 		}
+	} else if daemon {
+		if port, ok := fetchDashboardPort(controlPort); ok && port > 0 {
+			fmt.Printf("mdp orchestrator already running (dashboard http://localhost:%d)\n", port)
+		} else {
+			fmt.Println("mdp orchestrator already running")
+		}
 	}
 
 	if daemon {
@@ -104,15 +110,16 @@ func runDaemonProcess(cmd *cobra.Command, controlPort int) error {
 
 	orch.StartSessionPruner(ctx, 10*time.Second, 30*time.Second)
 
-	ctrlSrv, err := orchestrator.StartControlServer(orch, controlPort, cancel)
-	if err != nil {
-		return fmt.Errorf("start control API: %w", err)
-	}
-
 	dashboardPort, _ := cmd.Flags().GetInt("dashboard-port")
 	dashSrv, err := orchestrator.StartDashboardServer(controlPort, dashboardPort)
 	if err != nil {
 		slog.Warn("failed to start dashboard", "port", dashboardPort, "err", err)
+		dashboardPort = 0
+	}
+
+	ctrlSrv, err := orchestrator.StartControlServer(orch, controlPort, dashboardPort, cancel)
+	if err != nil {
+		return fmt.Errorf("start control API: %w", err)
 	}
 
 	slog.Info("mdp orchestrator started (daemon)", "control-port", controlPort, "dashboard-port", dashboardPort)

--- a/internal/orchestrator/controlapi.go
+++ b/internal/orchestrator/controlapi.go
@@ -18,8 +18,9 @@ import (
 
 // ControlAPI handles the orchestrator HTTP control endpoints.
 type ControlAPI struct {
-	orch       *Orchestrator
-	shutdownFn func()
+	orch          *Orchestrator
+	shutdownFn    func()
+	dashboardPort int // 0 if the dashboard server is not running
 }
 
 // NewControlAPI creates a new control API handler.
@@ -78,8 +79,9 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func (c *ControlAPI) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
-		"ok":      true,
-		"proxies": len(c.orch.ListProxies()),
+		"ok":            true,
+		"proxies":       len(c.orch.ListProxies()),
+		"dashboardPort": c.dashboardPort,
 	})
 }
 
@@ -401,8 +403,12 @@ func StartDashboardServer(controlPort, dashboardPort int) (*http.Server, error) 
 }
 
 // StartControlServer starts the control API server on the given port.
-func StartControlServer(orch *Orchestrator, port int, shutdownFn func()) (*http.Server, error) {
+// dashboardPort is the port the dashboard web UI is serving on (0 if it
+// failed to start); it is reported on the health endpoint so clients can
+// discover the running daemon's actual dashboard URL.
+func StartControlServer(orch *Orchestrator, port, dashboardPort int, shutdownFn func()) (*http.Server, error) {
 	capi := NewControlAPI(orch, shutdownFn)
+	capi.dashboardPort = dashboardPort
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {


### PR DESCRIPTION
Adds an `mdp dashboard` command that opens the web dashboard in the default browser, with cross-platform open helpers (`open`/`xdg-open`/`rundll32`) split by build tags.

The daemon now reports its actual dashboard port on `GET /__mdp/health` (0 if the dashboard failed to start), and both `mdp dashboard` and the `mdp -d` startup/already-running messages discover the real port from there instead of assuming flag defaults. `mdp -d` now prints the dashboard URL on start and when the orchestrator is already running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)